### PR TITLE
Depend on `pydantic` directly instead of `langchain`

### DIFF
--- a/packages/jupyterlab-ws-chat/jupyterlab_ws_chat/handlers.py
+++ b/packages/jupyterlab-ws-chat/jupyterlab_ws_chat/handlers.py
@@ -8,7 +8,7 @@ import uuid
 from typing import Dict, List
 
 from jupyter_server.base.handlers import APIHandler as BaseAPIHandler, JupyterHandler
-from langchain.pydantic_v1 import ValidationError
+from pydantic.v1 import ValidationError
 from tornado import web, websocket
 
 from .config_manager import WriteConflictError

--- a/packages/jupyterlab-ws-chat/jupyterlab_ws_chat/models.py
+++ b/packages/jupyterlab-ws-chat/jupyterlab_ws_chat/models.py
@@ -3,7 +3,7 @@
 
 from typing import Any, Dict, List, Literal, Optional, Union
 
-from langchain.pydantic_v1 import BaseModel, validator
+from pydantic.v1 import BaseModel, validator
 
 DEFAULT_CHUNK_SIZE = 2000
 DEFAULT_CHUNK_OVERLAP = 100

--- a/packages/jupyterlab-ws-chat/pyproject.toml
+++ b/packages/jupyterlab-ws-chat/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "jupyterlab~=4.0",
     "traitlets>=5.0",
     "deepmerge>=1.0",
-    "langchain"
+    "pydantic>=2"
 ]
 dynamic = ["version", "description", "authors", "urls", "keywords"]
 


### PR DESCRIPTION
Looks like `langchain` is currently used as a proxy for importing `pydantic_v1`.

So we can probably depend on `pydantic` directly and update the imports, to avoid having to depend on `langchain`.