### PR TITLE
Use the server time in collaborative chat

### DIFF
--- a/packages/jupyter-chat/src/components/chat-input.tsx
+++ b/packages/jupyter-chat/src/components/chat-input.tsx
@@ -16,8 +16,8 @@ import {
 import SendIcon from '@mui/icons-material/Send';
 import clsx from 'clsx';
 
-const INPUT_BOX_CLASS = 'jp-chat_input-container';
-const SEND_BUTTON_CLASS = 'jp-chat_send-button';
+const INPUT_BOX_CLASS = 'jp-chat-input-container';
+const SEND_BUTTON_CLASS = 'jp-chat-send-button';
 
 export function ChatInput(props: ChatInput.IProps): JSX.Element {
   function handleKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {

--- a/packages/jupyter-chat/src/components/chat-messages.tsx
+++ b/packages/jupyter-chat/src/components/chat-messages.tsx
@@ -22,6 +22,7 @@ type ChatMessagesProps = {
 
 export type ChatMessageHeaderProps = IUser & {
   timestamp: string;
+  rawTime?: boolean;
   sx?: SxProps<Theme>;
 };
 
@@ -91,8 +92,9 @@ export function ChatMessageHeader(props: ChatMessageHeaderProps): JSX.Element {
             color: 'var(--jp-ui-font-color2)',
             fontWeight: 300
           }}
+          title={props.rawTime ? 'Unverified date' : ''}
         >
-          {props.timestamp}
+          {`${props.timestamp}${props.rawTime ? '*' : ''}`}
         </Typography>
       </Box>
     </Box>
@@ -167,6 +169,7 @@ export function ChatMessages(props: ChatMessagesProps): JSX.Element {
             <ChatMessageHeader
               {...sender}
               timestamp={timestamps[message.id]}
+              rawTime={message.raw_time || false}
               sx={{ marginBottom: 3 }}
             />
             <RendermimeMarkdown

--- a/packages/jupyter-chat/src/components/chat-messages.tsx
+++ b/packages/jupyter-chat/src/components/chat-messages.tsx
@@ -109,14 +109,33 @@ export function ChatMessages(props: ChatMessagesProps): JSX.Element {
     const newTimestamps: Record<string, string> = { ...timestamps };
     let timestampAdded = false;
 
+    const currentDate = new Date();
+    const sameDay = (date: Date) =>
+      date.getFullYear() === currentDate.getFullYear() &&
+      date.getMonth() === currentDate.getMonth() &&
+      date.getDate() === currentDate.getDate();
+
     for (const message of props.messages) {
       if (!(message.id in newTimestamps)) {
-        // Use the browser's default locale
-        newTimestamps[message.id] = new Date(message.time * 1000) // Convert message time to milliseconds
-          .toLocaleTimeString([], {
-            hour: 'numeric', // Avoid leading zero for hours; we don't want "03:15 PM"
+        const date = new Date(message.time * 1000); // Convert message time to milliseconds
+
+        // Display only the time if the day of the message is the current one.
+        if (sameDay(date)) {
+          // Use the browser's default locale
+          newTimestamps[message.id] = date.toLocaleTimeString([], {
+            hour: 'numeric',
             minute: '2-digit'
           });
+        } else {
+          // Use the browser's default locale
+          newTimestamps[message.id] = date.toLocaleString([], {
+            day: 'numeric',
+            month: 'numeric',
+            year: 'numeric',
+            hour: 'numeric',
+            minute: '2-digit'
+          });
+        }
 
         timestampAdded = true;
       }

--- a/packages/jupyter-chat/src/components/chat-messages.tsx
+++ b/packages/jupyter-chat/src/components/chat-messages.tsx
@@ -12,8 +12,8 @@ import React, { useState, useEffect } from 'react';
 import { RendermimeMarkdown } from './rendermime-markdown';
 import { IChatMessage, IUser } from '../types';
 
-const MESSAGES_BOX_CLASS = 'jp-chat_messages-container';
-const MESSAGE_CLASS = 'jp-chat_message';
+const MESSAGES_BOX_CLASS = 'jp-chat-messages-container';
+const MESSAGE_CLASS = 'jp-chat-message';
 
 type ChatMessagesProps = {
   rmRegistry: IRenderMimeRegistry;

--- a/packages/jupyter-chat/src/components/chat-messages.tsx
+++ b/packages/jupyter-chat/src/components/chat-messages.tsx
@@ -14,6 +14,8 @@ import { IChatMessage, IUser } from '../types';
 
 const MESSAGES_BOX_CLASS = 'jp-chat-messages-container';
 const MESSAGE_CLASS = 'jp-chat-message';
+const MESSAGE_HEADER_CLASS = 'jp-chat-message-header';
+const MESSAGE_TIME_CLASS = 'jp-chat-message-time';
 
 type ChatMessagesProps = {
   rmRegistry: IRenderMimeRegistry;
@@ -64,6 +66,7 @@ export function ChatMessageHeader(props: ChatMessageHeaderProps): JSX.Element {
 
   return (
     <Box
+      className={MESSAGE_HEADER_CLASS}
       sx={{
         display: 'flex',
         alignItems: 'center',
@@ -87,12 +90,13 @@ export function ChatMessageHeader(props: ChatMessageHeaderProps): JSX.Element {
           {name}
         </Typography>
         <Typography
+          className={MESSAGE_TIME_CLASS}
           sx={{
             fontSize: '0.8em',
             color: 'var(--jp-ui-font-color2)',
             fontWeight: 300
           }}
-          title={props.rawTime ? 'Unverified date' : ''}
+          title={props.rawTime ? 'Unverified time' : ''}
         >
           {`${props.timestamp}${props.rawTime ? '*' : ''}`}
         </Typography>

--- a/packages/jupyter-chat/src/types.ts
+++ b/packages/jupyter-chat/src/types.ts
@@ -33,6 +33,7 @@ export interface IChatMessage {
   id: string;
   time: number;
   sender: IUser | string;
+  raw_time?: boolean;
 }
 
 export type IClearMessage = {

--- a/packages/jupyterlab-collaborative-chat/jupyterlab_collaborative_chat/ychat.py
+++ b/packages/jupyterlab-collaborative-chat/jupyterlab_collaborative_chat/ychat.py
@@ -4,18 +4,22 @@
 # TODO: remove this module in favor of the one in jupyter_ydoc when released.
 
 import json
+import time
+import asyncio
 from functools import partial
-from typing import Any, Callable, Dict
+from typing import Any, Callable, Dict, List, Set
 
 from jupyter_ydoc.ybasedoc import YBaseDoc
-from pycrdt import Map
+from pycrdt import Map, MapEvent
 
 
 class YChat(YBaseDoc):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self._background_tasks: Set[asyncio.Task] = set()
         self._ydoc["users"] = self._yusers = Map()
         self._ydoc["messages"] = self._ymessages = Map()
+        self._ymessages.observe(self._timestamp_new_messages)
 
     @property
     def version(self) -> str:
@@ -25,6 +29,11 @@ class YChat(YBaseDoc):
         :rtype: str
         """
         return "1.0.0"
+
+    def create_task(self, coro):
+        task = asyncio.create_task(coro)
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_tasks.discard)
 
     @property
     def users(self) -> Map:
@@ -93,3 +102,35 @@ class YChat(YBaseDoc):
             partial(callback, "messages")
         )
         self._subscriptions[self._yusers] = self._yusers.observe(partial(callback, "users"))
+
+    def _timestamp_new_messages(self, event: MapEvent) -> None:
+        """
+        Called when a the ymessages changes to update the timestamp with the server one,
+        to synchronize all messages with a unique time server.
+        """
+        timestamp: float = time.time()
+        new_msg_ids: List[str] = []
+        for key, value in event.keys.items():
+            if value["action"] != "add":
+                continue
+            message = self._ymessages.get(key, None)
+            if message and not message.get("validated_time", False):
+                new_msg_ids.append(key)
+
+        if len(new_msg_ids):
+            self.create_task(self._set_timestamp(new_msg_ids, timestamp))
+
+    async def _set_timestamp(self, new_msg_ids: List[str], timestamp: float):
+        """
+        Update the timestamp of a list of message.
+        """
+        messages = {}
+        for msg_id in new_msg_ids:
+            message = self._ymessages.get(msg_id, None)
+            if message:
+                message["time"] = timestamp
+                message["validated_time"] = True
+                messages[msg_id] = message
+
+        with self._ydoc.transaction():
+            self._ymessages.update(messages)

--- a/packages/jupyterlab-collaborative-chat/jupyterlab_collaborative_chat/ychat.py
+++ b/packages/jupyterlab-collaborative-chat/jupyterlab_collaborative_chat/ychat.py
@@ -17,6 +17,7 @@ class YChat(YBaseDoc):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._background_tasks: Set[asyncio.Task] = set()
+        self.dirty = True
         self._ydoc["users"] = self._yusers = Map()
         self._ydoc["messages"] = self._ymessages = Map()
         self._ymessages.observe(self._timestamp_new_messages)
@@ -108,6 +109,11 @@ class YChat(YBaseDoc):
         Called when a the ymessages changes to update the timestamp with the server one,
         to synchronize all messages with a unique time server.
         """
+
+        # Avoid updating the time while reading the document the first time, the dirty
+        # flag is set to False after first reading.
+        if self.dirty:
+            return
         timestamp: float = time.time()
         new_msg_ids: List[str] = []
         for key, value in event.keys.items():

--- a/packages/jupyterlab-collaborative-chat/jupyterlab_collaborative_chat/ychat.py
+++ b/packages/jupyterlab-collaborative-chat/jupyterlab_collaborative_chat/ychat.py
@@ -114,7 +114,7 @@ class YChat(YBaseDoc):
             if value["action"] != "add":
                 continue
             message = self._ymessages.get(key, None)
-            if message and not message.get("validated_time", False):
+            if message and message.get("raw_time", True):
                 new_msg_ids.append(key)
 
         if len(new_msg_ids):
@@ -129,7 +129,7 @@ class YChat(YBaseDoc):
             message = self._ymessages.get(msg_id, None)
             if message:
                 message["time"] = timestamp
-                message["validated_time"] = True
+                message["raw_time"] = False
                 messages[msg_id] = message
 
         with self._ydoc.transaction():

--- a/packages/jupyterlab-collaborative-chat/src/model.ts
+++ b/packages/jupyterlab-collaborative-chat/src/model.ts
@@ -151,7 +151,8 @@ export class CollaborativeChatModel
       id: UUID.uuid4(),
       body: message.body,
       time: Date.now() / 1000,
-      sender: this._user.username || this._user.id
+      sender: this._user.username || this._user.id,
+      raw_time: true
     };
 
     // Add the user if it does not exist or has changed

--- a/packages/jupyterlab-collaborative-chat/ui-tests/tests/jupyterlab_collaborative_chat.spec.ts
+++ b/packages/jupyterlab-collaborative-chat/ui-tests/tests/jupyterlab_collaborative_chat.spec.ts
@@ -183,35 +183,35 @@ test.describe('#messages', () => {
   test('should send a message using button', async ({ page }) => {
     const chatPanel = await openChat(page, filename);
     const input = chatPanel
-      .locator('.jp-chat_input-container')
+      .locator('.jp-chat-input-container')
       .getByRole('textbox');
     const sendButton = chatPanel
-      .locator('.jp-chat_input-container')
+      .locator('.jp-chat-input-container')
       .getByRole('button');
     await input.pressSequentially(msg);
     await sendButton.click();
 
-    const messages = chatPanel.locator('.jp-chat_messages-container');
-    await expect(messages.locator('.jp-chat_message')).toHaveCount(1);
+    const messages = chatPanel.locator('.jp-chat-messages-container');
+    await expect(messages.locator('.jp-chat-message')).toHaveCount(1);
     // It seems that the markdown renderer adds a new line.
     await expect(
-      messages.locator('.jp-chat_message .jp-chat-rendermime-markdown')
+      messages.locator('.jp-chat-message .jp-chat-rendermime-markdown')
     ).toHaveText(msg + '\n');
   });
 
   test('should send a message using keyboard', async ({ page }) => {
     const chatPanel = await openChat(page, filename);
     const input = chatPanel
-      .locator('.jp-chat_input-container')
+      .locator('.jp-chat-input-container')
       .getByRole('textbox');
     await input.pressSequentially(msg);
     await input.press('Enter');
 
-    const messages = chatPanel.locator('.jp-chat_messages-container');
-    await expect(messages.locator('.jp-chat_message')).toHaveCount(1);
+    const messages = chatPanel.locator('.jp-chat-messages-container');
+    await expect(messages.locator('.jp-chat-message')).toHaveCount(1);
     // It seems that the markdown renderer adds a new line.
     await expect(
-      messages.locator('.jp-chat_message .jp-chat-rendermime-markdown')
+      messages.locator('.jp-chat-message .jp-chat-rendermime-markdown')
     ).toHaveText(msg + '\n');
   });
 });
@@ -270,23 +270,23 @@ test.describe('#settings', () => {
 
     // Should not send message with Enter
     const chatPanel = await openChat(page, filename);
-    const messages = chatPanel.locator('.jp-chat_messages-container');
+    const messages = chatPanel.locator('.jp-chat-messages-container');
     const input = chatPanel
-      .locator('.jp-chat_input-container')
+      .locator('.jp-chat-input-container')
       .getByRole('textbox');
     await input!.pressSequentially(msg);
     await input!.press('Enter');
 
-    await expect(messages!.locator('.jp-chat_message')).toHaveCount(0);
+    await expect(messages!.locator('.jp-chat-message')).toHaveCount(0);
 
     // Should not send message with Shift+Enter
     await input!.press('Shift+Enter');
-    await expect(messages!.locator('.jp-chat_message')).toHaveCount(1);
+    await expect(messages!.locator('.jp-chat-message')).toHaveCount(1);
 
     // It seems that the markdown renderer adds a new line, but the '\n' inserter when
     // pressing Enter above is trimmed.
     await expect(
-      messages.locator('.jp-chat_message .jp-chat-rendermime-markdown')
+      messages.locator('.jp-chat-message .jp-chat-rendermime-markdown')
     ).toHaveText(msg + '\n');
   });
 
@@ -316,24 +316,24 @@ test.describe('#settings', () => {
     await page.activity.activateTab(filename);
 
     // Should not send message with Enter
-    const messages = chatPanel.locator('.jp-chat_messages-container');
+    const messages = chatPanel.locator('.jp-chat-messages-container');
     const input = chatPanel
-      .locator('.jp-chat_input-container')
+      .locator('.jp-chat-input-container')
       .getByRole('textbox');
     await input!.pressSequentially(msg);
     await input!.press('Enter');
 
-    await expect(messages!.locator('.jp-chat_message')).toHaveCount(0);
+    await expect(messages!.locator('.jp-chat-message')).toHaveCount(0);
 
     // Should not send message with Shift+Enter
     await input!.press('Shift+Enter');
-    await expect(messages!.locator('.jp-chat_message')).toHaveCount(1);
+    await expect(messages!.locator('.jp-chat-message')).toHaveCount(1);
 
     // It seems that the markdown renderer adds a new line, but the '\n' inserted when
     // pressing Enter above is trimmed.
     expect(
       await messages
-        .locator('.jp-chat_message .jp-chat-rendermime-markdown')
+        .locator('.jp-chat-message .jp-chat-rendermime-markdown')
         .textContent()
     ).toBe(msg + '\n');
   });

--- a/packages/jupyterlab-collaborative-chat/ui-tests/tests/jupyterlab_collaborative_chat.spec.ts
+++ b/packages/jupyterlab-collaborative-chat/ui-tests/tests/jupyterlab_collaborative_chat.spec.ts
@@ -3,12 +3,15 @@
  * Distributed under the terms of the Modified BSD License.
  */
 
+import { IChatMessage } from '@jupyter/chat';
 import {
   IJupyterLabPageFixture,
   expect,
   galata,
   test
 } from '@jupyterlab/galata';
+import { User } from '@jupyterlab/services';
+import { UUID } from '@lumino/coreutils';
 import { Locator } from '@playwright/test';
 
 const fillModal = async (
@@ -213,6 +216,100 @@ test.describe('#messages', () => {
     await expect(
       messages.locator('.jp-chat-message .jp-chat-rendermime-markdown')
     ).toHaveText(msg + '\n');
+  });
+});
+
+test.describe('#raw_time', () => {
+  const filename = 'my-chat.chat';
+  const originalContent = 'Hello World!';
+  const username = UUID.uuid4();
+  const user: User.IUser = {
+    identity: {
+      username: username,
+      name: 'jovyan',
+      display_name: 'jovyan',
+      initials: 'JP',
+      color: 'var(--jp-collaborator-color1)'
+    },
+    permissions: {}
+  };
+  const msgID_raw = UUID.uuid4();
+  const msg_raw_time: IChatMessage = {
+    type: 'msg',
+    id: msgID_raw,
+    sender: username,
+    body: originalContent,
+    time: 1714116341,
+    raw_time: true
+  };
+  const msgID_verif = UUID.uuid4();
+  const msg_verif: IChatMessage = {
+    type: 'msg',
+    id: msgID_verif,
+    sender: username,
+    body: originalContent,
+    time: 1714116341,
+    raw_time: false
+  };
+  const chatContent = {
+    messages: {},
+    users: {}
+  };
+  chatContent.users[username] = user.identity;
+  chatContent.messages[msgID_raw] = msg_raw_time;
+  chatContent.messages[msgID_verif] = msg_verif;
+
+  test.use({
+    mockUser: user
+  });
+
+  test.beforeEach(async ({ page }) => {
+    // Create a chat file with content
+    await page.filebrowser.contents.uploadContent(
+      JSON.stringify(chatContent),
+      'text',
+      filename
+    );
+  });
+
+  test.afterEach(async ({ page }) => {
+    if (await page.filebrowser.contents.fileExists(filename)) {
+      await page.filebrowser.contents.deleteFile(filename);
+    }
+  });
+
+  test('message timestamp should be raw according to file content', async ({ page }) => {
+    const chatPanel = await openChat(page, filename);
+    const messages = chatPanel.locator('.jp-chat-messages-container .jp-chat-message');
+
+    const raw_time = messages.locator('.jp-chat-message-time').first();
+    expect(await raw_time.getAttribute('title')).toBe('Unverified time');
+    expect(await raw_time.textContent()).toMatch(/\*$/);
+
+    const verified_time = messages.locator('.jp-chat-message-time').last();
+    expect(await verified_time.getAttribute('title')).toBe('');
+    expect(await verified_time.textContent()).toMatch(/[^\*]$/);
+  });
+
+  test('time for new message should not be raw', async ({ page }) => {
+    const chatPanel = await openChat(page, filename);
+    const messages = chatPanel.locator('.jp-chat-messages-container .jp-chat-message');
+
+    // Send a new message
+    const input = chatPanel
+      .locator('.jp-chat-input-container')
+      .getByRole('textbox');
+    const sendButton = chatPanel
+      .locator('.jp-chat-input-container')
+      .getByRole('button');
+    await input.pressSequentially('New message');
+    await sendButton.click();
+
+    expect(messages).toHaveCount(3),
+
+    await expect(
+      messages.locator('.jp-chat-message-time').last()
+    ).toHaveAttribute('title', '');
   });
 });
 

--- a/packages/jupyterlab-collaborative-chat/ui-tests/tests/jupyterlab_collaborative_chat.spec.ts
+++ b/packages/jupyterlab-collaborative-chat/ui-tests/tests/jupyterlab_collaborative_chat.spec.ts
@@ -278,9 +278,13 @@ test.describe('#raw_time', () => {
     }
   });
 
-  test('message timestamp should be raw according to file content', async ({ page }) => {
+  test('message timestamp should be raw according to file content', async ({
+    page
+  }) => {
     const chatPanel = await openChat(page, filename);
-    const messages = chatPanel.locator('.jp-chat-messages-container .jp-chat-message');
+    const messages = chatPanel.locator(
+      '.jp-chat-messages-container .jp-chat-message'
+    );
 
     const raw_time = messages.locator('.jp-chat-message-time').first();
     expect(await raw_time.getAttribute('title')).toBe('Unverified time');
@@ -293,7 +297,9 @@ test.describe('#raw_time', () => {
 
   test('time for new message should not be raw', async ({ page }) => {
     const chatPanel = await openChat(page, filename);
-    const messages = chatPanel.locator('.jp-chat-messages-container .jp-chat-message');
+    const messages = chatPanel.locator(
+      '.jp-chat-messages-container .jp-chat-message'
+    );
 
     // Send a new message
     const input = chatPanel
@@ -305,8 +311,7 @@ test.describe('#raw_time', () => {
     await input.pressSequentially('New message');
     await sendButton.click();
 
-    expect(messages).toHaveCount(3),
-
+    expect(messages).toHaveCount(3);
     await expect(
       messages.locator('.jp-chat-message-time').last()
     ).toHaveAttribute('title', '');


### PR DESCRIPTION
Fix #23 

With this PR the time of the message is updated with the time of the server, when the message is added in the collaborative document. This increases reliability of the timestamp by using a unique source.

It also add a `*` and a tooltip on the time if it has not been updated, using a new `raw_time` key in `IChatMessage`.

<img src=https://github.com/jupyterlab/jupyter-chat/assets/32258950/51f9ef57-5eb4-40cb-9b81-ce2e2439a236 width=150>

