### PR TITLE
Add metadata to ychat, id to model and store last unread in localStorage

### DIFF
--- a/packages/jupyter-chat/src/components/chat-messages.tsx
+++ b/packages/jupyter-chat/src/components/chat-messages.tsx
@@ -88,7 +88,7 @@ export function ChatMessages(props: BaseMessageProps): JSX.Element {
    * Function called when a message enter or leave the viewport.
    */
   function viewportChange(entries: IntersectionObserverEntry[]) {
-    const unread = model.unreadMessages;
+    const unread = [...model.unreadMessages];
     let unreadModified = false;
     entries.forEach(entry => {
       const index = parseInt(entry.target.getAttribute('data-index') ?? '');

--- a/packages/jupyter-chat/src/model.ts
+++ b/packages/jupyter-chat/src/model.ts
@@ -179,20 +179,23 @@ export class ChatModel implements IChatModel {
    * Timestamp of the last read message in local storage.
    */
   get lastRead(): number {
+    if (this._id === undefined) {
+      return 0;
+    }
     const storage = JSON.parse(
-      localStorage.getItem(`jp-collaborative-chat_${this.id}`) || '{}'
+      localStorage.getItem(`@jupyter/chat:${this._id}`) || '{}'
     );
-    return storage.lastRead;
+    return storage.lastRead ?? 0;
   }
   set lastRead(value: number) {
+    if (this._id === undefined) {
+      return;
+    }
     const storage = JSON.parse(
-      localStorage.getItem(`jp-collaborative-chat_${this.id}`) || '{}'
+      localStorage.getItem(`@jupyter/chat:${this._id}`) || '{}'
     );
     storage.lastRead = value;
-    localStorage.setItem(
-      `jp-collaborative-chat_${this.id}`,
-      JSON.stringify(storage)
-    );
+    localStorage.setItem(`@jupyter/chat:${this._id}`, JSON.stringify(storage));
   }
 
   /**

--- a/packages/jupyter-chat/src/model.ts
+++ b/packages/jupyter-chat/src/model.ts
@@ -156,6 +156,16 @@ export class ChatModel implements IChatModel {
   }
 
   /**
+   * The chat model id.
+   */
+  get id(): string | undefined {
+    return this._id;
+  }
+  set id(value: string | undefined) {
+    this._id = value;
+  }
+
+  /**
    * The chat model name.
    */
   get name(): string {
@@ -404,6 +414,7 @@ export class ChatModel implements IChatModel {
   private _messages: IChatMessage[] = [];
   private _unreadMessages: number[] = [];
   private _messagesInViewport: number[] = [];
+  private _id: string | undefined;
   private _name: string = '';
   private _config: IConfig;
   private _isDisposed = false;

--- a/packages/jupyterlab-collaborative-chat/src/model.ts
+++ b/packages/jupyterlab-collaborative-chat/src/model.ts
@@ -45,6 +45,8 @@ export class CollaborativeChatModel
       this._sharedModel = YChat.create();
     }
 
+    this.id = this._sharedModel.id;
+
     this.sharedModel.changed.connect(this._onchange, this);
 
     this.config = widgetConfig.config;
@@ -192,6 +194,14 @@ export class CollaborativeChatModel
         } else if (delta.delete) {
           this.messagesDeleted(index, delta.delete);
         }
+      });
+    }
+
+    if (change.metadataChanges) {
+      change.metadataChanges.forEach(change => {
+        // no need to search for update or add, if the new value contains ID, let's
+        // update the model ID.
+        this.id = change.newValue as string;
       });
     }
   };

--- a/packages/jupyterlab-collaborative-chat/src/model.ts
+++ b/packages/jupyterlab-collaborative-chat/src/model.ts
@@ -11,7 +11,7 @@ import { PartialJSONObject, UUID } from '@lumino/coreutils';
 import { ISignal, Signal } from '@lumino/signaling';
 
 import { IWidgetConfig } from './token';
-import { ChatChange, IYmessage, YChat } from './ychat';
+import { ChatChanges, IYmessage, YChat } from './ychat';
 
 /**
  * Collaborative chat namespace.
@@ -171,9 +171,9 @@ export class CollaborativeChatModel
     this.sharedModel.updateMessage(index, message);
   }
 
-  private _onchange = (_: YChat, change: ChatChange) => {
-    if (change.messageChanges) {
-      const msgDelta = change.messageChanges;
+  private _onchange = (_: YChat, changes: ChatChanges) => {
+    if (changes.messageChanges) {
+      const msgDelta = changes.messageChanges;
       let index = 0;
       msgDelta.forEach(delta => {
         if (delta.retain) {
@@ -197,11 +197,13 @@ export class CollaborativeChatModel
       });
     }
 
-    if (change.metadataChanges) {
-      change.metadataChanges.forEach(change => {
+    if (changes.metadataChanges) {
+      changes.metadataChanges.forEach(change => {
         // no need to search for update or add, if the new value contains ID, let's
         // update the model ID.
-        this.id = change.newValue as string;
+        if (change.key === 'id') {
+          this.id = change.newValue as string;
+        }
       });
     }
   };

--- a/packages/jupyterlab-collaborative-chat/src/ychat.ts
+++ b/packages/jupyterlab-collaborative-chat/src/ychat.ts
@@ -16,21 +16,12 @@ export type IYmessage = IChatMessage<string>;
 /**
  * The type for a YMessage.
  */
-export interface IMetadata {
-  /**
-   * The id of the chat, stored in the metadata.
-   */
-  id: string;
-  /**
-   * Allow any other keys in metadata.
-   */
-  [anyKey: string]: PartialJSONValue;
-}
+export type IMetadata = PartialJSONValue;
 
 /**
  * Definition of the shared Chat changes.
  */
-export type ChatChange = DocumentChange & {
+export type ChatChanges = DocumentChange & {
   /**
    * Changes in messages.
    */
@@ -58,12 +49,12 @@ export type UserChange = IMapChange<IUser>;
 /**
  * The metadata change type.
  */
-export type MetadataChange = IMapChange<any>;
+export type MetadataChange = IMapChange<IMetadata>;
 
 /**
  * The collaborative chat shared document.
  */
-export class YChat extends YDocument<ChatChange> {
+export class YChat extends YDocument<ChatChanges> {
   /**
    * Create a new collaborative chat model.
    */
@@ -94,11 +85,7 @@ export class YChat extends YDocument<ChatChange> {
   }
 
   get id(): string {
-    const metadata: IMetadata | undefined = this._metadata.get('metadata');
-    if (!metadata) {
-      return '';
-    }
-    return metadata?.id || '';
+    return (this._metadata.get('id') as string) || '';
   }
 
   get users(): JSONObject {
@@ -182,18 +169,18 @@ export class YChat extends YDocument<ChatChange> {
       }
     });
 
-    this._changed.emit({ userChange: userChange } as Partial<ChatChange>);
+    this._changed.emit({ userChange: userChange } as Partial<ChatChanges>);
   };
 
   private _messagesObserver = (event: Y.YArrayEvent<IYmessage>): void => {
     const messageChanges = event.delta;
     this._changed.emit({
       messageChanges: messageChanges
-    } as Partial<ChatChange>);
+    } as Partial<ChatChanges>);
   };
 
-  private _metadataObserver = (event: Y.YMapEvent<any>): void => {
-    const metadataChange = new Array<any>();
+  private _metadataObserver = (event: Y.YMapEvent<IMetadata>): void => {
+    const metadataChange = new Array<MetadataChange>();
     event.changes.keys.forEach((change, key) => {
       switch (change.action) {
         case 'add':
@@ -223,7 +210,7 @@ export class YChat extends YDocument<ChatChange> {
 
     this._changed.emit({
       metadataChanges: metadataChange
-    } as Partial<ChatChange>);
+    } as Partial<ChatChanges>);
   };
 
   private _users: Y.Map<IUser>;

--- a/packages/jupyterlab-collaborative-chat/ui-tests/tests/jupyterlab_collaborative_chat.spec.ts
+++ b/packages/jupyterlab-collaborative-chat/ui-tests/tests/jupyterlab_collaborative_chat.spec.ts
@@ -49,7 +49,7 @@ const readFileContent = async (
   return await page.evaluate(async filepath => {
     return await window.jupyterapp.serviceManager.contents.get(filepath);
   }, filename);
-}
+};
 
 const openChat = async (
   page: IJupyterLabPageFixture,
@@ -872,7 +872,7 @@ test.describe('#localStorage', () => {
         }
       }
       return false;
-    }
+    };
 
     await page.waitForCondition(hasLocalStorage);
     const storage = await page.evaluate(() => window.localStorage);
@@ -886,7 +886,7 @@ test.describe('#localStorage', () => {
     const value = JSON.parse(storage[key]);
     expect(value['lastRead']).toBeDefined();
     expect(value['lastRead']).toBe(baseTime + (messagesCount - 1) * 60);
-  })
+  });
 });
 
 test.describe('#raw_time', () => {
@@ -1114,12 +1114,18 @@ test.describe('#ychat', () => {
 
   test('should add an id to the chat metadata', async ({ page }) => {
     const chatPanel = await openChat(page, FILENAME);
-    await chatPanel.locator('.jp-chat-input-container').getByRole('textbox').waitFor();
+    await chatPanel
+      .locator('.jp-chat-input-container')
+      .getByRole('textbox')
+      .waitFor();
     const hasId = async () => {
       const model = await readFileContent(page, FILENAME);
       const content = JSON.parse(model.content) as ReadonlyJSONObject;
-      return content.metadata !== undefined && (content.metadata as ReadonlyJSONObject).id !== undefined;
-    }
+      return (
+        content.metadata !== undefined &&
+        (content.metadata as ReadonlyJSONObject).id !== undefined
+      );
+    };
     await page.waitForCondition(hasId);
   });
 });

--- a/packages/jupyterlab-collaborative-chat/ui-tests/tests/jupyterlab_collaborative_chat.spec.ts
+++ b/packages/jupyterlab-collaborative-chat/ui-tests/tests/jupyterlab_collaborative_chat.spec.ts
@@ -867,7 +867,7 @@ test.describe('#localStorage', () => {
     const hasLocalStorage = async () => {
       const storage = await page.evaluate(() => window.localStorage);
       for (const k in storage) {
-        if (k.startsWith('jp-collaborative-chat_')) {
+        if (k.startsWith('@jupyter/chat:')) {
           return true;
         }
       }
@@ -878,7 +878,7 @@ test.describe('#localStorage', () => {
     const storage = await page.evaluate(() => window.localStorage);
     let key = '';
     for (const k in storage) {
-      if (k.startsWith('jp-collaborative-chat_')) {
+      if (k.startsWith('@jupyter/chat:')) {
         key = k;
         break;
       }

--- a/packages/jupyterlab-collaborative-chat/ui-tests/tests/jupyterlab_collaborative_chat.spec.ts
+++ b/packages/jupyterlab-collaborative-chat/ui-tests/tests/jupyterlab_collaborative_chat.spec.ts
@@ -685,7 +685,9 @@ test.describe('#notifications', () => {
     await messages.first().scrollIntoViewIfNeeded();
 
     await sendMessage(guestPage);
-    await page.waitForCondition(async () => (await page.notifications).length > 0);
+    await page.waitForCondition(
+      async () => (await page.notifications).length > 0
+    );
     const notifications = await page.notifications;
     expect(notifications).toHaveLength(1);
 
@@ -704,12 +706,16 @@ test.describe('#notifications', () => {
     await messages.first().scrollIntoViewIfNeeded();
 
     await sendMessage(guestPage);
-    await page.waitForCondition(async () => (await page.notifications).length > 0);
+    await page.waitForCondition(
+      async () => (await page.notifications).length > 0
+    );
     let notifications = await page.notifications;
     expect(notifications).toHaveLength(1);
 
     await messages.last().scrollIntoViewIfNeeded();
-    await page.waitForCondition(async () => (await page.notifications).length === 0);
+    await page.waitForCondition(
+      async () => (await page.notifications).length === 0
+    );
   });
 
   test('should update existing notification on new message', async ({
@@ -720,7 +726,9 @@ test.describe('#notifications', () => {
     await messages.first().scrollIntoViewIfNeeded();
 
     await sendMessage(guestPage);
-    await page.waitForCondition(async () => (await page.notifications).length > 0);
+    await page.waitForCondition(
+      async () => (await page.notifications).length > 0
+    );
     let notifications = await page.notifications;
     expect(notifications).toHaveLength(1);
 
@@ -741,7 +749,9 @@ test.describe('#notifications', () => {
     await messages.first().scrollIntoViewIfNeeded();
 
     await sendMessage(guestPage);
-    await page.waitForCondition(async () => (await page.notifications).length > 0);
+    await page.waitForCondition(
+      async () => (await page.notifications).length > 0
+    );
     let notifications = await page.notifications;
     expect(notifications).toHaveLength(1);
 
@@ -764,7 +774,9 @@ test.describe('#notifications', () => {
     // Activate the chat panel
     await page.activity.activateTab(FILENAME);
 
-    await page.waitForCondition(async () => (await page.notifications).length === 0);
+    await page.waitForCondition(
+      async () => (await page.notifications).length === 0
+    );
 
     await sendMessage(guestPage);
     await expect(messages).toHaveCount(messagesCount + 2);

--- a/packages/jupyterlab-collaborative-chat/ui-tests/tests/jupyterlab_collaborative_chat.spec.ts
+++ b/packages/jupyterlab-collaborative-chat/ui-tests/tests/jupyterlab_collaborative_chat.spec.ts
@@ -685,7 +685,7 @@ test.describe('#notifications', () => {
     await messages.first().scrollIntoViewIfNeeded();
 
     await sendMessage(guestPage);
-    page.waitForCondition(async () => (await page.notifications).length > 0);
+    await page.waitForCondition(async () => (await page.notifications).length > 0);
     const notifications = await page.notifications;
     expect(notifications).toHaveLength(1);
 
@@ -704,12 +704,12 @@ test.describe('#notifications', () => {
     await messages.first().scrollIntoViewIfNeeded();
 
     await sendMessage(guestPage);
-    page.waitForCondition(async () => (await page.notifications).length > 0);
+    await page.waitForCondition(async () => (await page.notifications).length > 0);
     let notifications = await page.notifications;
     expect(notifications).toHaveLength(1);
 
     await messages.last().scrollIntoViewIfNeeded();
-    page.waitForCondition(async () => (await page.notifications).length === 0);
+    await page.waitForCondition(async () => (await page.notifications).length === 0);
   });
 
   test('should update existing notification on new message', async ({
@@ -720,7 +720,7 @@ test.describe('#notifications', () => {
     await messages.first().scrollIntoViewIfNeeded();
 
     await sendMessage(guestPage);
-    page.waitForCondition(async () => (await page.notifications).length > 0);
+    await page.waitForCondition(async () => (await page.notifications).length > 0);
     let notifications = await page.notifications;
     expect(notifications).toHaveLength(1);
 
@@ -741,7 +741,7 @@ test.describe('#notifications', () => {
     await messages.first().scrollIntoViewIfNeeded();
 
     await sendMessage(guestPage);
-    page.waitForCondition(async () => (await page.notifications).length > 0);
+    await page.waitForCondition(async () => (await page.notifications).length > 0);
     let notifications = await page.notifications;
     expect(notifications).toHaveLength(1);
 
@@ -764,7 +764,7 @@ test.describe('#notifications', () => {
     // Activate the chat panel
     await page.activity.activateTab(FILENAME);
 
-    page.waitForCondition(async () => (await page.notifications).length === 0);
+    await page.waitForCondition(async () => (await page.notifications).length === 0);
 
     await sendMessage(guestPage);
     await expect(messages).toHaveCount(messagesCount + 2);

--- a/packages/jupyterlab-ws-chat/src/handlers/websocket-handler.ts
+++ b/packages/jupyterlab-ws-chat/src/handlers/websocket-handler.ts
@@ -64,11 +64,11 @@ export class WebSocketHandler extends ChatModel {
   /**
    * Getter and setter for the chat ID.
    */
-  get id(): string {
-    return this._id;
+  get userId(): string {
+    return this._userId;
   }
-  set id(value: string) {
-    this._id = value;
+  set userId(value: string) {
+    this._userId = value;
   }
 
   /**
@@ -126,12 +126,12 @@ export class WebSocketHandler extends ChatModel {
   messageAdded(message: GenericMessage): void {
     // resolve promise from `sendMessage()`
     if (message.type === 'msg') {
-      if (message.sender.id === this.id) {
+      if (message.sender.id === this.userId) {
         this._sendResolverQueue.get(message.id)?.(true);
       }
       super.messageAdded(message);
     } else if (message.type === 'connection') {
-      this.id = message.client_id;
+      this.userId = message.client_id;
       this._connectionInitialized.resolve(true);
     }
   }
@@ -168,9 +168,9 @@ export class WebSocketHandler extends ChatModel {
   }
 
   /**
-   * The chat ID.
+   * The user ID.
    */
-  private _id: string = '';
+  private _userId: string = '';
   /**
    * The websocket.
    */


### PR DESCRIPTION
This PR store the last read message in the local storage, to mark new messages only as unread when opening a chat.
To handle it properly, it adds an ID to the chat, which is stored as metadata in the collaborative chat.
Therefore this PR change the ychat definition to handle metadata.

Related to https://github.com/jupyterlab/jupyter-chat/pull/43.

Currently it only saves the date of the last message read, which means that if some previous message were unread, they will be considered as read when reopening the chat.