### PR TITLE
Update jupyter_collaboration dependency

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -12,7 +12,7 @@ dependencies:
   - hatch-nodejs-version
   # Use pip to get the the latest version
   - pip:
-    - jupyter_server >=2.0.0
-    - jupyter_collaboration
-    - jupyter_ydoc >=2.0.0,<3.0.0
+    - jupyter_server >=2.0.1,<3
+    - jupyter_collaboration >=2.1.4,<3
+    - jupyter_ydoc
     - pycrdt

--- a/packages/jupyterlab-collaborative-chat/package.json
+++ b/packages/jupyterlab-collaborative-chat/package.json
@@ -52,8 +52,7 @@
   },
   "dependencies": {
     "@jupyter/chat": "^0.4.0",
-    "@jupyter/collaboration": "^2.1.0",
-    "@jupyter/docprovider": "^2.1.0",
+    "@jupyter/docprovider": "^2.1.4",
     "@jupyter/ydoc": "^1.1.1",
     "@jupyterlab/application": "^4.2.0",
     "@jupyterlab/apputils": "^4.3.0",

--- a/python/jupyterlab-collaborative-chat/package.json
+++ b/python/jupyterlab-collaborative-chat/package.json
@@ -57,8 +57,7 @@
     "watch:labextension": "jupyter labextension watch ."
   },
   "dependencies": {
-    "@jupyter/collaboration": "^2.1.0",
-    "@jupyter/docprovider": "^2.1.0",
+    "@jupyter/docprovider": "^2.1.4",
     "@jupyter/ydoc": "^1.1.1",
     "@jupyterlab/application": "^4.2.0",
     "@jupyterlab/apputils": "^4.3.0",

--- a/python/jupyterlab-collaborative-chat/pyproject.toml
+++ b/python/jupyterlab-collaborative-chat/pyproject.toml
@@ -27,9 +27,9 @@ classifiers = [
 ]
 dependencies = [
     "jupyterlab~=4.0",
-    "jupyter_collaboration>=2,<3",
+    "jupyter_collaboration>=2.1.4,<3",
     "jupyter_server>=2.0.1,<3",
-    "jupyter_ydoc>=2.0.0,<3.0.0",
+    "jupyter_ydoc",
     "pycrdt"
 ]
 dynamic = ["version", "description", "authors", "urls", "keywords"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -1775,14 +1775,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@codemirror/state@npm:^6.0.0, @codemirror/state@npm:^6.2.0, @codemirror/state@npm:^6.4.0, @codemirror/state@npm:^6.4.1":
+"@codemirror/state@npm:^6.0.0, @codemirror/state@npm:^6.4.0, @codemirror/state@npm:^6.4.1":
   version: 6.4.1
   resolution: "@codemirror/state@npm:6.4.1"
   checksum: b81b55574091349eed4d32fc0eadb0c9688f1f7c98b681318f59138ee0f527cb4c4a97831b70547c0640f02f3127647838ae6730782de4a3dd2cc58836125d01
   languageName: node
   linkType: hard
 
-"@codemirror/view@npm:^6.0.0, @codemirror/view@npm:^6.17.0, @codemirror/view@npm:^6.23.0, @codemirror/view@npm:^6.26.0, @codemirror/view@npm:^6.27.0, @codemirror/view@npm:^6.7.0":
+"@codemirror/view@npm:^6.0.0, @codemirror/view@npm:^6.17.0, @codemirror/view@npm:^6.23.0, @codemirror/view@npm:^6.26.0, @codemirror/view@npm:^6.27.0":
   version: 6.28.4
   resolution: "@codemirror/view@npm:6.28.4"
   dependencies:
@@ -2478,30 +2478,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@jupyter/collaboration@npm:^2.1.0":
-  version: 2.1.1
-  resolution: "@jupyter/collaboration@npm:2.1.1"
-  dependencies:
-    "@codemirror/state": ^6.2.0
-    "@codemirror/view": ^6.7.0
-    "@jupyter/docprovider": ^2.1.1
-    "@jupyterlab/apputils": ^4.0.5
-    "@jupyterlab/coreutils": ^6.0.5
-    "@jupyterlab/services": ^7.0.5
-    "@jupyterlab/ui-components": ^4.0.5
-    "@lumino/coreutils": ^2.1.0
-    "@lumino/virtualdom": ^2.0.0
-    "@lumino/widgets": ^2.1.0
-    react: ^18.2.0
-    y-protocols: ^1.0.5
-    yjs: ^13.5.40
-  checksum: abbdb5d89917eaaa910bac42f54e4da0c6598494b1fa0d61a98c62284251b323cfa75759af9d085eabc08ede307b374cb8ca8ec7ef913b88851b0e35b93a3f87
-  languageName: node
-  linkType: hard
-
-"@jupyter/docprovider@npm:^2.1.0, @jupyter/docprovider@npm:^2.1.1":
-  version: 2.1.1
-  resolution: "@jupyter/docprovider@npm:2.1.1"
+"@jupyter/docprovider@npm:^2.1.4":
+  version: 2.1.4
+  resolution: "@jupyter/docprovider@npm:2.1.4"
   dependencies:
     "@jupyter/ydoc": ^1.1.0-a0
     "@jupyterlab/coreutils": ^6.0.5
@@ -2512,7 +2491,7 @@ __metadata:
     y-protocols: ^1.0.5
     y-websocket: ^1.3.15
     yjs: ^13.5.40
-  checksum: 07c718fac69bdc005769afa2a996f071bb62ffeaafc0f66cb58694d825c3ea6c611043f48f5315d7fa8852df4973cd9186119d3f33f2a8c11d7f8882267f7d47
+  checksum: 6553d1b76bc48ca20bc55548fe25b8bff75f6a3b2063232f50abdf731dad46dfb613166822f77063ee752f70c7b2173dc0e563102caeb63eb0e32516d01c64dc
   languageName: node
   linkType: hard
 
@@ -2595,7 +2574,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyterlab/apputils@npm:^4.0.5, @jupyterlab/apputils@npm:^4.3.0, @jupyterlab/apputils@npm:^4.3.3":
+"@jupyterlab/apputils@npm:^4.3.0, @jupyterlab/apputils@npm:^4.3.3":
   version: 4.3.3
   resolution: "@jupyterlab/apputils@npm:4.3.3"
   dependencies:
@@ -3211,7 +3190,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyterlab/ui-components@npm:^4.0.5, @jupyterlab/ui-components@npm:^4.2.0, @jupyterlab/ui-components@npm:^4.2.3":
+"@jupyterlab/ui-components@npm:^4.2.0, @jupyterlab/ui-components@npm:^4.2.3":
   version: 4.2.3
   resolution: "@jupyterlab/ui-components@npm:4.2.3"
   dependencies:
@@ -3623,7 +3602,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@lumino/virtualdom@npm:^2.0.0, @lumino/virtualdom@npm:^2.0.1, @lumino/virtualdom@npm:^2.0.2":
+"@lumino/virtualdom@npm:^2.0.1, @lumino/virtualdom@npm:^2.0.2":
   version: 2.0.2
   resolution: "@lumino/virtualdom@npm:2.0.2"
   dependencies:
@@ -3632,7 +3611,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@lumino/widgets@npm:^1.37.2 || ^2.3.2, @lumino/widgets@npm:^2.0.0, @lumino/widgets@npm:^2.1.0, @lumino/widgets@npm:^2.3.2, @lumino/widgets@npm:^2.4.0":
+"@lumino/widgets@npm:^1.37.2 || ^2.3.2, @lumino/widgets@npm:^2.0.0, @lumino/widgets@npm:^2.3.2, @lumino/widgets@npm:^2.4.0":
   version: 2.4.0
   resolution: "@lumino/widgets@npm:2.4.0"
   dependencies:
@@ -10041,8 +10020,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "jupyterlab-collaborative-chat-extension@workspace:python/jupyterlab-collaborative-chat"
   dependencies:
-    "@jupyter/collaboration": ^2.1.0
-    "@jupyter/docprovider": ^2.1.0
+    "@jupyter/docprovider": ^2.1.4
     "@jupyter/ydoc": ^1.1.1
     "@jupyterlab/application": ^4.2.0
     "@jupyterlab/apputils": ^4.3.0
@@ -10093,8 +10071,7 @@ __metadata:
   resolution: "jupyterlab-collaborative-chat@workspace:packages/jupyterlab-collaborative-chat"
   dependencies:
     "@jupyter/chat": ^0.4.0
-    "@jupyter/collaboration": ^2.1.0
-    "@jupyter/docprovider": ^2.1.0
+    "@jupyter/docprovider": ^2.1.4
     "@jupyter/ydoc": ^1.1.1
     "@jupyterlab/application": ^4.2.0
     "@jupyterlab/apputils": ^4.3.0


### PR DESCRIPTION
This PR update the jupyter_collaboration dependency to 2.1.4.
This allows using the awareness on the server side, following https://github.com/jupyterlab/jupyter-collaboration/pull/376