### PR TITLE
Prevent sending empty message

### DIFF
--- a/packages/jupyter-chat/src/components/chat-input.tsx
+++ b/packages/jupyter-chat/src/components/chat-input.tsx
@@ -130,16 +130,22 @@ export function ChatInput(props: ChatInput.IProps): JSX.Element {
       return;
     }
 
-    // do not send the message if the user was selecting a suggested command from the
+    // Do not send the message if the user was selecting a suggested command from the
     // Autocomplete component.
     if (highlighted) {
       return;
     }
 
+    // Do not send empty messages, and avoid adding new line in empty message.
+    if (!input.trim()) {
+      event.stopPropagation();
+      event.preventDefault();
+      return;
+    }
+
     if (
-      event.key === 'Enter' &&
-      ((sendWithShiftEnter && event.shiftKey) ||
-        (!sendWithShiftEnter && !event.shiftKey))
+      (sendWithShiftEnter && event.shiftKey) ||
+      (!sendWithShiftEnter && !event.shiftKey)
     ) {
       onSend();
       event.stopPropagation();

--- a/packages/jupyter-chat/src/components/chat-input.tsx
+++ b/packages/jupyter-chat/src/components/chat-input.tsx
@@ -78,6 +78,8 @@ export function ChatInput(props: ChatInput.IProps): JSX.Element {
   // controls whether the slash command autocomplete is open
   const [open, setOpen] = useState<boolean>(false);
 
+  const inputExists = !!input.trim();
+
   /**
    * Effect: fetch the list of available autocomplete commands.
    */
@@ -137,7 +139,7 @@ export function ChatInput(props: ChatInput.IProps): JSX.Element {
     }
 
     // Do not send empty messages, and avoid adding new line in empty message.
-    if (!input.trim()) {
+    if (!inputExists) {
       event.stopPropagation();
       event.preventDefault();
       return;
@@ -232,14 +234,14 @@ ${selection.source}
                 <InputAdornment position="end">
                   {props.onCancel && (
                     <CancelButton
-                      inputExists={input.length > 0}
+                      inputExists={inputExists}
                       onCancel={onCancel}
                     />
                   )}
                   <SendButton
                     model={model}
                     sendWithShiftEnter={sendWithShiftEnter}
-                    inputExists={input.length > 0}
+                    inputExists={inputExists}
                     onSend={onSend}
                     hideIncludeSelection={hideIncludeSelection}
                     hasButtonOnLeft={!!props.onCancel}

--- a/packages/jupyter-chat/src/components/chat-input.tsx
+++ b/packages/jupyter-chat/src/components/chat-input.tsx
@@ -232,12 +232,7 @@ ${selection.source}
               ...params.InputProps,
               endAdornment: (
                 <InputAdornment position="end">
-                  {props.onCancel && (
-                    <CancelButton
-                      inputExists={inputExists}
-                      onCancel={onCancel}
-                    />
-                  )}
+                  {props.onCancel && <CancelButton onCancel={onCancel} />}
                   <SendButton
                     model={model}
                     sendWithShiftEnter={sendWithShiftEnter}

--- a/packages/jupyter-chat/src/components/input/cancel-button.tsx
+++ b/packages/jupyter-chat/src/components/input/cancel-button.tsx
@@ -13,7 +13,6 @@ const CANCEL_BUTTON_CLASS = 'jp-chat-cancel-button';
  * The cancel button props.
  */
 export type CancelButtonProps = {
-  inputExists: boolean;
   onCancel: () => void;
 };
 
@@ -22,11 +21,9 @@ export type CancelButtonProps = {
  */
 export function CancelButton(props: CancelButtonProps): JSX.Element {
   const tooltip = 'Cancel edition';
-  const disabled = !props.inputExists;
   return (
     <TooltippedButton
       onClick={props.onCancel}
-      disabled={disabled}
       tooltip={tooltip}
       buttonProps={{
         size: 'small',


### PR DESCRIPTION
Fixes #118 

Port https://github.com/jupyterlab/jupyter-ai/pull/946

**EDIT**
- prevent sending empty message (only whitespace) with keyboard and button
- remove condition on 'cancel' button to disable it