### PR TITLE
Prevent dependabot from using yarn 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,5 +137,6 @@
             "selector-no-vendor-prefix": null,
             "value-no-vendor-prefix": null
         }
-    }
+    },
+    "packageManager": "yarn@3.5.0"
 }

--- a/packages/jupyterlab-collaborative-chat/ui-tests/package.json
+++ b/packages/jupyterlab-collaborative-chat/ui-tests/package.json
@@ -11,5 +11,6 @@
   "devDependencies": {
     "@jupyterlab/galata": "^5.0.0",
     "@playwright/test": "^1.43.0"
-  }
+  },
+  "packageManager": "yarn@3.5.0"
 }

--- a/packages/jupyterlab-ws-chat/ui-tests/package.json
+++ b/packages/jupyterlab-ws-chat/ui-tests/package.json
@@ -11,5 +11,6 @@
     "devDependencies": {
         "@jupyterlab/galata": "^5.0.5",
         "@playwright/test": "^1.37.0"
-    }
+    },
+    "packageManager": "yarn@3.5.0"
 }


### PR DESCRIPTION
This PR should prevent dependabot from using yarn 4, and change the whole dependencies in `yarn.lock`.

See https://github.com/jupyterlab/extension-template/pull/79 for more information.