### PR TITLE
Update to `actions/upload-artifact@v4` and `actions/download-artifact@v4`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,7 +118,7 @@ jobs:
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
 
       - name: Download extension package
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: jupyterlab_chat-artifacts
 
@@ -175,7 +175,7 @@ jobs:
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
 
       - name: Download extension package
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: jupyterlab_chat-artifacts
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,7 +96,7 @@ jobs:
           pip uninstall -y "jupyterlab_chat" jupyterlab
 
       - name: Upload package
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: jupyterlab_chat-artifacts
           path: python/jupyterlab-chat/dist/jupyterlab_chat*
@@ -152,7 +152,7 @@ jobs:
 
       - name: Upload Playwright Test report
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: jupyterlab_chat-playwright-tests
           path: |
@@ -209,7 +209,7 @@ jobs:
 
       - name: Upload Playwright Test report
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: jupyterlab_chat-notebook-playwright-tests
           path: |

--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -25,7 +25,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload Distributions
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: jupyter_chat-releaser-dist-${{ github.run_number }}
           path: .jupyter_releaser_checkout/dist


### PR DESCRIPTION
To fix the currently failing CI:

```
Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
```