### PR TITLE
Use dataclass models in YChat

### DIFF
--- a/python/jupyterlab-chat/jupyterlab_chat/models.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/models.py
@@ -1,3 +1,6 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
 from dataclasses import dataclass
 from typing import Literal, Optional
 from jupyter_server.auth import User as JupyterUser

--- a/python/jupyterlab-chat/jupyterlab_chat/models.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/models.py
@@ -1,0 +1,35 @@
+from dataclasses import dataclass
+from typing import Literal, Optional
+from jupyter_server.auth import User as JupyterUser
+
+
+@dataclass(kw_only=True)
+class Message:
+    """ Object representing a message """
+
+    type: Literal["msg"] = "msg"
+    body: str
+    """ The content of the message """
+
+    id: str
+    """ Unique ID """
+
+    time: float
+    """ Timestamp in second since epoch """
+
+    sender: str
+    """ The message sender unique id """
+
+    raw_time: Optional[bool] = None
+    """ Whether the timestamp is raw (from client) or not (from server, unified) """
+
+    deleted: Optional[bool] = None
+    """ Whether the message has been deleted or not (body should be empty if True) """
+
+    edited: Optional[bool] = None
+    """ Whether the message has been edited or not """
+
+
+@dataclass(kw_only=True)
+class User(JupyterUser):
+    """ Object representing a user (same as Jupyter User ) """

--- a/python/jupyterlab-chat/jupyterlab_chat/tests/test_ychat.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/tests/test_ychat.py
@@ -8,29 +8,30 @@ import pytest
 import time
 from copy import deepcopy
 from uuid import uuid4
+from ..models import User, Message
 from ..ychat import YChat
 
-USER = {
-  "username": str(uuid4()),
-  "name": "Test user",
-  "display_name": "Test user"
-}
+USER = User(
+  username=str(uuid4()),
+  name="Test user",
+  display_name="Test user"
+)
 
-USER2 = {
-  "username": str(uuid4()),
-  "name": "Test user 2",
-  "display_name": "Test user 2"
-}
+USER2 = User(
+  username=str(uuid4()),
+  name="Test user 2",
+  display_name="Test user 2"
+)
 
 
 def create_message():
-  return {
-  "type": "msg",
-  "id": str(uuid4()),
-  "body": "This is a test message",
-  "time": time.time(),
-  "sender": USER["username"]
-}
+  return Message (
+    type="msg",
+    id=str(uuid4()),
+    body="This is a test message",
+    time=time.time(),
+    sender=USER.username
+  )
 
 
 def test_initialize_ychat():
@@ -43,16 +44,16 @@ def test_initialize_ychat():
 def test_add_user():
   chat = YChat()
   chat.set_user(USER)
-  assert USER["username"] in chat.get_users().keys()
-  assert chat.get_users()[USER["username"]] == USER
+  assert USER.username in chat.get_users().keys()
+  assert chat.get_users()[USER.username] == USER
 
 
 def test_get_user_by_name():
   chat = YChat()
   chat.set_user(USER)
   chat.set_user(USER2)
-  assert chat.get_user_by_name(USER["name"]) == USER
-  assert chat.get_user_by_name(USER2["name"]) == USER2
+  assert chat.get_user_by_name(USER.name) == USER
+  assert chat.get_user_by_name(USER2.name) == USER2
   assert chat.get_user_by_name(str(uuid4())) == None
 
 
@@ -76,7 +77,7 @@ def test_set_message_should_update():
   chat = YChat()
   msg = create_message()
   index = chat.add_message(msg)
-  msg["body"] = "Updated content"
+  msg.body = "Updated content"
   chat.set_message(msg, index)
   assert len(chat.get_messages()) == 1
   assert chat.get_messages()[0] == msg
@@ -87,8 +88,8 @@ def test_set_message_should_add_with_new_id():
   msg = create_message()
   index = chat.add_message(msg)
   new_msg = deepcopy(msg)
-  new_msg["id"] = str(uuid4())
-  new_msg["body"] = "Updated content"
+  new_msg.id = str(uuid4())
+  new_msg.body = "Updated content"
   chat.set_message(new_msg, index)
   assert len(chat.get_messages()) == 2
   assert chat.get_messages()[0] == msg
@@ -100,10 +101,10 @@ def test_set_message_should_update_with_wrong_index():
   msg = create_message()
   chat.add_message(msg)
   new_msg = create_message()
-  new_msg["body"] = "New content"
+  new_msg.body = "New content"
   index = chat.add_message(new_msg)
   assert index == 1
-  new_msg["body"] = "Updated content"
+  new_msg.body = "Updated content"
   chat.set_message(new_msg, 0)
   assert len(chat.get_messages()) == 2
   assert chat.get_messages()[0] == msg

--- a/python/jupyterlab-chat/jupyterlab_chat/ychat.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/ychat.py
@@ -185,11 +185,14 @@ class YChat(YBaseDoc):
         Returns the contents of the document.
         :return: Document's contents in JSON.
         """
-        return json.dumps({
-            "messages": self.get_messages(),
-            "users": self.get_users(),
-            "metadata": self.get_metadata()
-        })
+        return json.dumps(
+            {
+                "messages": self.get_messages(),
+                "users": self.get_users(),
+                "metadata": self.get_metadata()
+            },
+            indent=2
+        )
 
     def set(self, value: str) -> None:
         """


### PR DESCRIPTION
Fixes https://github.com/jupyterlab/jupyter-chat/issues/115

The `YChat` uses `dataclass` models for the messages users. The `User` model is inherited (without change) from the jupyter server [model](https://github.com/jupyter-server/jupyter_server/blob/main/jupyter_server/auth/identity.py#L35).
It does not use `dataclass` for metadata, because it can contain anything. Only the `id` field is used by `jupyterlab_chat`.

This PR also save the chat file as a more readable JSON file.