### PR TITLE
Messages as a list in collaborative chat document

### DIFF
--- a/packages/jupyter-chat/src/__tests__/model.spec.ts
+++ b/packages/jupyter-chat/src/__tests__/model.spec.ts
@@ -52,7 +52,7 @@ describe('test chat model', () => {
         expect(sender).toBe(model);
         messages = model.messages;
       });
-      model.onMessage(msg);
+      model.messageAdded(msg);
       expect(messages).toHaveLength(1);
       expect(messages[0]).toBe(msg);
     });
@@ -63,7 +63,7 @@ describe('test chat model', () => {
         expect(sender).toBe(model);
         messages = model.messages;
       });
-      model.onMessage({ ...msg });
+      model.messageAdded({ ...msg });
       expect(messages).toHaveLength(1);
       expect(messages[0]).not.toBe(msg);
       expect((messages[0] as IChatMessage).body).toBe('formatted msg');

--- a/packages/jupyter-chat/src/__tests__/model.spec.ts
+++ b/packages/jupyter-chat/src/__tests__/model.spec.ts
@@ -8,7 +8,7 @@
  */
 
 import { ChatModel, IChatModel } from '../model';
-import { IChatMessage, IMessage } from '../types';
+import { IChatMessage } from '../types';
 
 describe('test chat model', () => {
   describe('model instantiation', () => {
@@ -33,7 +33,7 @@ describe('test chat model', () => {
     }
 
     let model: IChatModel;
-    let messages: IMessage[];
+    let messages: IChatMessage[];
     const msg = {
       type: 'msg',
       id: 'message1',
@@ -48,9 +48,9 @@ describe('test chat model', () => {
 
     it('should signal incoming message', () => {
       model = new ChatModel();
-      model.incomingMessage.connect((sender: IChatModel, message: IMessage) => {
+      model.messagesUpdated.connect((sender: IChatModel) => {
         expect(sender).toBe(model);
-        messages.push(message);
+        messages = model.messages;
       });
       model.onMessage(msg);
       expect(messages).toHaveLength(1);
@@ -59,11 +59,11 @@ describe('test chat model', () => {
 
     it('should format message', () => {
       model = new TestChat();
-      model.incomingMessage.connect((sender: IChatModel, message: IMessage) => {
+      model.messagesUpdated.connect((sender: IChatModel) => {
         expect(sender).toBe(model);
-        messages.push(message);
+        messages = model.messages;
       });
-      model.onMessage({ ...msg } as IChatMessage);
+      model.onMessage({ ...msg });
       expect(messages).toHaveLength(1);
       expect(messages[0]).not.toBe(msg);
       expect((messages[0] as IChatMessage).body).toBe('formatted msg');

--- a/packages/jupyter-chat/src/components/chat.tsx
+++ b/packages/jupyter-chat/src/components/chat.tsx
@@ -16,7 +16,7 @@ import { ChatMessages } from './chat-messages';
 import { ChatInput } from './chat-input';
 import { ScrollContainer } from './scroll-container';
 import { IChatModel } from '../model';
-import { IChatMessage, IMessage } from '../types';
+import { IChatMessage } from '../types';
 
 type ChatBodyProps = {
   model: IChatModel;
@@ -50,49 +50,13 @@ function ChatBody({
    * Effect: listen to chat messages
    */
   useEffect(() => {
-    function handleChatEvents(_: IChatModel, message: IMessage) {
-      if (message.type === 'clear') {
-        setMessages([]);
-        return;
-      } else {
-        setMessages((messageGroups: IChatMessage[]) => {
-          const existingMessages = [...messageGroups];
-
-          const messageIndex = existingMessages.findIndex(
-            msg => msg.id === message.id
-          );
-          if (messageIndex > -1) {
-            // The message is an update of an existing one (or a removal).
-            // Let's remove it anyway (to avoid position conflict if timestamp has
-            // changed) and add the new one if it is an update.
-            existingMessages.splice(messageIndex, 1);
-          }
-
-          if (message.type === 'remove') {
-            return existingMessages;
-          }
-
-          // Find the first message that should be after this one.
-          let nextMsgIndex = existingMessages.findIndex(
-            msg => msg.time > message.time
-          );
-          if (nextMsgIndex === -1) {
-            // There is no message after this one, so let's insert the message at
-            // the end.
-            nextMsgIndex = existingMessages.length;
-          }
-
-          // Insert the message.
-          existingMessages.splice(nextMsgIndex, 0, message);
-
-          return existingMessages;
-        });
-      }
+    function handleChatEvents(_: IChatModel) {
+      setMessages([...model.messages]);
     }
 
-    model.incomingMessage.connect(handleChatEvents);
+    model.messagesUpdated.connect(handleChatEvents);
     return function cleanup() {
-      model.incomingMessage.disconnect(handleChatEvents);
+      model.messagesUpdated.disconnect(handleChatEvents);
     };
   }, [model]);
 

--- a/packages/jupyter-chat/src/types.ts
+++ b/packages/jupyter-chat/src/types.ts
@@ -37,17 +37,6 @@ export interface IChatMessage {
   edited?: boolean;
 }
 
-export type IClearMessage = {
-  type: 'clear';
-};
-
-export type IDeleteMessage = {
-  type: 'remove';
-  id: string;
-};
-
-export type IMessage = IChatMessage | IClearMessage | IDeleteMessage;
-
 /**
  * The chat history interface.
  */

--- a/packages/jupyterlab-collaborative-chat/jupyterlab_collaborative_chat/ychat.py
+++ b/packages/jupyterlab-collaborative-chat/jupyterlab_collaborative_chat/ychat.py
@@ -147,15 +147,20 @@ class YChat(YBaseDoc):
         """
         with self._ydoc.transaction():
             # Remove the message from the list and modify the timestamp
-            message = self._ymessages.pop(msg_idx)
+            try:
+                message = self._ymessages[msg_idx]
+            except IndexError:
+                return
 
-        if message:
             message["time"] = timestamp
             message["raw_time"] = False
-            with self._ydoc.transaction():
-                # Move the message at the correct position in the list, looking first at the end, since the message
-                # should be the last one.
-                # The next() function below return the index of the first message with a timestamp inferior of the
-                # current one, starting from the end of the list.
-                new_idx = len(self._ymessages) - next((i for i, v in enumerate(self._ymessages.to_py()[::-1]) if v["time"] < timestamp), len(self._ymessages))
+            self._ymessages[msg_idx] = message
+
+            # Move the message at the correct position in the list, looking first at the end, since the message
+            # should be the last one.
+            # The next() function below return the index of the first message with a timestamp inferior of the
+            # current one, starting from the end of the list.
+            new_idx = len(self._ymessages) - next((i for i, v in enumerate(self._ymessages.to_py()[::-1]) if v["time"] < timestamp), len(self._ymessages))
+            if msg_idx != new_idx:
+                message = self._ymessages.pop(msg_idx)
                 self._ymessages.insert(new_idx, message)

--- a/packages/jupyterlab-collaborative-chat/src/model.ts
+++ b/packages/jupyterlab-collaborative-chat/src/model.ts
@@ -3,13 +3,7 @@
  * Distributed under the terms of the Modified BSD License.
  */
 
-import {
-  ChatModel,
-  IChatMessage,
-  IDeleteMessage,
-  INewMessage,
-  IUser
-} from '@jupyter/chat';
+import { ChatModel, IChatMessage, INewMessage, IUser } from '@jupyter/chat';
 import { IChangedArgs } from '@jupyterlab/coreutils';
 import { DocumentRegistry } from '@jupyterlab/docregistry';
 import { User } from '@jupyterlab/services';
@@ -203,11 +197,8 @@ export class CollaborativeChatModel
       }
       if (deletedMessages) {
         deletedMessages.forEach(message => {
-          const msg: IDeleteMessage = {
-            type: 'remove',
-            id: message.id
-          };
-          this.onMessage(msg);
+          const index = this.messages.findIndex(msg => msg.id === message.id);
+          this.updateMessagesList(index, 1);
         });
       }
     }

--- a/packages/jupyterlab-collaborative-chat/src/model.ts
+++ b/packages/jupyterlab-collaborative-chat/src/model.ts
@@ -177,25 +177,22 @@ export class CollaborativeChatModel
     if (change.messageChanges) {
       const msgDelta = change.messageChanges;
       let index = 0;
-      const messages: IYmessage[] = [];
-      let deletedCount = 0;
       msgDelta.forEach(delta => {
         if (delta.retain) {
-          index = delta.retain;
+          index += delta.retain;
         } else if (delta.insert) {
-          messages.push(...delta.insert);
+          const messages = delta.insert.map(ymessage => {
+            const msg: IChatMessage = { ...ymessage };
+            msg.sender =
+              this.sharedModel.getUser(ymessage.sender) || ymessage.sender;
+            return msg;
+          });
+          this.messagesInserted(index, messages);
+          index += messages.length;
         } else if (delta.delete) {
-          deletedCount = delta.delete;
+          this.messagesDeleted(index, delta.delete);
         }
       });
-
-      const chatMessages = messages.map(message => {
-        const msg: IChatMessage = { ...message };
-        msg.sender = this.sharedModel.getUser(message.sender) || message.sender;
-        return msg;
-      });
-
-      this.updateMessagesList(index, deletedCount, chatMessages);
     }
   };
 

--- a/packages/jupyterlab-collaborative-chat/ui-tests/tests/jupyterlab_collaborative_chat.spec.ts
+++ b/packages/jupyterlab-collaborative-chat/ui-tests/tests/jupyterlab_collaborative_chat.spec.ts
@@ -292,7 +292,7 @@ test.describe('#raw_time', () => {
     raw_time: false
   };
   const chatContent = {
-    messages: <IChatMessage[]> [],
+    messages: <IChatMessage[]>[],
     users: {}
   };
   chatContent.users[USERNAME] = USER.identity;
@@ -365,7 +365,7 @@ test.describe('#messageToolbar', () => {
     time: 1714116341
   };
   const chatContent = {
-    messages: <IChatMessage[]> [],
+    messages: <IChatMessage[]>[],
     users: {}
   };
   chatContent.users[USERNAME] = USER.identity;
@@ -494,7 +494,7 @@ test.describe('#outofband', () => {
     time: 1714116341
   };
   const chatContent = {
-    messages: <IChatMessage[]> [],
+    messages: <IChatMessage[]>[],
     users: {}
   };
   chatContent.users[USERNAME] = USER.identity;
@@ -523,7 +523,7 @@ test.describe('#outofband', () => {
       .first();
     const newMsg = { ...msg, body: updatedContent };
     const newContent = {
-      messages: <IChatMessage[]> [],
+      messages: <IChatMessage[]>[],
       users: {}
     };
     newContent.users[USERNAME] = USER.identity;
@@ -552,7 +552,7 @@ test.describe('#outofband', () => {
       time: msg.time + 5
     };
     const newContent = {
-      messages: <IChatMessage[]> [],
+      messages: <IChatMessage[]>[],
       users: {}
     };
     newContent.users[USERNAME] = USER.identity;
@@ -577,7 +577,7 @@ test.describe('#outofband', () => {
       .locator('.jp-chat-messages-container .jp-chat-rendermime-markdown')
       .first();
     const newContent = {
-      messages: <IChatMessage[]> [],
+      messages: <IChatMessage[]>[],
       users: {}
     };
     newContent.users[USERNAME] = USER.identity;

--- a/packages/jupyterlab-collaborative-chat/ui-tests/tests/jupyterlab_collaborative_chat.spec.ts
+++ b/packages/jupyterlab-collaborative-chat/ui-tests/tests/jupyterlab_collaborative_chat.spec.ts
@@ -275,31 +275,29 @@ test.describe('#messages', () => {
 });
 
 test.describe('#raw_time', () => {
-  const msgID_raw = UUID.uuid4();
   const msg_raw_time: IChatMessage = {
     type: 'msg',
-    id: msgID_raw,
+    id: UUID.uuid4(),
     sender: USERNAME,
     body: MSG_CONTENT,
     time: 1714116341,
     raw_time: true
   };
-  const msgID_verif = UUID.uuid4();
   const msg_verif: IChatMessage = {
     type: 'msg',
-    id: msgID_verif,
+    id: UUID.uuid4(),
     sender: USERNAME,
     body: MSG_CONTENT,
     time: 1714116341,
     raw_time: false
   };
   const chatContent = {
-    messages: {},
+    messages: <IChatMessage[]> [],
     users: {}
   };
   chatContent.users[USERNAME] = USER.identity;
-  chatContent.messages[msgID_raw] = msg_raw_time;
-  chatContent.messages[msgID_verif] = msg_verif;
+  chatContent.messages.push(msg_raw_time);
+  chatContent.messages.push(msg_verif);
 
   test.beforeEach(async ({ page }) => {
     // Create a chat file with content
@@ -359,20 +357,19 @@ test.describe('#raw_time', () => {
 test.describe('#messageToolbar', () => {
   const additionnalContent = ' Messages can be edited';
 
-  const msgID = UUID.uuid4();
   const msg: IChatMessage = {
     type: 'msg',
-    id: msgID,
+    id: UUID.uuid4(),
     sender: USERNAME,
     body: MSG_CONTENT,
     time: 1714116341
   };
   const chatContent = {
-    messages: {},
+    messages: <IChatMessage[]> [],
     users: {}
   };
   chatContent.users[USERNAME] = USER.identity;
-  chatContent.messages[msgID] = msg;
+  chatContent.messages.push(msg);
 
   test.beforeEach(async ({ page }) => {
     // Create a chat file with content
@@ -489,20 +486,19 @@ test.describe('#messageToolbar', () => {
 });
 
 test.describe('#outofband', () => {
-  const msgID = UUID.uuid4();
   const msg: IChatMessage = {
     type: 'msg',
-    id: msgID,
+    id: UUID.uuid4(),
     sender: USERNAME,
     body: MSG_CONTENT,
     time: 1714116341
   };
   const chatContent = {
-    messages: {},
+    messages: <IChatMessage[]> [],
     users: {}
   };
   chatContent.users[USERNAME] = USER.identity;
-  chatContent.messages[msgID] = msg;
+  chatContent.messages.push(msg);
 
   test.beforeEach(async ({ page }) => {
     // Create a chat file with content
@@ -527,11 +523,11 @@ test.describe('#outofband', () => {
       .first();
     const newMsg = { ...msg, body: updatedContent };
     const newContent = {
-      messages: {},
+      messages: <IChatMessage[]> [],
       users: {}
     };
     newContent.users[USERNAME] = USER.identity;
-    newContent.messages[msgID] = newMsg;
+    newContent.messages.push(newMsg);
 
     await page.filebrowser.contents.uploadContent(
       JSON.stringify(newContent),
@@ -544,25 +540,24 @@ test.describe('#outofband', () => {
 
   test('should add a message from file', async ({ page }) => {
     const newMsgContent = 'New message';
-    const newMsgID = UUID.uuid4();
     const chatPanel = await openChat(page, FILENAME);
     const messages = chatPanel.locator(
       '.jp-chat-messages-container .jp-chat-message'
     );
     const newMsg: IChatMessage = {
       type: 'msg',
-      id: newMsgID,
+      id: UUID.uuid4(),
       sender: USERNAME,
       body: newMsgContent,
       time: msg.time + 5
     };
     const newContent = {
-      messages: {},
+      messages: <IChatMessage[]> [],
       users: {}
     };
     newContent.users[USERNAME] = USER.identity;
-    newContent.messages[msgID] = msg;
-    newContent.messages[newMsgID] = newMsg;
+    newContent.messages.push(msg);
+    newContent.messages.push(newMsg);
 
     await page.filebrowser.contents.uploadContent(
       JSON.stringify(newContent),
@@ -582,7 +577,7 @@ test.describe('#outofband', () => {
       .locator('.jp-chat-messages-container .jp-chat-rendermime-markdown')
       .first();
     const newContent = {
-      messages: {},
+      messages: <IChatMessage[]> [],
       users: {}
     };
     newContent.users[USERNAME] = USER.identity;

--- a/packages/jupyterlab-ws-chat/src/handlers/websocket-handler.ts
+++ b/packages/jupyterlab-ws-chat/src/handlers/websocket-handler.ts
@@ -117,7 +117,7 @@ export class WebSocketHandler extends ChatModel {
     }
   }
 
-  onMessage(message: GenericMessage): void {
+  messageAdded(message: GenericMessage): void {
     // resolve promise from `sendMessage()`
     if (message.type === 'msg') {
       const sender =
@@ -126,7 +126,7 @@ export class WebSocketHandler extends ChatModel {
       if (sender === this.id) {
         this._sendResolverQueue.get(message.id)?.(true);
       }
-      super.onMessage(message);
+      super.messageAdded(message);
     } else if (message.type === 'connection') {
       this.id = message.client_id;
       this._connectionInitialized.resolve(true);
@@ -160,7 +160,8 @@ export class WebSocketHandler extends ChatModel {
     const socket = (this._socket = new WebSocket(url));
     socket.onclose = e => this._onClose(e);
     socket.onerror = e => console.error(e);
-    socket.onmessage = msg => msg.data && this.onMessage(JSON.parse(msg.data));
+    socket.onmessage = msg =>
+      msg.data && this.messageAdded(JSON.parse(msg.data));
   }
 
   /**

--- a/packages/jupyterlab-ws-chat/src/handlers/websocket-handler.ts
+++ b/packages/jupyterlab-ws-chat/src/handlers/websocket-handler.ts
@@ -7,15 +7,12 @@ import {
   ChatModel,
   IChatHistory,
   IChatMessage,
-  IChatModel,
-  IClearMessage,
-  IDeleteMessage,
   INewMessage,
   IUser
 } from '@jupyter/chat';
 import { URLExt } from '@jupyterlab/coreutils';
 import { ServerConnection } from '@jupyterlab/services';
-import { UUID } from '@lumino/coreutils';
+import { PromiseDelegate, UUID } from '@lumino/coreutils';
 
 import { requestAPI } from './handler';
 
@@ -43,14 +40,12 @@ export interface IWsMessage extends IChatMessage {
   sender: IWsUser | string;
 }
 
-export type IMessage = IWsMessage | IClearMessage | IDeleteMessage;
-
 export type ConnectionMessage = {
   type: 'connection';
   client_id: string;
 };
 
-type GenericMessage = IMessage | ConnectionMessage;
+type GenericMessage = IWsMessage | ConnectionMessage;
 
 /**
  * An implementation of the chat model based on websocket handler.
@@ -76,7 +71,8 @@ export class WebSocketHandler extends ChatModel {
    * must be awaited before calling any other method.
    */
   async initialize(): Promise<void> {
-    await this._initialize();
+    this._initialize();
+    await this._connectionInitialized.promise;
   }
 
   /**
@@ -121,7 +117,7 @@ export class WebSocketHandler extends ChatModel {
     }
   }
 
-  onMessage(message: IMessage): void {
+  onMessage(message: GenericMessage): void {
     // resolve promise from `sendMessage()`
     if (message.type === 'msg') {
       const sender =
@@ -130,57 +126,55 @@ export class WebSocketHandler extends ChatModel {
       if (sender === this.id) {
         this._sendResolverQueue.get(message.id)?.(true);
       }
+      super.onMessage(message);
+    } else if (message.type === 'connection') {
+      this.id = message.client_id;
+      this._connectionInitialized.resolve(true);
     }
-    super.onMessage(message);
   }
 
-  private _onClose(e: CloseEvent, reject: any) {
-    reject(new Error('Chat UI websocket disconnected'));
+  private _onClose(e: CloseEvent) {
+    this._connectionInitialized.reject(
+      new Error('Chat UI websocket disconnected')
+    );
     console.error('Chat UI websocket disconnected');
     // only attempt re-connect if there was an abnormal closure
     // WebSocket status codes defined in RFC 6455: https://www.rfc-editor.org/rfc/rfc6455.html#section-7.4.1
     if (e.code === 1006) {
       const delaySeconds = 1;
       console.info(`Will try to reconnect in ${delaySeconds} s.`);
-      setTimeout(async () => await this._initialize(), delaySeconds * 1000);
+      setTimeout(async () => await this.initialize(), delaySeconds * 1000);
     }
   }
 
-  private _initialize(): Promise<void> {
-    return new Promise<void>((resolve, reject) => {
-      if (this.isDisposed) {
-        return;
-      }
-      console.log('Creating a new websocket connection for chat...');
-      const { token, WebSocket, wsUrl } = this.serverSettings;
-      const url =
-        URLExt.join(wsUrl, CHAT_SERVICE_URL) +
-        (token ? `?token=${encodeURIComponent(token)}` : '');
+  private _initialize(): void {
+    if (this.isDisposed) {
+      return;
+    }
+    console.log('Creating a new websocket connection for chat...');
+    const { token, WebSocket, wsUrl } = this.serverSettings;
+    const url =
+      URLExt.join(wsUrl, CHAT_SERVICE_URL) +
+      (token ? `?token=${encodeURIComponent(token)}` : '');
 
-      const socket = (this._socket = new WebSocket(url));
-      socket.onclose = e => this._onClose(e, reject);
-      socket.onerror = e => reject(e);
-      socket.onmessage = msg =>
-        msg.data && this.onMessage(JSON.parse(msg.data));
-
-      const listenForConnection = (_: IChatModel, message: GenericMessage) => {
-        if (message.type !== 'connection') {
-          return;
-        }
-        this.id = message.client_id;
-        resolve();
-        this.incomingMessage.disconnect(listenForConnection);
-      };
-
-      this.incomingMessage.connect(listenForConnection);
-    });
+    const socket = (this._socket = new WebSocket(url));
+    socket.onclose = e => this._onClose(e);
+    socket.onerror = e => console.error(e);
+    socket.onmessage = msg => msg.data && this.onMessage(JSON.parse(msg.data));
   }
 
+  /**
+   * The websocket.
+   */
   private _socket: WebSocket | null = null;
   /**
-   * Queue of Promise resolvers pushed onto by `send()`
+   * Queue of Promise resolvers pushed onto by `send()`.
    */
   private _sendResolverQueue = new Map<string, (value: boolean) => void>();
+  /**
+   * A promise that resolves when the connection is initialized.
+   */
+  private _connectionInitialized = new PromiseDelegate<boolean>();
 }
 
 /**


### PR DESCRIPTION
This PR aims to use a list of messages in `YChat` document, instead of a Map.

Fixes #25

Before this PR, the messages order was handled in the chat component itself.
With this PR, the messages list is handled in the model, and used by the chat component. It adds some function to insert or delete messages with index.

The collaborative chat document now saves messages in a list and is responsible for the message order. That way the order is computed only once, when a message is added, server side. It make use of the insert/delete functions of the model to set the order in front end side.
