### PR TITLE
Autocomplete commands

### DIFF
--- a/packages/jupyter-chat/src/components/chat-input.tsx
+++ b/packages/jupyter-chat/src/components/chat-input.tsx
@@ -47,7 +47,7 @@ export function ChatInput(props: ChatInput.IProps): JSX.Element {
     }
     autocompletion.current = autocompletionName
       ? autocompletionRegistry.get(autocompletionName)
-      : autocompletionRegistry.getDefault();
+      : autocompletionRegistry.getDefaultCompletion();
 
     if (autocompletion.current === undefined) {
       return;

--- a/packages/jupyter-chat/src/components/chat-input.tsx
+++ b/packages/jupyter-chat/src/components/chat-input.tsx
@@ -3,28 +3,85 @@
  * Distributed under the terms of the Modified BSD License.
  */
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import {
+  Autocomplete,
   Box,
+  IconButton,
+  InputAdornment,
   SxProps,
   TextField,
-  Theme,
-  IconButton,
-  InputAdornment
+  Theme
 } from '@mui/material';
 import { Send, Cancel } from '@mui/icons-material';
 import clsx from 'clsx';
+import { AutocompleteCommand, IAutocompletionCommandsProps } from '../types';
 
 const INPUT_BOX_CLASS = 'jp-chat-input-container';
 const SEND_BUTTON_CLASS = 'jp-chat-send-button';
 const CANCEL_BUTTON_CLASS = 'jp-chat-cancel-button';
 
 export function ChatInput(props: ChatInput.IProps): JSX.Element {
+  const { autocompletion, sendWithShiftEnter } = props;
   const [input, setInput] = useState<string>(props.value || '');
-  const { sendWithShiftEnter } = props;
+
+  // The autocomplete commands options.
+  const [commandOptions, setCommandOptions] = useState<AutocompleteCommand[]>(
+    []
+  );
+  // whether any option is highlighted in the slash command autocomplete
+  const [highlighted, setHighlighted] = useState<boolean>(false);
+  // controls whether the slash command autocomplete is open
+  const [open, setOpen] = useState<boolean>(false);
+
+  /**
+   * Effect: fetch the list of available autocomplete commands.
+   */
+  useEffect(() => {
+    if (autocompletion === undefined || !autocompletion.commands) {
+      return;
+    }
+    if (Array.isArray(autocompletion.commands)) {
+      setCommandOptions(autocompletion.commands);
+    } else if (typeof autocompletion.commands === 'function') {
+      autocompletion.commands().then((commands: AutocompleteCommand[]) => {
+        setCommandOptions(commands);
+      });
+    }
+  }, []);
+
+  /**
+   * Effect: Open the autocomplete when the user types the 'opener' string into an
+   * empty chat input. Close the autocomplete and reset the last selected value when
+   * the user clears the chat input.
+   */
+  useEffect(() => {
+    if (!autocompletion?.opener) {
+      return;
+    }
+    if (input === props.autocompletion?.opener) {
+      setOpen(true);
+      return;
+    }
+
+    if (input === '') {
+      setOpen(false);
+      return;
+    }
+  }, [input]);
 
   function handleKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {
+    if (event.key !== 'Enter') {
+      return;
+    }
+
+    // do not send the message if the user was selecting a suggested command from the
+    // Autocomplete component.
+    if (highlighted) {
+      return;
+    }
+
     if (
       event.key === 'Enter' &&
       ((sendWithShiftEnter && event.shiftKey) ||
@@ -65,49 +122,94 @@ export function ChatInput(props: ChatInput.IProps): JSX.Element {
 
   return (
     <Box sx={props.sx} className={clsx(INPUT_BOX_CLASS)}>
-      <Box sx={{ display: 'flex' }}>
-        <TextField
-          value={input}
-          onChange={e => setInput(e.target.value)}
-          fullWidth
-          variant="outlined"
-          multiline
-          onKeyDown={handleKeyDown}
-          placeholder="Start chatting"
-          InputProps={{
-            endAdornment: (
-              <InputAdornment position="end">
-                {props.onCancel && (
+      <Autocomplete
+        options={commandOptions}
+        value=""
+        open={open}
+        autoHighlight
+        freeSolo
+        // ensure the autocomplete popup always renders on top
+        componentsProps={{
+          popper: {
+            placement: 'top'
+          },
+          paper: {
+            sx: {
+              border: '1px solid lightgray'
+            }
+          }
+        }}
+        renderInput={params => (
+          <TextField
+            {...params}
+            fullWidth
+            variant="outlined"
+            multiline
+            onKeyDown={handleKeyDown}
+            placeholder="Start chatting"
+            InputProps={{
+              ...params.InputProps,
+              endAdornment: (
+                <InputAdornment position="end">
+                  {props.onCancel && (
+                    <IconButton
+                      size="small"
+                      color="primary"
+                      onClick={onCancel}
+                      disabled={!input.trim().length}
+                      title={'Cancel edition'}
+                      className={clsx(CANCEL_BUTTON_CLASS)}
+                    >
+                      <Cancel />
+                    </IconButton>
+                  )}
                   <IconButton
                     size="small"
                     color="primary"
-                    onClick={onCancel}
+                    onClick={onSend}
                     disabled={!input.trim().length}
-                    title={'Cancel edition'}
-                    className={clsx(CANCEL_BUTTON_CLASS)}
+                    title={`Send message ${sendWithShiftEnter ? '(SHIFT+ENTER)' : '(ENTER)'}`}
+                    className={clsx(SEND_BUTTON_CLASS)}
                   >
-                    <Cancel />
+                    <Send />
                   </IconButton>
-                )}
-                <IconButton
-                  size="small"
-                  color="primary"
-                  onClick={onSend}
-                  disabled={!input.trim().length}
-                  title={`Send message ${sendWithShiftEnter ? '(SHIFT+ENTER)' : '(ENTER)'}`}
-                  className={clsx(SEND_BUTTON_CLASS)}
-                >
-                  <Send />
-                </IconButton>
-              </InputAdornment>
-            )
-          }}
-          FormHelperTextProps={{
-            sx: { marginLeft: 'auto', marginRight: 0 }
-          }}
-          helperText={input.length > 2 ? helperText : ' '}
-        />
-      </Box>
+                </InputAdornment>
+              )
+            }}
+            FormHelperTextProps={{
+              sx: { marginLeft: 'auto', marginRight: 0 }
+            }}
+            helperText={input.length > 2 ? helperText : ' '}
+          />
+        )}
+        {...autocompletion?.props}
+        inputValue={input}
+        onInputChange={(_, newValue: string) => {
+          setInput(newValue);
+        }}
+        onHighlightChange={
+          /**
+           * On highlight change: set `highlighted` to whether an option is
+           * highlighted by the user.
+           *
+           * This isn't called when an option is selected for some reason, so we
+           * need to call `setHighlighted(false)` in `onClose()`.
+           */
+          (_, highlightedOption) => {
+            setHighlighted(!!highlightedOption);
+          }
+        }
+        onClose={
+          /**
+           * On close: set `highlighted` to `false` and close the popup by
+           * setting `open` to `false`.
+           */
+          () => {
+            setHighlighted(false);
+            setOpen(false);
+          }
+        }
+      />
     </Box>
   );
 }
@@ -140,5 +242,9 @@ export namespace ChatInput {
      * Custom mui/material styles.
      */
     sx?: SxProps<Theme>;
+    /**
+     * Autocompletion properties.
+     */
+    autocompletion?: IAutocompletionCommandsProps;
   }
 }

--- a/packages/jupyter-chat/src/components/chat-input.tsx
+++ b/packages/jupyter-chat/src/components/chat-input.tsx
@@ -138,7 +138,7 @@ export function ChatInput(props: ChatInput.IProps): JSX.Element {
     <Box sx={props.sx} className={clsx(INPUT_BOX_CLASS)}>
       <Autocomplete
         options={commandOptions}
-        value=""
+        value={props.value}
         open={open}
         autoHighlight
         freeSolo
@@ -150,6 +150,13 @@ export function ChatInput(props: ChatInput.IProps): JSX.Element {
           paper: {
             sx: {
               border: '1px solid lightgray'
+            }
+          }
+        }}
+        ListboxProps={{
+          sx: {
+            '& .MuiAutocomplete-option': {
+              padding: 2
             }
           }
         }}
@@ -170,7 +177,6 @@ export function ChatInput(props: ChatInput.IProps): JSX.Element {
                       size="small"
                       color="primary"
                       onClick={onCancel}
-                      disabled={!input.trim().length}
                       title={'Cancel edition'}
                       className={clsx(CANCEL_BUTTON_CLASS)}
                     >
@@ -181,7 +187,11 @@ export function ChatInput(props: ChatInput.IProps): JSX.Element {
                     size="small"
                     color="primary"
                     onClick={onSend}
-                    disabled={!input.trim().length}
+                    disabled={
+                      props.onCancel
+                        ? input === props.value
+                        : !input.trim().length
+                    }
                     title={`Send message ${sendWithShiftEnter ? '(SHIFT+ENTER)' : '(ENTER)'}`}
                     className={clsx(SEND_BUTTON_CLASS)}
                   >
@@ -223,6 +233,8 @@ export function ChatInput(props: ChatInput.IProps): JSX.Element {
             setOpen(false);
           }
         }
+        // hide default extra right padding in the text field
+        disableClearable
       />
     </Box>
   );

--- a/packages/jupyter-chat/src/components/chat.tsx
+++ b/packages/jupyter-chat/src/components/chat.tsx
@@ -15,16 +15,14 @@ import { JlThemeProvider } from './jl-theme-provider';
 import { ChatMessages } from './chat-messages';
 import { ChatInput } from './chat-input';
 import { IChatModel } from '../model';
-import { IAutocompletionCommandsProps } from '../types';
+import { IAutocompletionRegistry } from '../registry';
 
-type ChatBodyProps = {
-  model: IChatModel;
-  rmRegistry: IRenderMimeRegistry;
-  autocompletion?: IAutocompletionCommandsProps;
-};
-
-function ChatBody(props: ChatBodyProps): JSX.Element {
-  const { model, rmRegistry: renderMimeRegistry, autocompletion } = props;
+export function ChatBody(props: Chat.IChatBodyProps): JSX.Element {
+  const {
+    model,
+    rmRegistry: renderMimeRegistry,
+    autocompletionRegistry
+  } = props;
   // no need to append to messageGroups imperatively here. all of that is
   // handled by the listeners registered in the effect hooks above.
   const onSend = async (input: string) => {
@@ -45,7 +43,7 @@ function ChatBody(props: ChatBodyProps): JSX.Element {
           borderTop: '1px solid var(--jp-border-color1)'
         }}
         sendWithShiftEnter={model.config.sendWithShiftEnter ?? false}
-        autocompletion={autocompletion}
+        autocompletionRegistry={autocompletionRegistry}
       />
     </>
   );
@@ -89,7 +87,7 @@ export function Chat(props: Chat.IOptions): JSX.Element {
           <ChatBody
             model={props.model}
             rmRegistry={props.rmRegistry}
-            autocompletion={props.autocompletion}
+            autocompletionRegistry={props.autocompletionRegistry}
           />
         )}
         {view === Chat.View.settings && props.settingsPanel && (
@@ -105,9 +103,9 @@ export function Chat(props: Chat.IOptions): JSX.Element {
  */
 export namespace Chat {
   /**
-   * The options to build the Chat UI.
+   * The props for the chat body component.
    */
-  export interface IOptions {
+  export interface IChatBodyProps {
     /**
      * The chat model.
      */
@@ -116,6 +114,20 @@ export namespace Chat {
      * The rendermime registry.
      */
     rmRegistry: IRenderMimeRegistry;
+    /**
+     * Autocompletion registry.
+     */
+    autocompletionRegistry?: IAutocompletionRegistry;
+    /**
+     * Autocompletion name.
+     */
+    autocompletionName?: string;
+  }
+
+  /**
+   * The options to build the Chat UI.
+   */
+  export interface IOptions extends IChatBodyProps {
     /**
      * The theme manager.
      */
@@ -128,10 +140,6 @@ export namespace Chat {
      * A settings panel that can be used for dedicated settings (e.g. jupyter-ai)
      */
     settingsPanel?: () => JSX.Element;
-    /**
-     * Autocompletion properties.
-     */
-    autocompletion?: IAutocompletionCommandsProps;
   }
 
   /**

--- a/packages/jupyter-chat/src/components/chat.tsx
+++ b/packages/jupyter-chat/src/components/chat.tsx
@@ -15,16 +15,16 @@ import { JlThemeProvider } from './jl-theme-provider';
 import { ChatMessages } from './chat-messages';
 import { ChatInput } from './chat-input';
 import { IChatModel } from '../model';
+import { IAutocompletionCommandsProps } from '../types';
 
 type ChatBodyProps = {
   model: IChatModel;
   rmRegistry: IRenderMimeRegistry;
+  autocompletion?: IAutocompletionCommandsProps;
 };
 
-function ChatBody({
-  model,
-  rmRegistry: renderMimeRegistry
-}: ChatBodyProps): JSX.Element {
+function ChatBody(props: ChatBodyProps): JSX.Element {
+  const { model, rmRegistry: renderMimeRegistry, autocompletion } = props;
   // no need to append to messageGroups imperatively here. all of that is
   // handled by the listeners registered in the effect hooks above.
   const onSend = async (input: string) => {
@@ -45,6 +45,7 @@ function ChatBody({
           borderTop: '1px solid var(--jp-border-color1)'
         }}
         sendWithShiftEnter={model.config.sendWithShiftEnter ?? false}
+        autocompletion={autocompletion}
       />
     </>
   );
@@ -85,7 +86,11 @@ export function Chat(props: Chat.IOptions): JSX.Element {
         </Box>
         {/* body */}
         {view === Chat.View.chat && (
-          <ChatBody model={props.model} rmRegistry={props.rmRegistry} />
+          <ChatBody
+            model={props.model}
+            rmRegistry={props.rmRegistry}
+            autocompletion={props.autocompletion}
+          />
         )}
         {view === Chat.View.settings && props.settingsPanel && (
           <props.settingsPanel />
@@ -123,6 +128,10 @@ export namespace Chat {
      * A settings panel that can be used for dedicated settings (e.g. jupyter-ai)
      */
     settingsPanel?: () => JSX.Element;
+    /**
+     * Autocompletion properties.
+     */
+    autocompletion?: IAutocompletionCommandsProps;
   }
 
   /**

--- a/packages/jupyter-chat/src/index.ts
+++ b/packages/jupyter-chat/src/index.ts
@@ -5,6 +5,7 @@
 
 export * from './icons';
 export * from './model';
+export * from './registry';
 export * from './types';
 export * from './widgets/chat-error';
 export * from './widgets/chat-sidebar';

--- a/packages/jupyter-chat/src/registry.ts
+++ b/packages/jupyter-chat/src/registry.ts
@@ -117,6 +117,13 @@ export class AutocompletionRegistry {
     return this._autocompletions.delete(name);
   }
 
+  /**
+   * Remove all registered autocompletions.
+   */
+  removeAll(): void {
+    this._autocompletions.clear();
+  }
+
   private _default: string | null = null;
   private _autocompletions = new Map<string, IAutocompletionCommandsProps>();
 }

--- a/packages/jupyter-chat/src/registry.ts
+++ b/packages/jupyter-chat/src/registry.ts
@@ -24,7 +24,7 @@ export interface IAutocompletionRegistry {
   /**
    * Get the default autocompletion.
    */
-  getDefault(): IAutocompletionCommandsProps | undefined;
+  getDefaultCompletion(): IAutocompletionCommandsProps | undefined;
   /**
    * Return a registered autocomplete props.
    *
@@ -51,7 +51,7 @@ export interface IAutocompletionRegistry {
 /**
  * A registry to provide autocompleters.
  */
-export class AutocompletionRegistry {
+export class AutocompletionRegistry implements IAutocompletionRegistry {
   /**
    * Getter and setter for the default autocompletion name.
    */
@@ -69,7 +69,7 @@ export class AutocompletionRegistry {
   /**
    * Get the default autocompletion.
    */
-  getDefault(): IAutocompletionCommandsProps | undefined {
+  getDefaultCompletion(): IAutocompletionCommandsProps | undefined {
     if (this._default === null) {
       return undefined;
     }

--- a/packages/jupyter-chat/src/registry.ts
+++ b/packages/jupyter-chat/src/registry.ts
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+import { Token } from '@lumino/coreutils';
+import { IAutocompletionCommandsProps } from './types';
+
+/**
+ * The token for the autocomplete registry, which can be provided by an extension
+ * using @jupyter/chat package.
+ */
+export const IAutocompletionRegistry = new Token<IAutocompletionRegistry>(
+  '@jupyter/chat:IAutocompleteRegistry'
+);
+
+/**
+ * The interface of a registry to provide autocompleters.
+ */
+export interface IAutocompletionRegistry {
+  /**
+   * The default autocompletion name.
+   */
+  default: string | null;
+  /**
+   * Get the default autocompletion.
+   */
+  getDefault(): IAutocompletionCommandsProps | undefined;
+  /**
+   * Return a registered autocomplete props.
+   *
+   * @param name - the name of the registered autocomplete props.
+   */
+  get(name: string): IAutocompletionCommandsProps | undefined;
+
+  /**
+   * Register autocomplete props.
+   *
+   * @param name - the name for the registration.
+   * @param autocompletion - the autocomplete props.
+   */
+  add(name: string, autocompletion: IAutocompletionCommandsProps): boolean;
+
+  /**
+   * Remove a registered autocomplete props.
+   *
+   * @param name - the name of the autocomplete props.
+   */
+  remove(name: string): boolean;
+}
+
+/**
+ * A registry to provide autocompleters.
+ */
+export class AutocompletionRegistry {
+  /**
+   * Getter and setter for the default autocompletion name.
+   */
+  get default(): string | null {
+    return this._default;
+  }
+  set default(name: string | null) {
+    if (name === null || this._autocompletions.has(name)) {
+      this._default = name;
+    } else {
+      console.warn(`There is no registered completer with the name '${name}'`);
+    }
+  }
+
+  /**
+   * Get the default autocompletion.
+   */
+  getDefault(): IAutocompletionCommandsProps | undefined {
+    if (this._default === null) {
+      return undefined;
+    }
+    return this._autocompletions.get(this._default);
+  }
+
+  /**
+   * Return a registered autocomplete props.
+   *
+   * @param name - the name of the registered autocomplete props.
+   */
+  get(name: string): IAutocompletionCommandsProps | undefined {
+    return this._autocompletions.get(name);
+  }
+
+  /**
+   * Register autocomplete props.
+   *
+   * @param name - the name for the registration.
+   * @param autocompletion - the autocomplete props.
+   */
+  add(
+    name: string,
+    autocompletion: IAutocompletionCommandsProps,
+    isDefault: boolean = false
+  ): boolean {
+    if (!this._autocompletions.has(name)) {
+      this._autocompletions.set(name, autocompletion);
+      if (this._autocompletions.size === 1 || isDefault) {
+        this.default = name;
+      }
+      return true;
+    } else {
+      console.warn(`A completer with the name '${name}' is already registered`);
+      return false;
+    }
+  }
+
+  /**
+   * Remove a registered autocomplete props.
+   *
+   * @param name - the name of the autocomplete props.
+   */
+  remove(name: string): boolean {
+    return this._autocompletions.delete(name);
+  }
+
+  private _default: string | null = null;
+  private _autocompletions = new Map<string, IAutocompletionCommandsProps>();
+}

--- a/packages/jupyter-chat/src/types.ts
+++ b/packages/jupyter-chat/src/types.ts
@@ -81,6 +81,9 @@ export type AutocompleteCommand = {
 
 /**
  * The properties of the autocompletion.
+ *
+ * The autocompletion component will open if the 'opener' string is typed at the
+ * beginning of the input field.
  */
 export interface IAutocompletionCommandsProps {
   /**
@@ -99,6 +102,7 @@ export interface IAutocompletionCommandsProps {
    * ## NOTES:
    * - providing `options` will overwrite the commands argument.
    * - providing `renderInput` will overwrite the input component.
+   * - providing `renderOptions` allows to customize the rendering of the component.
    * - some arguments should not be provided and would be overwritten:
    *   - inputValue
    *   - onInputChange

--- a/packages/jupyter-chat/src/types.ts
+++ b/packages/jupyter-chat/src/types.ts
@@ -71,3 +71,38 @@ export interface INewMessage {
  * An empty interface to describe optional settings that could be fetched from server.
  */
 export interface ISettings {}
+
+/**
+ * The autocomplete command type.
+ */
+export type AutocompleteCommand = {
+  label: string;
+};
+
+/**
+ * The properties of the autocompletion.
+ */
+export interface IAutocompletionCommandsProps {
+  /**
+   * The string that open the completer.
+   */
+  opener: string;
+  /**
+   * The list of available commands.
+   */
+  commands?: AutocompleteCommand[] | (() => Promise<AutocompleteCommand[]>);
+  /**
+   * The props for the Autocomplete component.
+   *
+   * Must be compatible with https://mui.com/material-ui/api/autocomplete/#props.
+   *
+   * ## NOTES:
+   * - providing `options` will overwrite the commands argument.
+   * - providing `renderInput` will overwrite the input component.
+   * - some arguments should not be provided and would be overwritten:
+   *   - inputValue
+   *   - onInputChange
+   *   - onHighlightChange
+   */
+  props?: any;
+}

--- a/packages/jupyterlab-collaborative-chat/src/factory.ts
+++ b/packages/jupyterlab-collaborative-chat/src/factory.ts
@@ -3,7 +3,7 @@
  * Distributed under the terms of the Modified BSD License.
  */
 
-import { ChatWidget, IConfig } from '@jupyter/chat';
+import { ChatWidget, IAutocompletionRegistry, IConfig } from '@jupyter/chat';
 import { IThemeManager } from '@jupyterlab/apputils';
 import { ABCWidgetFactory, DocumentRegistry } from '@jupyterlab/docregistry';
 import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
@@ -52,6 +52,7 @@ export class ChatWidgetFactory extends ABCWidgetFactory<
     super(options);
     this._themeManager = options.themeManager;
     this._rmRegistry = options.rmRegistry;
+    this._autocompletionRegistry = options.autocompletionRegistry;
   }
 
   /**
@@ -65,6 +66,7 @@ export class ChatWidgetFactory extends ABCWidgetFactory<
   ): CollaborativeChatPanel {
     context.rmRegistry = this._rmRegistry;
     context.themeManager = this._themeManager;
+    context.autocompletionRegistry = this._autocompletionRegistry;
     return new CollaborativeChatPanel({
       context,
       content: new ChatWidget(context)
@@ -73,6 +75,7 @@ export class ChatWidgetFactory extends ABCWidgetFactory<
 
   private _themeManager: IThemeManager | null;
   private _rmRegistry: IRenderMimeRegistry;
+  private _autocompletionRegistry?: IAutocompletionRegistry;
 }
 
 export namespace ChatWidgetFactory {
@@ -80,12 +83,14 @@ export namespace ChatWidgetFactory {
     extends DocumentRegistry.IContext<CollaborativeChatModel> {
     themeManager: IThemeManager | null;
     rmRegistry: IRenderMimeRegistry;
+    autocompletionRegistry?: IAutocompletionRegistry;
   }
 
   export interface IOptions<T extends CollaborativeChatPanel>
     extends DocumentRegistry.IWidgetFactoryOptions<T> {
     themeManager: IThemeManager | null;
     rmRegistry: IRenderMimeRegistry;
+    autocompletionRegistry?: IAutocompletionRegistry;
   }
 }
 

--- a/packages/jupyterlab-collaborative-chat/src/index.ts
+++ b/packages/jupyterlab-collaborative-chat/src/index.ts
@@ -47,7 +47,8 @@ import { YChat } from './ychat';
 const FACTORY = 'Chat';
 
 const pluginIds = {
-  acRegistry: 'jupyterlab-collaborative-chat:autocompletionRegistry',
+  autocompletionRegistry:
+    'jupyterlab-collaborative-chat:autocompletionRegistry',
   chatCommands: 'jupyterlab-collaborative-chat:commands',
   docFactories: 'jupyterlab-collaborative-chat:factory',
   chatPanel: 'jupyterlab-collaborative-chat:chat-panel'
@@ -57,7 +58,7 @@ const pluginIds = {
  * Extension providing the autocompletion registry.
  */
 const autocompletionPlugin: JupyterFrontEndPlugin<IAutocompletionRegistry> = {
-  id: pluginIds.acRegistry,
+  id: pluginIds.autocompletionRegistry,
   description: 'An autocompletion registry',
   autoStart: true,
   provides: IAutocompletionRegistry,

--- a/packages/jupyterlab-collaborative-chat/src/index.ts
+++ b/packages/jupyterlab-collaborative-chat/src/index.ts
@@ -3,7 +3,12 @@
  * Distributed under the terms of the Modified BSD License.
  */
 
-import { chatIcon, readIcon } from '@jupyter/chat';
+import {
+  AutocompletionRegistry,
+  IAutocompletionRegistry,
+  chatIcon,
+  readIcon
+} from '@jupyter/chat';
 import { ICollaborativeDrive } from '@jupyter/docprovider';
 import {
   ILayoutRestorer,
@@ -42,9 +47,23 @@ import { YChat } from './ychat';
 const FACTORY = 'Chat';
 
 const pluginIds = {
+  acRegistry: 'jupyterlab-collaborative-chat:autocompletionRegistry',
   chatCommands: 'jupyterlab-collaborative-chat:commands',
   docFactories: 'jupyterlab-collaborative-chat:factory',
   chatPanel: 'jupyterlab-collaborative-chat:chat-panel'
+};
+
+/**
+ * Extension providing the autocompletion registry.
+ */
+const autocompletionPlugin: JupyterFrontEndPlugin<IAutocompletionRegistry> = {
+  id: pluginIds.acRegistry,
+  description: 'An autocompletion registry',
+  autoStart: true,
+  provides: IAutocompletionRegistry,
+  activate: (app: JupyterFrontEnd): IAutocompletionRegistry => {
+    return new AutocompletionRegistry();
+  }
 };
 
 /**
@@ -56,6 +75,7 @@ const docFactories: JupyterFrontEndPlugin<IChatFactory> = {
   autoStart: true,
   requires: [IRenderMimeRegistry],
   optional: [
+    IAutocompletionRegistry,
     ICollaborativeDrive,
     ILayoutRestorer,
     ISettingRegistry,
@@ -67,6 +87,7 @@ const docFactories: JupyterFrontEndPlugin<IChatFactory> = {
   activate: (
     app: JupyterFrontEnd,
     rmRegistry: IRenderMimeRegistry,
+    autocompletionRegistry: IAutocompletionRegistry,
     drive: ICollaborativeDrive | null,
     restorer: ILayoutRestorer | null,
     settingRegistry: ISettingRegistry | null,
@@ -187,7 +208,8 @@ const docFactories: JupyterFrontEndPlugin<IChatFactory> = {
       themeManager,
       rmRegistry,
       toolbarFactory,
-      translator
+      translator,
+      autocompletionRegistry
     });
 
     // Add the widget to the tracker when it's created
@@ -480,11 +502,12 @@ const chatPanel: JupyterFrontEndPlugin<ChatPanel> = {
   autoStart: true,
   provides: IChatPanel,
   requires: [ICollaborativeDrive, IRenderMimeRegistry],
-  optional: [ILayoutRestorer, IThemeManager],
+  optional: [IAutocompletionRegistry, ILayoutRestorer, IThemeManager],
   activate: (
     app: JupyterFrontEnd,
     drive: ICollaborativeDrive,
     rmRegistry: IRenderMimeRegistry,
+    autocompletionRegistry: IAutocompletionRegistry,
     restorer: ILayoutRestorer | null,
     themeManager: IThemeManager | null
   ): ChatPanel => {
@@ -497,7 +520,8 @@ const chatPanel: JupyterFrontEndPlugin<ChatPanel> = {
       commands,
       drive,
       rmRegistry,
-      themeManager
+      themeManager,
+      autocompletionRegistry
     });
     chatPanel.id = 'JupyterCollaborationChat:sidepanel';
     chatPanel.title.icon = chatIcon;
@@ -560,4 +584,4 @@ const chatPanel: JupyterFrontEndPlugin<ChatPanel> = {
   }
 };
 
-export default [chatCommands, docFactories, chatPanel];
+export default [autocompletionPlugin, chatCommands, docFactories, chatPanel];

--- a/packages/jupyterlab-collaborative-chat/src/widget.tsx
+++ b/packages/jupyterlab-collaborative-chat/src/widget.tsx
@@ -3,7 +3,13 @@
  * Distributed under the terms of the Modified BSD License.
  */
 
-import { ChatWidget, IChatModel, IConfig, readIcon } from '@jupyter/chat';
+import {
+  ChatWidget,
+  IAutocompletionRegistry,
+  IChatModel,
+  IConfig,
+  readIcon
+} from '@jupyter/chat';
 import { ICollaborativeDrive } from '@jupyter/docprovider';
 import { IThemeManager } from '@jupyterlab/apputils';
 import { PathExt } from '@jupyterlab/coreutils';
@@ -101,6 +107,7 @@ export class ChatPanel extends SidePanel {
     this._drive = options.drive;
     this._rmRegistry = options.rmRegistry;
     this._themeManager = options.themeManager;
+    this._autocompletionRegistry = options.autocompletionRegistry;
 
     const addChat = new CommandToolbarButton({
       commands: this._commands,
@@ -158,7 +165,8 @@ export class ChatPanel extends SidePanel {
     const widget = new ChatWidget({
       model: model,
       rmRegistry: this._rmRegistry,
-      themeManager: this._themeManager
+      themeManager: this._themeManager,
+      autocompletionRegistry: this._autocompletionRegistry
     });
     this.addWidget(new ChatSection({ name, widget, commands: this._commands }));
   }
@@ -231,6 +239,7 @@ export class ChatPanel extends SidePanel {
   private _openChat: ReactWidget;
   private _rmRegistry: IRenderMimeRegistry;
   private _themeManager: IThemeManager | null;
+  private _autocompletionRegistry?: IAutocompletionRegistry;
 }
 
 /**
@@ -245,6 +254,7 @@ export namespace ChatPanel {
     drive: ICollaborativeDrive;
     rmRegistry: IRenderMimeRegistry;
     themeManager: IThemeManager | null;
+    autocompletionRegistry?: IAutocompletionRegistry;
   }
 }
 

--- a/packages/jupyterlab-collaborative-chat/ui-tests/tests/autocompletion.spec.ts
+++ b/packages/jupyterlab-collaborative-chat/ui-tests/tests/autocompletion.spec.ts
@@ -1,0 +1,359 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+import { expect, IJupyterLabPageFixture, test } from '@jupyterlab/galata';
+import { Locator } from '@playwright/test';
+
+const FILENAME = 'my-chat.chat';
+const opener = '?';
+const commands = ['?test', '?other-test', '?last-test'];
+
+// Workaround to expose a function using 'window' in the browser context.
+// Copied from https://github.com/puppeteer/puppeteer/issues/724#issuecomment-896755822
+const exposeDepsJs = (deps: Record<string, (...args: any) => any>): string => {
+  return Object.keys(deps)
+    .map(key => {
+      return `window["${key}"] = ${deps[key]};`;
+    })
+    .join('\n');
+};
+
+// The function running in browser context to get a plugin.
+const getPlugin = (pluginId: string): Promise<any> => {
+  return new Promise((resolve, reject) => {
+    const app = window.jupyterapp;
+    const hasPlugin = app.hasPlugin(pluginId);
+
+    if (hasPlugin) {
+      try {
+        const appAny = app as any;
+        const plugin: any = appAny._plugins
+          ? appAny._plugins.get(pluginId)
+          : undefined;
+        if (plugin.activated) {
+          resolve(plugin.service);
+        } else {
+          void app.activatePlugin(pluginId).then(response => {
+            resolve(plugin.service);
+          });
+        }
+      } catch (error) {
+        console.error('Failed to get plugin', error);
+      }
+    }
+  });
+};
+
+const openChat = async (
+  page: IJupyterLabPageFixture,
+  filename: string
+): Promise<Locator> => {
+  const panel = await page.activity.getPanelLocator(filename);
+  if (panel !== null && (await panel.count())) {
+    return panel;
+  }
+
+  await page.evaluate(async filepath => {
+    await window.jupyterapp.commands.execute('collaborative-chat:open', {
+      filepath
+    });
+  }, filename);
+  await page.waitForCondition(
+    async () => await page.activity.isTabActive(filename)
+  );
+  return (await page.activity.getPanelLocator(filename)) as Locator;
+};
+
+test.beforeEach(async ({ page }) => {
+  // Expose a function to get a plugin.
+  await page.evaluate(exposeDepsJs({ getPlugin }));
+
+  // Create a chat file
+  await page.filebrowser.contents.uploadContent('{}', 'text', FILENAME);
+});
+
+test.afterEach(async ({ page }) => {
+  if (await page.filebrowser.contents.fileExists(FILENAME)) {
+    await page.filebrowser.contents.deleteFile(FILENAME);
+  }
+});
+
+test.describe('#autocompletionRegistry', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.evaluate(
+      async options => {
+        // register a basic autocompletion object in registry.
+        const registry = await window.getPlugin(
+          'jupyterlab-collaborative-chat:autocompletionRegistry'
+        );
+
+        registry.removeAll();
+
+        const autocompletion = {
+          opener: options.opener,
+          commands: async () =>
+            options.commands.map(str => ({
+              label: str,
+              id: str.replace('?', '')
+            }))
+        };
+        registry.add('test-completion', autocompletion, true);
+      },
+      { opener, commands }
+    );
+  });
+
+  test('should open autocompletion with opener string', async ({ page }) => {
+    const chatPanel = await openChat(page, FILENAME);
+    const input = chatPanel
+      .locator('.jp-chat-input-container')
+      .getByRole('combobox');
+    const completionPopup = page.locator('.MuiAutocomplete-popper');
+    // Autocompletion should no be attached by default.
+    await expect(completionPopup).not.toBeAttached();
+
+    // Autocompletion should no be attached with other character than the opener.
+    await input.fill('/');
+    await expect(completionPopup).not.toBeAttached();
+
+    // Autocompletion should no be attached with opener character.
+    await input.fill(opener);
+    await expect(completionPopup).toBeAttached();
+
+    // The autocompletion should be closed when removing opener string.
+    await input.press('Backspace');
+    await expect(completionPopup).not.toBeAttached();
+  });
+
+  test('autocompletion should contain correct tags', async ({ page }) => {
+    const chatPanel = await openChat(page, FILENAME);
+    const input = chatPanel
+      .locator('.jp-chat-input-container')
+      .getByRole('combobox');
+    const completionPopup = page.locator('.MuiAutocomplete-popper');
+    // Autocompletion should no be attached by default.
+    await expect(completionPopup).not.toBeAttached();
+
+    // Autocompletion should no be attached with opener character.
+    await input.fill(opener);
+    await expect(completionPopup).toBeAttached();
+
+    const options = completionPopup.locator('.MuiAutocomplete-option');
+    await expect(options).toHaveCount(3);
+    for (let i = 0; i < (await options.count()); i++) {
+      await expect(options.nth(i)).toHaveText(commands[i]);
+    }
+  });
+
+  test('should open autocompletion with a tag highlighted', async ({
+    page
+  }) => {
+    const chatPanel = await openChat(page, FILENAME);
+    const input = chatPanel
+      .locator('.jp-chat-input-container')
+      .getByRole('combobox');
+    const completionPopup = page.locator('.MuiAutocomplete-popper');
+
+    // Autocompletion should no be attached with opener character.
+    await input.fill(opener);
+    await expect(completionPopup).toBeAttached();
+    await expect(completionPopup.locator('.Mui-focused')).toHaveCount(1);
+  });
+
+  test('should remove autocompletion from registry', async ({ page }) => {
+    await page.evaluate(
+      async options => {
+        const registry = await window.getPlugin(
+          'jupyterlab-collaborative-chat:autocompletionRegistry'
+        );
+        registry.remove('test-completion');
+      },
+      { opener, commands }
+    );
+    const chatPanel = await openChat(page, FILENAME);
+    const input = chatPanel
+      .locator('.jp-chat-input-container')
+      .getByRole('combobox');
+    const completionPopup = page.locator('.MuiAutocomplete-popper');
+
+    // Autocompletion should not be attached with opener character.
+    await input.fill(opener);
+    await expect(completionPopup).not.toBeAttached();
+  });
+
+  test('should change the default completion when adding a new default', async ({
+    page
+  }) => {
+    const newOpener = '/';
+    await page.evaluate(
+      async options => {
+        const registry = await window.getPlugin(
+          'jupyterlab-collaborative-chat:autocompletionRegistry'
+        );
+        const autocompletion = {
+          opener: options.newOpener,
+          commands: async () =>
+            options.commands.map(str => ({
+              label: str.replace('?', '/'),
+              id: str.replace('?', '')
+            }))
+        };
+        registry.add('test-completion-other', autocompletion, true);
+      },
+      { newOpener, commands }
+    );
+
+    const chatPanel = await openChat(page, FILENAME);
+    const input = chatPanel
+      .locator('.jp-chat-input-container')
+      .getByRole('combobox');
+    const completionPopup = page.locator('.MuiAutocomplete-popper');
+
+    // Autocompletion should not be attached with the previous opener character.
+    await input.fill(opener);
+    await expect(completionPopup).not.toBeAttached();
+
+    await input.fill(newOpener);
+    await expect(completionPopup).toBeAttached();
+
+    const options = completionPopup.locator('.MuiAutocomplete-option');
+    await expect(options).toHaveCount(3);
+    for (let i = 0; i < (await options.count()); i++) {
+      await expect(options.nth(i)).toHaveText(commands[i].replace('?', '/'));
+    }
+  });
+
+  test('should not add autocompletion with the same name', async ({ page }) => {
+    const newOpener = '/';
+    const added = await page.evaluate(
+      async options => {
+        const registry = await window.getPlugin(
+          'jupyterlab-collaborative-chat:autocompletionRegistry'
+        );
+        const autocompletion = {
+          opener: options.newOpener,
+          commands: async () =>
+            options.commands.map(str => ({
+              label: str.replace('?', '/'),
+              id: str.replace('?', '')
+            }))
+        };
+        return registry.add('test-completion', autocompletion, true);
+      },
+      { newOpener, commands }
+    );
+
+    expect(added).toBe(false);
+
+    const chatPanel = await openChat(page, FILENAME);
+    const input = chatPanel
+      .locator('.jp-chat-input-container')
+      .getByRole('combobox');
+    const completionPopup = page.locator('.MuiAutocomplete-popper');
+
+    // Autocompletion should be attached with the previous opener character.
+    await input.fill(opener);
+    await expect(completionPopup).toBeAttached();
+  });
+
+  test('should not change the default completion when adding a non default', async ({
+    page
+  }) => {
+    const newOpener = '/';
+    await page.evaluate(
+      async options => {
+        const registry = await window.getPlugin(
+          'jupyterlab-collaborative-chat:autocompletionRegistry'
+        );
+        const autocompletion = {
+          opener: options.newOpener,
+          commands: async () =>
+            options.commands.map(str => ({
+              label: str.replace('?', '/'),
+              id: str.replace('?', '')
+            }))
+        };
+        registry.add('test-completion-other', autocompletion, false);
+      },
+      { newOpener, commands }
+    );
+
+    const chatPanel = await openChat(page, FILENAME);
+    const input = chatPanel
+      .locator('.jp-chat-input-container')
+      .getByRole('combobox');
+    const completionPopup = page.locator('.MuiAutocomplete-popper');
+
+    // Autocompletion should be attached with the previous opener character.
+    await input.fill(opener);
+    await expect(completionPopup).toBeAttached();
+  });
+});
+
+test('should use properties from autocompletion object', async ({ page }) => {
+  await page.evaluate(
+    async options => {
+      const registry = await window.getPlugin(
+        'jupyterlab-collaborative-chat:autocompletionRegistry'
+      );
+      registry.removeAll();
+      const autocompletion = {
+        opener: options.opener,
+        commands: async () =>
+          options.commands.map(str => ({
+            label: str,
+            id: str.replace('?', '')
+          })),
+        props: {
+          autoHighlight: false
+        }
+      };
+      registry.add('test-completion', autocompletion, true);
+    },
+    { opener, commands }
+  );
+
+  const chatPanel = await openChat(page, FILENAME);
+  const input = chatPanel
+    .locator('.jp-chat-input-container')
+    .getByRole('combobox');
+  const completionPopup = page.locator('.MuiAutocomplete-popper');
+
+  // There should be no highlighted option.
+  await input.fill(opener);
+  await expect(completionPopup).toBeAttached();
+  await expect(completionPopup.locator('.Mui-focused')).toHaveCount(0);
+});
+
+test('single autocompletion should be the default', async ({ page }) => {
+  await page.evaluate(
+    async options => {
+      const registry = await window.getPlugin(
+        'jupyterlab-collaborative-chat:autocompletionRegistry'
+      );
+      registry.removeAll();
+      const autocompletion = {
+        opener: options.opener,
+        commands: async () =>
+          options.commands.map(str => ({
+            label: str,
+            id: str.replace('?', '')
+          }))
+      };
+      registry.add('test-completion', autocompletion, false);
+    },
+    { opener, commands }
+  );
+
+  const chatPanel = await openChat(page, FILENAME);
+  const input = chatPanel
+    .locator('.jp-chat-input-container')
+    .getByRole('combobox');
+  const completionPopup = page.locator('.MuiAutocomplete-popper');
+
+  // Autocompletion should be attached with the opener character.
+  await input.fill(opener);
+  await expect(completionPopup).toBeAttached();
+});

--- a/packages/jupyterlab-collaborative-chat/ui-tests/tests/jupyterlab_collaborative_chat.spec.ts
+++ b/packages/jupyterlab-collaborative-chat/ui-tests/tests/jupyterlab_collaborative_chat.spec.ts
@@ -1201,6 +1201,9 @@ test.describe('#outofband', () => {
     const messages = chatPanel.locator(
       '.jp-chat-messages-container .jp-chat-message'
     );
+    await page.waitForCondition(async () =>
+      messages.first().locator('.jp-chat-rendermime-markdown').isVisible()
+    );
     const newMsg = {
       type: 'msg',
       id: UUID.uuid4(),

--- a/packages/jupyterlab-collaborative-chat/ui-tests/tests/jupyterlab_collaborative_chat.spec.ts
+++ b/packages/jupyterlab-collaborative-chat/ui-tests/tests/jupyterlab_collaborative_chat.spec.ts
@@ -128,7 +128,7 @@ const sendMessage = async (
   const chatPanel = await openChat(page, filename);
   const input = chatPanel
     .locator('.jp-chat-input-container')
-    .getByRole('textbox');
+    .getByRole('combobox');
   const sendButton = chatPanel
     .locator('.jp-chat-input-container')
     .getByRole('button');
@@ -304,7 +304,7 @@ test.describe('#sendMessages', () => {
     const chatPanel = await openChat(page, FILENAME);
     const input = chatPanel
       .locator('.jp-chat-input-container')
-      .getByRole('textbox');
+      .getByRole('combobox');
     const sendButton = chatPanel
       .locator('.jp-chat-input-container')
       .getByRole('button');
@@ -323,7 +323,7 @@ test.describe('#sendMessages', () => {
     const chatPanel = await openChat(page, FILENAME);
     const input = chatPanel
       .locator('.jp-chat-input-container')
-      .getByRole('textbox');
+      .getByRole('combobox');
     await input.pressSequentially(MSG_CONTENT);
     await input.press('Enter');
 
@@ -358,7 +358,7 @@ test.describe('#sendMessages', () => {
     const messages = chatPanel.locator('.jp-chat-messages-container');
     const input = chatPanel
       .locator('.jp-chat-input-container')
-      .getByRole('textbox');
+      .getByRole('combobox');
     await input!.pressSequentially(MSG_CONTENT);
     await input!.press('Enter');
 
@@ -404,7 +404,7 @@ test.describe('#sendMessages', () => {
     const messages = chatPanel.locator('.jp-chat-messages-container');
     const input = chatPanel
       .locator('.jp-chat-input-container')
-      .getByRole('textbox');
+      .getByRole('combobox');
     await input!.pressSequentially(MSG_CONTENT);
     await input!.press('Enter');
 
@@ -1033,7 +1033,7 @@ test.describe('#messageToolbar', () => {
 
     const editInput = chatPanel
       .locator('.jp-chat-messages-container .jp-chat-input-container')
-      .getByRole('textbox');
+      .getByRole('combobox');
 
     await expect(editInput).toBeVisible();
     await editInput.focus();
@@ -1065,7 +1065,7 @@ test.describe('#messageToolbar', () => {
 
     const editInput = chatPanel
       .locator('.jp-chat-messages-container .jp-chat-input-container')
-      .getByRole('textbox');
+      .getByRole('combobox');
 
     await expect(editInput).toBeVisible();
     await editInput.focus();
@@ -1130,7 +1130,7 @@ test.describe('#ychat', () => {
     const chatPanel = await openChat(page, FILENAME);
     await chatPanel
       .locator('.jp-chat-input-container')
-      .getByRole('textbox')
+      .getByRole('combobox')
       .waitFor();
     const hasId = async () => {
       const model = await readFileContent(page, FILENAME);

--- a/packages/jupyterlab-collaborative-chat/ui-tests/tests/jupyterlab_collaborative_chat.spec.ts
+++ b/packages/jupyterlab-collaborative-chat/ui-tests/tests/jupyterlab_collaborative_chat.spec.ts
@@ -10,7 +10,7 @@ import {
   test
 } from '@jupyterlab/galata';
 import { Contents, User } from '@jupyterlab/services';
-import { PartialJSONObject, ReadonlyJSONObject, UUID } from '@lumino/coreutils';
+import { ReadonlyJSONObject, UUID } from '@lumino/coreutils';
 import { Locator } from '@playwright/test';
 
 const FILENAME = 'my-chat.chat';

--- a/packages/jupyterlab-collaborative-chat/ui-tests/tests/jupyterlab_collaborative_chat.spec.ts
+++ b/packages/jupyterlab-collaborative-chat/ui-tests/tests/jupyterlab_collaborative_chat.spec.ts
@@ -1150,7 +1150,8 @@ test.describe('#outofband', () => {
     id: UUID.uuid4(),
     sender: USERNAME,
     body: MSG_CONTENT,
-    time: 1714116341
+    time: 1714116341,
+    raw_time: false
   };
   const chatContent = {
     messages: [msg],
@@ -1201,15 +1202,13 @@ test.describe('#outofband', () => {
     const messages = chatPanel.locator(
       '.jp-chat-messages-container .jp-chat-message'
     );
-    await page.waitForCondition(async () =>
-      messages.first().locator('.jp-chat-rendermime-markdown').isVisible()
-    );
     const newMsg = {
       type: 'msg',
       id: UUID.uuid4(),
       sender: USERNAME,
       body: newMsgContent,
-      time: msg.time + 5
+      time: msg.time + 5,
+      raw_time: false
     };
     const newContent = {
       messages: [msg, newMsg],

--- a/packages/jupyterlab-ws-chat/src/index.ts
+++ b/packages/jupyterlab-ws-chat/src/index.ts
@@ -21,7 +21,7 @@ import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { WebSocketHandler } from './handlers/websocket-handler';
 
 const pluginIds = {
-  acRegistry: 'jupyterlab-ws-chat:autocompletionRegistry',
+  autocompletionRegistry: 'jupyterlab-ws-chat:autocompletionRegistry',
   chat: 'jupyterlab-ws-chat:chat'
 };
 
@@ -29,7 +29,7 @@ const pluginIds = {
  * Extension providing the autocompletion registry.
  */
 const autocompletionPlugin: JupyterFrontEndPlugin<IAutocompletionRegistry> = {
-  id: pluginIds.acRegistry,
+  id: pluginIds.autocompletionRegistry,
   description: 'An autocompletion registry',
   autoStart: true,
   provides: IAutocompletionRegistry,


### PR DESCRIPTION
This PR adds autocomplete commands to the chat component, using a registry.
It is strongly inspired by the PR made by @dlqqq in `jupyter-ai` https://github.com/jupyterlab/jupyter-ai/pull/810

Fixes https://github.com/jupyterlab/jupyter-chat/issues/51

If some autocomplete commands are provided, a list of commands will open if the first character match a specific string.

The logic is as following:
- an extension like `jupyterlab-collaborativ-chat` provides a registry for autocomplete commands, using a token.
- an extension relying on `jupyterlab-collaborativ-chat` (like possibly `jupyter-ai`) will be able to register some autocomplete commands for its own use.

The 2 extensions (collaborative and websocket chat) provide the token in a new plugin.

cc @jtpio 