### PR TITLE
Buttons to mark chat as read

### DIFF
--- a/packages/jupyter-chat/src/components/chat-messages.tsx
+++ b/packages/jupyter-chat/src/components/chat-messages.tsx
@@ -421,7 +421,6 @@ type NavigationProps = BaseMessageProps & {
  */
 export function Navigation(props: NavigationProps): JSX.Element {
   const { model } = props;
-  const initialized = useRef<boolean>(false);
   const [lastInViewport, setLastInViewport] = useState<boolean>(true);
   const [unreadBefore, setUnreadBefore] = useState<number | null>(null);
   const [unreadAfter, setUnreadAfter] = useState<number | null>(null);
@@ -476,13 +475,11 @@ export function Navigation(props: NavigationProps): JSX.Element {
 
     unreadChanged(model, model.unreadMessages);
 
-    if (!initialized.current) {
-      if (model.unreadMessages.length) {
-        gotoMessage(Math.min(...model.unreadMessages));
-      } else {
-        gotoMessage(model.messages.length - 1);
-      }
-      initialized.current = true;
+    // Move to first the unread message or to last message on first rendering.
+    if (model.unreadMessages.length) {
+      gotoMessage(Math.min(...model.unreadMessages));
+    } else {
+      gotoMessage(model.messages.length - 1);
     }
 
     return () => {

--- a/packages/jupyter-chat/src/components/chat-messages.tsx
+++ b/packages/jupyter-chat/src/components/chat-messages.tsx
@@ -421,6 +421,7 @@ type NavigationProps = BaseMessageProps & {
  */
 export function Navigation(props: NavigationProps): JSX.Element {
   const { model } = props;
+  const initialized = useRef<boolean>(false);
   const [lastInViewport, setLastInViewport] = useState<boolean>(true);
   const [unreadBefore, setUnreadBefore] = useState<number | null>(null);
   const [unreadAfter, setUnreadAfter] = useState<number | null>(null);
@@ -474,6 +475,15 @@ export function Navigation(props: NavigationProps): JSX.Element {
     model.unreadChanged?.connect(unreadChanged);
 
     unreadChanged(model, model.unreadMessages);
+
+    if (!initialized.current) {
+      if (model.unreadMessages.length) {
+        gotoMessage(Math.min(...model.unreadMessages));
+      } else {
+        gotoMessage(model.messages.length - 1);
+      }
+      initialized.current = true;
+    }
 
     return () => {
       model.unreadChanged?.disconnect(unreadChanged);

--- a/packages/jupyter-chat/src/components/scroll-container.tsx
+++ b/packages/jupyter-chat/src/components/scroll-container.tsx
@@ -3,7 +3,7 @@
  * Distributed under the terms of the Modified BSD License.
  */
 
-import React, { useEffect, useMemo } from 'react';
+import React, { useMemo } from 'react';
 import { Box, SxProps, Theme } from '@mui/material';
 
 type ScrollContainerProps = {
@@ -31,30 +31,6 @@ export function ScrollContainer(props: ScrollContainerProps): JSX.Element {
     () => 'jupyter-chat-scroll-container-' + Date.now().toString(),
     []
   );
-
-  /**
-   * Effect: Scroll the container to the bottom as soon as it is visible.
-   */
-  useEffect(() => {
-    const el = document.querySelector<HTMLElement>(`#${id}`);
-    if (!el) {
-      return;
-    }
-
-    const observer = new IntersectionObserver(
-      entries => {
-        entries.forEach(entry => {
-          if (entry.isIntersecting) {
-            el.scroll({ top: 999999999 });
-          }
-        });
-      },
-      { threshold: 1.0 }
-    );
-
-    observer.observe(el);
-    return () => observer.disconnect();
-  }, []);
 
   return (
     <Box

--- a/packages/jupyter-chat/src/icons.ts
+++ b/packages/jupyter-chat/src/icons.ts
@@ -8,8 +8,14 @@
 import { LabIcon } from '@jupyterlab/ui-components';
 
 import chatSvgStr from '../style/icons/chat.svg';
+import readSvgStr from '../style/icons/read.svg';
 
 export const chatIcon = new LabIcon({
   name: 'jupyter-chat::chat',
   svgstr: chatSvgStr
+});
+
+export const readIcon = new LabIcon({
+  name: 'jupyter-chat::read',
+  svgstr: readSvgStr
 });

--- a/packages/jupyter-chat/style/icons/read.svg
+++ b/packages/jupyter-chat/style/icons/read.svg
@@ -1,0 +1,11 @@
+<svg height="24px" viewBox="0 0 24 24" width="24px" xmlns="http://www.w3.org/2000/svg">
+  <g>
+    <path
+       style="display:inline;fill:none;fill-opacity:1;stroke:#545454;stroke-width:1.54693;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:1.5;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
+       d="M 2.2734634,9 V 20.226537 H 21.726536 V 9" />
+    <path
+       style="display:inline;fill:none;stroke:#545454;stroke-width:1.54528;stroke-linecap:square;stroke-miterlimit:10"
+       transform="matrix(0.81805878,0.57513462,-0.81805878,0.57513462,0,0)"
+       d="M 9.5141659,-5.1535239 H 20.802967 V 6.1352773 H 9.5141659 Z" />
+  </g>
+</svg>

--- a/packages/jupyterlab-collaborative-chat/schema/chat-panel.json
+++ b/packages/jupyterlab-collaborative-chat/schema/chat-panel.json
@@ -7,6 +7,10 @@
       {
         "name": "moveToSide",
         "command": "collaborative-chat:moveToSide"
+      },
+      {
+        "name": "markAsRead",
+        "command": "collaborative-chat:markAsRead"
       }
     ]
   },

--- a/packages/jupyterlab-collaborative-chat/src/token.ts
+++ b/packages/jupyterlab-collaborative-chat/src/token.ts
@@ -80,7 +80,11 @@ export const CommandIDs = {
   /**
    * Move a main widget to the side panel
    */
-  moveToSide: 'collaborative-chat:moveToSide'
+  moveToSide: 'collaborative-chat:moveToSide',
+  /**
+   * Mark as read.
+   */
+  markAsRead: 'collaborative-chat:markAsRead'
 };
 
 /**

--- a/packages/jupyterlab-collaborative-chat/src/widget.tsx
+++ b/packages/jupyterlab-collaborative-chat/src/widget.tsx
@@ -265,7 +265,7 @@ class ChatSection extends PanelWithToolbar {
 
     this._markAsRead = new ToolbarButton({
       icon: readIcon,
-      iconLabel: 'Mark the chat as read',
+      iconLabel: 'Mark chat as read',
       className: 'jp-mod-styled',
       onClick: () => (this.model.unreadMessages = [])
     });

--- a/packages/jupyterlab-collaborative-chat/src/widget.tsx
+++ b/packages/jupyterlab-collaborative-chat/src/widget.tsx
@@ -3,7 +3,7 @@
  * Distributed under the terms of the Modified BSD License.
  */
 
-import { ChatWidget, IChatModel, IConfig } from '@jupyter/chat';
+import { ChatWidget, IChatModel, IConfig, readIcon } from '@jupyter/chat';
 import { ICollaborativeDrive } from '@jupyter/docprovider';
 import { IThemeManager } from '@jupyterlab/apputils';
 import { PathExt } from '@jupyterlab/coreutils';
@@ -263,6 +263,13 @@ class ChatSection extends PanelWithToolbar {
     this.title.caption = this._name;
     this.toolbar.addClass(TOOLBAR_CLASS);
 
+    this._markAsReadButton = new ToolbarButton({
+      icon: readIcon,
+      iconLabel: 'Mark the chat as read',
+      className: 'jp-mod-styled',
+      onClick: () => (this.model.unreadMessages = [])
+    });
+
     const moveToMain = new ToolbarButton({
       icon: launchIcon,
       iconLabel: 'Move the chat to the main area',
@@ -285,12 +292,16 @@ class ChatSection extends PanelWithToolbar {
         this.dispose();
       }
     });
+
+    this.toolbar.addItem('collaborativeChat-main', this._markAsReadButton);
     this.toolbar.addItem('collaborativeChat-main', moveToMain);
     this.toolbar.addItem('collaborativeChat-close', closeButton);
 
     this.addWidget(options.widget);
 
     this.model.unreadChanged?.connect(this._unreadChanged);
+
+    this._markAsReadButton.enabled = this.model.unreadMessages.length > 0;
 
     options.widget.node.style.height = '100%';
   }
@@ -326,10 +337,12 @@ class ChatSection extends PanelWithToolbar {
    * time.
    */
   private _unreadChanged = (_: IChatModel, unread: number[]) => {
+    this._markAsReadButton.enabled = unread.length > 0;
     // this.title.label = `${unread.length ? '* ' : ''}${this._name}`;
   };
 
   private _name: string;
+  private _markAsReadButton: ToolbarButton;
 }
 
 /**

--- a/packages/jupyterlab-collaborative-chat/src/widget.tsx
+++ b/packages/jupyterlab-collaborative-chat/src/widget.tsx
@@ -263,7 +263,7 @@ class ChatSection extends PanelWithToolbar {
     this.title.caption = this._name;
     this.toolbar.addClass(TOOLBAR_CLASS);
 
-    this._markAsReadButton = new ToolbarButton({
+    this._markAsRead = new ToolbarButton({
       icon: readIcon,
       iconLabel: 'Mark the chat as read',
       className: 'jp-mod-styled',
@@ -293,15 +293,15 @@ class ChatSection extends PanelWithToolbar {
       }
     });
 
-    this.toolbar.addItem('collaborativeChat-main', this._markAsReadButton);
-    this.toolbar.addItem('collaborativeChat-main', moveToMain);
+    this.toolbar.addItem('collaborativeChat-markRead', this._markAsRead);
+    this.toolbar.addItem('collaborativeChat-moveMain', moveToMain);
     this.toolbar.addItem('collaborativeChat-close', closeButton);
 
     this.addWidget(options.widget);
 
     this.model.unreadChanged?.connect(this._unreadChanged);
 
-    this._markAsReadButton.enabled = this.model.unreadMessages.length > 0;
+    this._markAsRead.enabled = this.model.unreadMessages.length > 0;
 
     options.widget.node.style.height = '100%';
   }
@@ -337,12 +337,12 @@ class ChatSection extends PanelWithToolbar {
    * time.
    */
   private _unreadChanged = (_: IChatModel, unread: number[]) => {
-    this._markAsReadButton.enabled = unread.length > 0;
+    this._markAsRead.enabled = unread.length > 0;
     // this.title.label = `${unread.length ? '* ' : ''}${this._name}`;
   };
 
   private _name: string;
-  private _markAsReadButton: ToolbarButton;
+  private _markAsRead: ToolbarButton;
 }
 
 /**

--- a/packages/jupyterlab-collaborative-chat/ui-tests/tests/jupyterlab_collaborative_chat.spec.ts
+++ b/packages/jupyterlab-collaborative-chat/ui-tests/tests/jupyterlab_collaborative_chat.spec.ts
@@ -1273,8 +1273,8 @@ test.describe('#sidepanel', () => {
     });
   });
 
-  test.describe('#chatCreation', () => {
-    const name = 'my-chat';
+  test.describe('#creation', () => {
+    const name = FILENAME.replace('.chat', '');
     let panel: Locator;
     let dialog: Locator;
 
@@ -1290,7 +1290,7 @@ test.describe('#sidepanel', () => {
     });
 
     test.afterEach(async ({ page }) => {
-      for (let filename of ['untitled.chat', `${name}.chat`]) {
+      for (let filename of ['untitled.chat', FILENAME]) {
         if (await page.filebrowser.contents.fileExists(filename)) {
           await page.filebrowser.contents.deleteFile(filename);
         }
@@ -1301,7 +1301,7 @@ test.describe('#sidepanel', () => {
       await dialog.locator('input[type="text"]').pressSequentially(name);
       await dialog.getByRole('button').getByText('Ok').click();
       await page.waitForCondition(
-        async () => await page.filebrowser.contents.fileExists(`${name}.chat`)
+        async () => await page.filebrowser.contents.fileExists(FILENAME)
       );
 
       const chatTitle = panel.locator(
@@ -1339,20 +1339,16 @@ test.describe('#sidepanel', () => {
   });
 
   test.describe('#openingClosing', () => {
-    const name = 'my-chat';
+    const name = FILENAME.replace('.chat', '');
     let panel: Locator;
     let select: Locator;
 
     test.beforeEach(async ({ page }) => {
-      await page.filebrowser.contents.uploadContent(
-        '{}',
-        'text',
-        `${name}.chat`
-      );
+      await page.filebrowser.contents.uploadContent('{}', 'text', FILENAME);
     });
 
     test.afterEach(async ({ page }) => {
-      await page.filebrowser.contents.deleteFile(`${name}.chat`);
+      await page.filebrowser.contents.deleteFile(FILENAME);
     });
 
     test('should list existing chat', async ({ page }) => {
@@ -1393,30 +1389,28 @@ test.describe('#sidepanel', () => {
   });
 
   test.describe('#movingChat', () => {
-    const filename = 'my-chat.chat';
-
     test.use({ mockSettings: { ...galata.DEFAULT_SETTINGS } });
 
     test.beforeEach(async ({ page }) => {
       // Create a chat file
-      await page.filebrowser.contents.uploadContent('{}', 'text', filename);
+      await page.filebrowser.contents.uploadContent('{}', 'text', FILENAME);
     });
 
     test.afterEach(async ({ page }) => {
-      if (await page.filebrowser.contents.fileExists(filename)) {
-        await page.filebrowser.contents.deleteFile(filename);
+      if (await page.filebrowser.contents.fileExists(FILENAME)) {
+        await page.filebrowser.contents.deleteFile(FILENAME);
       }
     });
 
     test('main widget toolbar should have a button', async ({ page }) => {
-      const chatPanel = await openChat(page, filename);
+      const chatPanel = await openChat(page, FILENAME);
       const button = chatPanel.getByTitle('Move the chat to the side panel');
       expect(button).toBeVisible();
       expect(await button.screenshot()).toMatchSnapshot('moveToSide.png');
     });
 
     test('chat should move to the side panel', async ({ page }) => {
-      const chatPanel = await openChat(page, filename);
+      const chatPanel = await openChat(page, FILENAME);
       const button = chatPanel.getByTitle('Move the chat to the side panel');
       await button.click();
       await expect(chatPanel).not.toBeAttached();
@@ -1429,13 +1423,13 @@ test.describe('#sidepanel', () => {
       await expect(chatTitle).toHaveCount(1);
       await expect(
         chatTitle.locator('.lm-AccordionPanel-titleLabel')
-      ).toHaveText(filename.split('.')[0]);
+      ).toHaveText(FILENAME.split('.')[0]);
     });
 
     test('side panel should contain a button to move the chat', async ({
       page
     }) => {
-      const sidePanel = await openChatToSide(page, filename);
+      const sidePanel = await openChatToSide(page, FILENAME);
       const chatTitle = sidePanel
         .locator('.jp-SidePanel-content .jp-AccordionPanel-title')
         .first();
@@ -1445,7 +1439,7 @@ test.describe('#sidepanel', () => {
     });
 
     test('chat should move to the main area', async ({ page }) => {
-      const sidePanel = await openChatToSide(page, filename);
+      const sidePanel = await openChatToSide(page, FILENAME);
       const chatTitle = sidePanel
         .locator('.jp-SidePanel-content .jp-AccordionPanel-title')
         .first();
@@ -1453,7 +1447,7 @@ test.describe('#sidepanel', () => {
       await button.click();
       expect(chatTitle).not.toBeAttached();
 
-      await expect(page.activity.getTabLocator(filename)).toBeVisible();
+      await expect(page.activity.getTabLocator(FILENAME)).toBeVisible();
     });
   });
 });
@@ -1586,9 +1580,7 @@ test.describe('#markUnread', () => {
     }
   });
   test.describe('without previous unread message', () => {
-    test('button should be disabled in main panel',async ({
-      page
-    }) => {
+    test('button should be disabled in main panel', async ({ page }) => {
       const chatPanel = await openChat(page, FILENAME);
       const button = chatPanel.getByTitle('Mark chat as read');
       await expect(button).toBeAttached();
@@ -1597,9 +1589,7 @@ test.describe('#markUnread', () => {
       await expect(button).toHaveAttribute('disabled');
     });
 
-    test('button should be disabled in side panel',async ({
-      page
-    }) => {
+    test('button should be disabled in side panel', async ({ page }) => {
       const sidePanel = await openChatToSide(page, FILENAME);
       const chatTitle = sidePanel
         .locator('.jp-SidePanel-content .jp-AccordionPanel-title')
@@ -1639,9 +1629,7 @@ test.describe('#markUnread', () => {
       );
     });
 
-    test('button should be enabled in main panel', async ({
-      page
-    }) => {
+    test('button should be enabled in main panel', async ({ page }) => {
       const chatPanel = await openChat(page, FILENAME);
       const button = chatPanel.getByTitle('Mark chat as read');
       await expect(button).toBeAttached();
@@ -1658,12 +1646,12 @@ test.describe('#markUnread', () => {
       expect(navigationBottom).toHaveClass(/jp-chat-navigation-unread/);
 
       await button.click();
-      await expect(navigationBottom).not.toHaveClass(/jp-chat-navigation-unread/);
+      await expect(navigationBottom).not.toHaveClass(
+        /jp-chat-navigation-unread/
+      );
     });
 
-    test('button should be enabled in side panel', async ({
-      page
-    }) => {
+    test('button should be enabled in side panel', async ({ page }) => {
       const chatPanel = await openChatToSide(page, FILENAME);
       const button = chatPanel.getByTitle('Mark chat as read');
       await expect(button).toBeAttached();
@@ -1680,7 +1668,9 @@ test.describe('#markUnread', () => {
       expect(navigationBottom).toHaveClass(/jp-chat-navigation-unread/);
 
       await button.click();
-      await expect(navigationBottom).not.toHaveClass(/jp-chat-navigation-unread/);
+      await expect(navigationBottom).not.toHaveClass(
+        /jp-chat-navigation-unread/
+      );
     });
   });
 });


### PR DESCRIPTION
- adds 'mark read' buttons in collaborative chat
- avoid scrolling to the end of the chat when showing the chat, but scroll to the first unread at startup 