### PR TITLE
Fix duplicated chats

### DIFF
--- a/packages/jupyterlab-collaborative-chat/src/widget.tsx
+++ b/packages/jupyterlab-collaborative-chat/src/widget.tsx
@@ -173,6 +173,9 @@ export class ChatPanel extends SidePanel {
     );
   }
 
+  /**
+   * Update the list of available chats in the root directory of the drive.
+   */
   updateChatNames = async (): Promise<void> => {
     const extension = chatFileType.extensions[0];
     this._drive
@@ -191,11 +194,43 @@ export class ChatPanel extends SidePanel {
   };
 
   /**
+   * Open a chat if it exists in the side panel.
+   *
+   * @param path - the path of the chat.
+   * @returns a boolean, whether the chat existed in the side panel or not.
+   */
+  openIfExists(path: string): boolean {
+    const index = this._getChatIndex(path);
+    if (index > -1) {
+      this._expandChat(index);
+    }
+    return index > -1;
+  }
+
+  /**
    * A message handler invoked on an `'after-show'` message.
    */
   protected onAfterShow(msg: Message): void {
     // Wait for the component to be rendered.
     this._openChat.renderPromise?.then(() => this.updateChatNames());
+  }
+
+  /**
+   * Return the index of the chat in the list (-1 if not opened).
+   *
+   * @param name - the chat name.
+   */
+  private _getChatIndex(path: string) {
+    return this.widgets.findIndex(w => (w as ChatSection).path === path);
+  }
+
+  /**
+   * Expand the chat from its index.
+   */
+  private _expandChat(index: number): void {
+    if (!this.widgets[index].isVisible) {
+      (this.content as AccordionPanel).expand(index);
+    }
   }
 
   /**
@@ -211,15 +246,10 @@ export class ChatPanel extends SidePanel {
       return;
     }
 
-    const index = this.widgets.findIndex(w => (w as ChatSection).path === path);
-    if (index === -1) {
-      this._commands.execute(CommandIDs.openChat, {
-        filepath: path,
-        inSidePanel: true
-      });
-    } else if (!this.widgets[index].isVisible) {
-      (this.content as AccordionPanel).expand(index);
-    }
+    this._commands.execute(CommandIDs.openChat, {
+      filepath: path,
+      inSidePanel: true
+    });
     event.target.selectedIndex = 0;
   };
 

--- a/python/jupyterlab-collaborative-chat/src/index.ts
+++ b/python/jupyterlab-collaborative-chat/src/index.ts
@@ -494,7 +494,11 @@ const chatCommands: JupyterFrontEndPlugin<void> = {
                */
               chatPanel.addChat(
                 chat,
-                PathExt.basename(model.name, chatFileType.extensions[0])
+                PathExt.join(
+                  PathExt.dirname(model.path),
+                  PathExt.basename(model.name, chatFileType.extensions[0])
+                ),
+                model.path
               );
             } else {
               // The chat is opened in the main area

--- a/python/jupyterlab-collaborative-chat/src/index.ts
+++ b/python/jupyterlab-collaborative-chat/src/index.ts
@@ -465,6 +465,11 @@ const chatCommands: JupyterFrontEndPlugin<void> = {
             if (inSidePanel && chatPanel) {
               // The chat is opened in the chat panel.
               app.shell.activateById(chatPanel.id);
+
+              if (chatPanel.openIfExists(filepath)) {
+                return;
+              }
+
               const model = await drive.get(filepath);
 
               /**


### PR DESCRIPTION
Fixes #83.

The command to open a chat in the side panel always checks if the same chat is not already opened (using the file path). If so, this chat is revealed.

This PR also rename the chat section with the relative path, to avoid duplicate names for chats with same name in several directories.