### PR TITLE
Allow use of up and down arrow in chat input

### DIFF
--- a/packages/jupyter-chat/src/components/chat-input.tsx
+++ b/packages/jupyter-chat/src/components/chat-input.tsx
@@ -128,6 +128,11 @@ export function ChatInput(props: ChatInput.IProps): JSX.Element {
   }, [input]);
 
   function handleKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {
+    if (['ArrowDown', 'ArrowUp'].includes(event.key) && !open) {
+      event.stopPropagation();
+      return;
+    }
+
     if (event.key !== 'Enter') {
       return;
     }


### PR DESCRIPTION
Fixes #155 

This PR prevent propagating the up and down arrow event to the `Autocomplete` component if the autocompletion is not opened.
It is weird that it is not handled by material UI itself, maybe there is a better solution.