### PR TITLE
Shortcut to focus on the chat input

### DIFF
--- a/packages/jupyter-chat/src/model.ts
+++ b/packages/jupyter-chat/src/model.ts
@@ -76,6 +76,11 @@ export interface IChatModel extends IDisposable {
   readonly viewportChanged?: ISignal<IChatModel, number[]>;
 
   /**
+   * A signal emitting when the focus is requested on the input.
+   */
+  readonly focusInputSignal?: ISignal<IChatModel, void>;
+
+  /**
    * Send a message, to be defined depending on the chosen technology.
    * Default to no-op.
    *
@@ -139,6 +144,11 @@ export interface IChatModel extends IDisposable {
    * @param count - the number of messages to delete.
    */
   messagesDeleted(index: number, count: number): void;
+
+  /**
+   * Function to request the focus on the input of the chat.
+   */
+  focusInput(): void;
 }
 
 /**
@@ -329,6 +339,13 @@ export class ChatModel implements IChatModel {
   }
 
   /**
+   * A signal emitting when the focus is requested on the input.
+   */
+  get focusInputSignal(): ISignal<IChatModel, void> {
+    return this._focusInputSignal;
+  }
+
+  /**
    * Send a message, to be defined depending on the chosen technology.
    * Default to no-op.
    *
@@ -436,6 +453,13 @@ export class ChatModel implements IChatModel {
   }
 
   /**
+   * Function to request the focus on the input of the chat.
+   */
+  focusInput(): void {
+    this._focusInputSignal.emit();
+  }
+
+  /**
    * Add unread messages to the list.
    * @param indexes - list of new indexes.
    */
@@ -498,6 +522,7 @@ export class ChatModel implements IChatModel {
   private _configChanged = new Signal<IChatModel, IConfig>(this);
   private _unreadChanged = new Signal<IChatModel, number[]>(this);
   private _viewportChanged = new Signal<IChatModel, number[]>(this);
+  private _focusInputSignal = new Signal<ChatModel, void>(this);
 }
 
 /**

--- a/packages/jupyterlab-collaborative-chat/src/token.ts
+++ b/packages/jupyterlab-collaborative-chat/src/token.ts
@@ -78,13 +78,17 @@ export const CommandIDs = {
    */
   openChat: 'collaborative-chat:open',
   /**
-   * Move a main widget to the side panel
+   * Move a main widget to the side panel.
    */
   moveToSide: 'collaborative-chat:moveToSide',
   /**
    * Mark as read.
    */
-  markAsRead: 'collaborative-chat:markAsRead'
+  markAsRead: 'collaborative-chat:markAsRead',
+  /**
+   * Focus the input of the current chat.
+   */
+  focusInput: 'collaborative-chat:focusInput'
 };
 
 /**

--- a/packages/jupyterlab-collaborative-chat/src/widget.tsx
+++ b/packages/jupyterlab-collaborative-chat/src/widget.tsx
@@ -73,7 +73,7 @@ export class CollaborativeChatPanel extends DocumentWidget<
    * The model for the widget.
    */
   get model(): CollaborativeChatModel {
-    return this.content.model as CollaborativeChatModel;
+    return this.context.model;
   }
 
   /**

--- a/python/jupyterlab-collaborative-chat/schema/commands.json
+++ b/python/jupyterlab-collaborative-chat/schema/commands.json
@@ -23,6 +23,14 @@
       }
     ]
   },
+  "jupyter.lab.shortcuts": [
+    {
+      "command": "collaborative-chat:focusInput",
+      "keys": ["Accel Shift 1"],
+      "selector": "body",
+      "preventDefault": false
+    }
+  ],
   "properties": {},
   "additionalProperties": false
 }

--- a/python/jupyterlab-collaborative-chat/src/index.ts
+++ b/python/jupyterlab-collaborative-chat/src/index.ts
@@ -512,6 +512,25 @@ const chatCommands: JupyterFrontEndPlugin<void> = {
       .catch(e =>
         console.error('The command to open a chat is not initialized\n', e)
       );
+
+    // The command to focus the input of the current chat widget.
+    commands.addCommand(CommandIDs.focusInput, {
+      caption: 'Focus the input of the current chat widget',
+      isEnabled: () => tracker.currentWidget !== null,
+      execute: async () => {
+        const widget = tracker.currentWidget;
+        // Ensure widget is a CollaborativeChatPanel and is in main area
+        if (
+          !widget ||
+          !(widget instanceof CollaborativeChatPanel) ||
+          !Array.from(app.shell.widgets('main')).includes(widget)
+        ) {
+          return;
+        }
+        app.shell.activateById(widget.id);
+        widget.model.focusInput();
+      }
+    });
   }
 };
 

--- a/python/jupyterlab-ws-chat/schema/chat.json
+++ b/python/jupyterlab-ws-chat/schema/chat.json
@@ -2,6 +2,14 @@
   "title": "Chat configuration",
   "description": "Configuration for the chat panel",
   "type": "object",
+  "jupyter.lab.shortcuts": [
+    {
+      "command": "websocket-chat:focusInput",
+      "keys": ["Accel Shift 1"],
+      "selector": "body",
+      "preventDefault": false
+    }
+  ],
   "properties": {
     "sendWithShiftEnter": {
       "description": "Whether to send a message via Shift-Enter instead of Enter.",

--- a/python/jupyterlab-ws-chat/src/index.ts
+++ b/python/jupyterlab-ws-chat/src/index.ts
@@ -64,6 +64,8 @@ const chat: JupyterFrontEndPlugin<void> = {
     settingsRegistry: ISettingRegistry | null,
     themeManager: IThemeManager | null
   ) => {
+    const { commands } = app;
+
     // Create an active cell manager for code toolbar.
     const activeCellManager = new ActiveCellManager({
       tracker: notebookTracker,
@@ -146,7 +148,17 @@ const chat: JupyterFrontEndPlugin<void> = {
       restorer.add(chatWidget as ReactWidget, 'jupyter-chat');
     }
 
-    console.log('Chat extension initialized');
+    // The command to focus the input of the chat widget.
+    commands.addCommand('websocket-chat:focusInput', {
+      caption: 'Focus the input of the chat widget',
+      isEnabled: () => chatWidget !== null,
+      execute: async () => {
+        if (chatWidget !== null) {
+          app.shell.activateById(chatWidget.id);
+          chatHandler.focusInput();
+        }
+      }
+    });
   }
 };
 


### PR DESCRIPTION
This PR adds a shortcut in the extensions to focus on the chat input.

It's mostly a refactoring of https://github.com/jupyterlab/jupyter-ai/pull/876

In the case of the collaborative chat, where several chat can be opened at the same time, the focus goes to the "current" chat in the main area (the current is the last active one).

Related to https://github.com/jupyterlab/jupyter-ai/issues/862