### PR TITLE
Bundle @jupyter/chat

### DIFF
--- a/python/jupyterlab-collaborative-chat/package.json
+++ b/python/jupyterlab-collaborative-chat/package.json
@@ -128,6 +128,10 @@
     "outputDir": "jupyterlab_collaborative_chat/labextension",
     "schemaDir": "schema",
     "sharedPackages": {
+      "@jupyter/chat": {
+        "bundled": true,
+        "singleton": true
+      },
       "@jupyter/docprovider": {
         "bundled": true,
         "singleton": true


### PR DESCRIPTION
Bundle *@jupyter/chat* as a shared package in *jupyter-collaborative-chat-extension*, to properly provide the `IAutocompletionRegistry` token.