### PR TITLE
Revert 'Allow `$` to literally denote quantities of USD in chat' (#95)

### DIFF
--- a/packages/jupyter-chat/src/components/rendermime-markdown.tsx
+++ b/packages/jupyter-chat/src/components/rendermime-markdown.tsx
@@ -39,61 +39,6 @@ function escapeLatexDelimiters(text: string) {
     .replace('\\]/g', '\\\\]');
 }
 
-/**
- * Type predicate function that determines whether a given DOM Node is a Text
- * node.
- */
-function isTextNode(node: Node | null): node is Text {
-  return node?.nodeType === Node.TEXT_NODE;
-}
-
-/**
- * Escapes all `$` symbols present in an HTML element except those within the
- * following elements: `pre`, `code`, `samp`, `kbd`.
- *
- * This prevents `$` symbols from being used as inline math delimiters, allowing
- * `$` symbols to be used literally to denote quantities of USD. This does not
- * escape literal `$` within elements that display their contents literally,
- * like code elements. This overrides JupyterLab's default rendering of MarkDown
- * w/ LaTeX.
- *
- * The Jupyter AI system prompt should explicitly request that the LLM not use
- * `$` as an inline math delimiter. This is the default behavior.
- */
-function escapeDollarSymbols(el: HTMLElement) {
-  // Get all text nodes that are not within pre, code, samp, or kbd elements
-  const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT, {
-    acceptNode: node => {
-      const isInSkippedElements = node.parentElement?.closest(
-        'pre, code, samp, kbd'
-      );
-      return isInSkippedElements
-        ? NodeFilter.FILTER_SKIP
-        : NodeFilter.FILTER_ACCEPT;
-    }
-  });
-
-  // Collect all valid text nodes in an array.
-  const textNodes: Text[] = [];
-  let currentNode: Node | null;
-  while ((currentNode = walker.nextNode())) {
-    if (isTextNode(currentNode)) {
-      textNodes.push(currentNode);
-    }
-  }
-
-  // Replace each `$` symbol with `\$` for each text node, unless there is
-  // another `$` symbol adjacent or it is already escaped. Examples:
-  // - `$10 - $5` => `\$10 - \$5` (escaped)
-  // - `$$ \infty $$` => `$$ \infty $$` (unchanged)
-  // - `\$10` => `\$10` (unchanged, already escaped)
-  textNodes.forEach(node => {
-    if (node.textContent) {
-      node.textContent = node.textContent.replace(/(?<![$\\])\$(?!\$)/g, '\\$');
-    }
-  });
-}
-
 function RendermimeMarkdownBase(props: RendermimeMarkdownProps): JSX.Element {
   const appendContent = props.appendContent || false;
   const [renderedContent, setRenderedContent] = useState<HTMLElement | null>(
@@ -124,8 +69,7 @@ function RendermimeMarkdownBase(props: RendermimeMarkdownProps): JSX.Element {
         );
       }
 
-      // step 2: render LaTeX via MathJax, while escaping single dollar symbols.
-      escapeDollarSymbols(renderer.node);
+      // step 2: render LaTeX via MathJax.
       props.rmRegistry.latexTypesetter?.typeset(renderer.node);
 
       const newCodeToolbarDefns: [HTMLDivElement, CodeToolbarProps][] = [];


### PR DESCRIPTION
Porting https://github.com/jupyterlab/jupyter-ai/pull/1094

This PR reverts the changes of #95.

> Users can still use $ to delimit inline math, and must double-escape $ symbols to use them literally (`\\$`). This is aligned with JupyterLab's rendering behavior.

