### PR TITLE
Fix support for Python 3.9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,49 +16,57 @@ jobs:
     name: Build jupyter_chat
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
 
-    - name: Base Setup
-      uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+      - name: Base Setup
+        uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
 
-    - name: Install dependencies
-      run: python -m pip install -U "jupyterlab>=4.0.0,<5"
+      - name: Install dependencies
+        run: python -m pip install -U "jupyterlab>=4.0.0,<5"
 
-    - name: Lint the packages
-      run: |
-        set -eux
-        jlpm
-        jlpm run lint:check
+      - name: Lint the packages
+        run: |
+          set -eux
+          jlpm
+          jlpm run lint:check
 
-    - name: Build the core package
-      run: jlpm build:core
+      - name: Build the core package
+        run: jlpm build:core
 
-    - name: Test the packages
-      run: |
-        set -eux
-        jlpm run test
+      - name: Test the packages
+        run: |
+          set -eux
+          jlpm run test
 
   test_extensions:
+    name: Python unit tests (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
     needs: build_jupyter-chat
-    name: Python test on extensions
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - python-version: '3.9'
+          - python-version: '3.12'
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
 
-    - name: Base Setup
-      uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+      - name: Base Setup
+        uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+        with:
+          python-version: ${{ matrix.python-version }}
 
-    - name: Install dependencies
-      run: python -m pip install -U "jupyterlab>=4.0.0,<5"
+      - name: Install dependencies
+        run: python -m pip install -U "jupyterlab>=4.0.0,<5"
 
-    - name: Build the extensions
-      run: |
-        set -eux
-        ./scripts/dev_install.sh
-        pytest -vv -r ap --cov
+      - name: Build the extensions
+        run: |
+          set -eux
+          ./scripts/dev_install.sh
+          pytest -vv -r ap --cov
 
   build_extension:
     runs-on: ubuntu-latest
@@ -66,33 +74,33 @@ jobs:
     name: Build chat extension
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
 
-    - name: Base Setup
-      uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+      - name: Base Setup
+        uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
 
-    - name: Install dependencies
-      run: python -m pip install -U "jupyterlab>=4.0.0,<5"
+      - name: Install dependencies
+        run: python -m pip install -U "jupyterlab>=4.0.0,<5"
 
-    - name: Package the extensions
-      run:  |
-        jlpm install
-        jlpm build
+      - name: Package the extensions
+        run: |
+          jlpm install
+          jlpm build
 
-    - name: Package extension
-      run: |
-        set -eux
-        pip install build python/jupyterlab-chat
-        python -m build python/jupyterlab-chat
-        pip uninstall -y "jupyterlab_chat" jupyterlab
+      - name: Package extension
+        run: |
+          set -eux
+          pip install build python/jupyterlab-chat
+          python -m build python/jupyterlab-chat
+          pip uninstall -y "jupyterlab_chat" jupyterlab
 
-    - name: Upload package
-      uses: actions/upload-artifact@v3
-      with:
-        name: jupyterlab_chat-artifacts
-        path: python/jupyterlab-chat/dist/jupyterlab_chat*
-        if-no-files-found: error
+      - name: Upload package
+        uses: actions/upload-artifact@v3
+        with:
+          name: jupyterlab_chat-artifacts
+          path: python/jupyterlab-chat/dist/jupyterlab_chat*
+          if-no-files-found: error
 
   integration-tests:
     name: Integration tests
@@ -103,53 +111,53 @@ jobs:
       PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/pw-browsers
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
 
-    - name: Base Setup
-      uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+      - name: Base Setup
+        uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
 
-    - name: Download extension package
-      uses: actions/download-artifact@v3
-      with:
-        name: jupyterlab_chat-artifacts
+      - name: Download extension package
+        uses: actions/download-artifact@v3
+        with:
+          name: jupyterlab_chat-artifacts
 
-    - name: Install the extension
-      run: |
-        set -eux
-        python -m pip install "jupyterlab>=4.0.0,<5" jupyterlab_chat*.whl
+      - name: Install the extension
+        run: |
+          set -eux
+          python -m pip install "jupyterlab>=4.0.0,<5" jupyterlab_chat*.whl
 
-    - name: Install dependencies
-      working-directory: ui-tests
-      env:
-        YARN_ENABLE_IMMUTABLE_INSTALLS: 0
-        PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
-      run: jlpm install
+      - name: Install dependencies
+        working-directory: ui-tests
+        env:
+          YARN_ENABLE_IMMUTABLE_INSTALLS: 0
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+        run: jlpm install
 
-    - name: Set up browser cache
-      uses: actions/cache@v3
-      with:
-        path: |
-          ${{ github.workspace }}/pw-browsers
-        key: ${{ runner.os }}-${{ hashFiles('ui-tests/yarn.lock') }}
+      - name: Set up browser cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ${{ github.workspace }}/pw-browsers
+          key: ${{ runner.os }}-${{ hashFiles('ui-tests/yarn.lock') }}
 
-    - name: Install browser
-      run: jlpm playwright install chromium
-      working-directory: ui-tests
+      - name: Install browser
+        run: jlpm playwright install chromium
+        working-directory: ui-tests
 
-    - name: Execute integration tests
-      working-directory: ui-tests
-      run: |
-        jlpm test --retries=2
+      - name: Execute integration tests
+        working-directory: ui-tests
+        run: |
+          jlpm test --retries=2
 
-    - name: Upload Playwright Test report
-      if: always()
-      uses: actions/upload-artifact@v3
-      with:
-        name: jupyterlab_chat-playwright-tests
-        path: |
-          ui-tests/test-results
-          ui-tests/playwright-report
+      - name: Upload Playwright Test report
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: jupyterlab_chat-playwright-tests
+          path: |
+            ui-tests/test-results
+            ui-tests/playwright-report
 
   integration-tests-notebook:
     name: Integration tests notebook
@@ -160,53 +168,53 @@ jobs:
       PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/pw-browsers
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
 
-    - name: Base Setup
-      uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+      - name: Base Setup
+        uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
 
-    - name: Download extension package
-      uses: actions/download-artifact@v3
-      with:
-        name: jupyterlab_chat-artifacts
+      - name: Download extension package
+        uses: actions/download-artifact@v3
+        with:
+          name: jupyterlab_chat-artifacts
 
-    - name: Install the extension
-      run: |
-        set -eux
-        python -m pip install "notebook>=7.0.0,<8" jupyterlab_chat*.whl
+      - name: Install the extension
+        run: |
+          set -eux
+          python -m pip install "notebook>=7.0.0,<8" jupyterlab_chat*.whl
 
-    - name: Install dependencies
-      working-directory: ui-tests
-      env:
-        YARN_ENABLE_IMMUTABLE_INSTALLS: 0
-        PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
-      run: jlpm install
+      - name: Install dependencies
+        working-directory: ui-tests
+        env:
+          YARN_ENABLE_IMMUTABLE_INSTALLS: 0
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+        run: jlpm install
 
-    - name: Set up browser cache
-      uses: actions/cache@v3
-      with:
-        path: |
-          ${{ github.workspace }}/pw-browsers
-        key: ${{ runner.os }}-${{ hashFiles('ui-tests/yarn.lock') }}
+      - name: Set up browser cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ${{ github.workspace }}/pw-browsers
+          key: ${{ runner.os }}-${{ hashFiles('ui-tests/yarn.lock') }}
 
-    - name: Install browser
-      run: jlpm playwright install chromium
-      working-directory: ui-tests
+      - name: Install browser
+        run: jlpm playwright install chromium
+        working-directory: ui-tests
 
-    - name: Execute integration tests
-      working-directory: ui-tests
-      run: |
-        jlpm test:notebook --retries=2
+      - name: Execute integration tests
+        working-directory: ui-tests
+        run: |
+          jlpm test:notebook --retries=2
 
-    - name: Upload Playwright Test report
-      if: always()
-      uses: actions/upload-artifact@v3
-      with:
-        name: jupyterlab_chat-notebook-playwright-tests
-        path: |
-          ui-tests/test-results
-          ui-tests/playwright-report
+      - name: Upload Playwright Test report
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: jupyterlab_chat-notebook-playwright-tests
+          path: |
+            ui-tests/test-results
+            ui-tests/playwright-report
 
   typing-tests:
     name: Typing test

--- a/python/jupyterlab-chat/jupyterlab_chat/models.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/models.py
@@ -15,7 +15,7 @@ def message_asdict_factory(data):
 class Message:
     """ Object representing a message """
 
-    type: Literal["msg"] = "msg"
+    # required arguments
     body: str
     """ The content of the message """
 
@@ -27,6 +27,13 @@ class Message:
 
     sender: str
     """ The message sender unique id """
+
+    # optional arguments, with defaults.
+    #
+    # These must be listed after all required arguments, unless `kw_only` is
+    # specified in the `@dataclass` decorator. This can only be done once Python
+    # 3.9 reaches EOL.
+    type: Literal["msg"] = "msg"
 
     raw_time: Optional[bool] = None
     """

--- a/python/jupyterlab-chat/jupyterlab_chat/models.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/models.py
@@ -11,7 +11,7 @@ def message_asdict_factory(data):
     return dict(x for x in data if x[1] is not None)
 
 
-@dataclass(kw_only=True)
+@dataclass
 class Message:
     """ Object representing a message """
 
@@ -47,7 +47,7 @@ class Message:
     """
 
 
-@dataclass(kw_only=True)
+@dataclass
 class NewMessage:
     """ Object representing a new message """
 
@@ -58,6 +58,6 @@ class NewMessage:
     """ The message sender unique id """
 
 
-@dataclass(kw_only=True)
+@dataclass
 class User(JupyterUser):
     """ Object representing a user (same as Jupyter User ) """


### PR DESCRIPTION
## Description

- Closes #134.
- Adds a GitHub job for running Python unit tests on Python 3.9. I've verified that this job catches the original issue, ensuring it will not happen again. See below for more details.
- Fixes Python 3.9 support for `jupyterlab_chat`.