### PR TITLE
Improve padding around code toolbar buttons

### DIFF
--- a/packages/jupyter-chat/src/components/code-blocks/code-toolbar.tsx
+++ b/packages/jupyter-chat/src/components/code-blocks/code-toolbar.tsx
@@ -80,7 +80,7 @@ export function CodeToolbar(props: CodeToolbarProps): JSX.Element {
         display: 'flex',
         justifyContent: 'flex-end',
         alignItems: 'center',
-        padding: '6px 2px',
+        padding: '2px 2px',
         marginBottom: '1em',
         border: '1px solid var(--jp-cell-editor-border-color)',
         borderTop: 'none'

--- a/packages/jupyter-chat/src/components/mui-extras/tooltipped-icon-button.tsx
+++ b/packages/jupyter-chat/src/components/mui-extras/tooltipped-icon-button.tsx
@@ -73,7 +73,11 @@ export function TooltippedIconButton(
           {...props.iconButtonProps}
           onClick={props.onClick}
           disabled={props.disabled}
-          sx={{ lineHeight: 0, ...(props.disabled && { opacity: 0.5 }) }}
+          sx={{
+            marginLeft: '8px',
+            lineHeight: 0,
+            ...(props.disabled && { opacity: 0.5 })
+          }}
           aria-label={props['aria-label']}
         >
           {props.children}


### PR DESCRIPTION
Port https://github.com/jupyterlab/jupyter-ai/pull/1072 to improve padding around code toolbar buttons.