### PR TITLE
Add screenshot to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
-# jupyter_chat
+# jupyter-chat
 
-[![Github Actions Status](https://github.com/jupyterlab/jupyter-chat/workflows/Build/badge.svg)](https://github.com/jupyterlab/jupyter-chat/actions/workflows/build.yml)[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jupyterlab/jupyter-chat/main?urlpath=lab)
+[![Github Actions Status](https://github.com/jupyterlab/jupyter-chat/workflows/Build/badge.svg)](https://github.com/jupyterlab/jupyter-chat/actions/workflows/build.yml)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jupyterlab/jupyter-chat/main?urlpath=lab)
 
 This project is a monorepo containing the frontend components and extensions to build
 a chat in Jupyter.
 
-A lot of the components of this chat project come from
-[jupyter-ai](https://github.com/jupyterlab/jupyter-ai).
+Many components of this chat project come from [jupyter-ai](https://github.com/jupyterlab/jupyter-ai).
+
+![a screenshot showing the jupyter-chat extension used in two browser windows](https://github.com/jtpio/jupyter-chat/assets/591645/977b6f8b-df73-4973-a4f2-abe5abc688c4)
 
 ## Composition
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ a chat in Jupyter.
 
 Many components of this chat project come from [jupyter-ai](https://github.com/jupyterlab/jupyter-ai).
 
-![a screenshot showing the jupyter-chat extension used in two browser windows](https://github.com/jtpio/jupyter-chat/assets/591645/977b6f8b-df73-4973-a4f2-abe5abc688c4)
+![a screenshot showing the jupyter-chat extension used in two browser windows](https://github.com/jupyterlab/jupyter-chat/assets/591645/5dac0b00-43ed-4458-ab67-18207644b92b)
 
 ## Composition
 


### PR DESCRIPTION
Add a screenshot to the README, so folks landing on the repo have a better idea of what the chat looks like.

![a screenshot showing the jupyter-chat extension used in two browser windows](https://github.com/jtpio/jupyter-chat/assets/591645/977b6f8b-df73-4973-a4f2-abe5abc688c4)