### PR TITLE
Add icons & descriptions to chat commands menu

### DIFF
--- a/packages/jupyter-chat/src/chat-commands/types.ts
+++ b/packages/jupyter-chat/src/chat-commands/types.ts
@@ -21,7 +21,7 @@ export type ChatCommand = {
    * If set, this will be rendered as the icon for the command in the chat
    * commands menu. Jupyter Chat will choose a default if this is unset.
    */
-  icon?: LabIcon;
+  icon?: LabIcon | string;
 
   /**
    * If set, this will be rendered as the description for the command in the

--- a/packages/jupyter-chat/src/components/input/use-chat-commands.tsx
+++ b/packages/jupyter-chat/src/components/input/use-chat-commands.tsx
@@ -145,7 +145,22 @@ export function useChatCommands(
         const { key, ...listItemProps } = defaultProps;
         return (
           <Box key={key} component="li" {...listItemProps}>
-            {command.name}
+            <span>
+              {command.icon !== undefined ? (
+                typeof command.icon === 'string' ? (
+                  command.icon
+                ) : (
+                  <command.icon.react />
+                )
+              ) : (
+                ''
+              )}
+            </span>
+            <p className="jp-chat-emoji-command-name">{command.name}</p>
+            <span> - </span>
+            <p className="jp-chat-emoji-command-description">
+              {command.description}
+            </p>
           </Box>
         );
       },

--- a/packages/jupyter-chat/src/components/input/use-chat-commands.tsx
+++ b/packages/jupyter-chat/src/components/input/use-chat-commands.tsx
@@ -143,24 +143,21 @@ export function useChatCommands(
         ___: unknown
       ) => {
         const { key, ...listItemProps } = defaultProps;
+        const commandIcon: JSX.Element = (
+          <span>
+            {typeof command.icon === 'object' ? (
+              <command.icon.react />
+            ) : (
+              command.icon
+            )}
+          </span>
+        );
         return (
           <Box key={key} component="li" {...listItemProps}>
-            <span>
-              {command.icon !== undefined ? (
-                typeof command.icon === 'string' ? (
-                  command.icon
-                ) : (
-                  <command.icon.react />
-                )
-              ) : (
-                ''
-              )}
-            </span>
-            <p className="jp-chat-emoji-command-name">{command.name}</p>
+            {commandIcon}
+            <p className="jp-chat-command-name">{command.name}</p>
             <span> - </span>
-            <p className="jp-chat-emoji-command-description">
-              {command.description}
-            </p>
+            <p className="jp-chat-command-description">{command.description}</p>
           </Box>
         );
       },

--- a/packages/jupyterlab-chat/style/base.css
+++ b/packages/jupyterlab-chat/style/base.css
@@ -20,3 +20,13 @@
 .jp-lab-chat-title-unread .lm-TabBar-tabLabel::before {
   content: '* ';
 }
+
+.jp-chat-emoji-command-name {
+  font-weight: normal;
+  margin: 5px;
+}
+
+.jp-chat-emoji-command-description {
+  color: gray;
+  margin: 5px;
+}

--- a/packages/jupyterlab-chat/style/base.css
+++ b/packages/jupyterlab-chat/style/base.css
@@ -21,12 +21,12 @@
   content: '* ';
 }
 
-.jp-chat-emoji-command-name {
+.jp-chat-command-name {
   font-weight: normal;
   margin: 5px;
 }
 
-.jp-chat-emoji-command-description {
+.jp-chat-command-description {
   color: gray;
   margin: 5px;
 }

--- a/python/jupyterlab-chat/src/chat-commands/providers/emoji.ts
+++ b/python/jupyterlab-chat/src/chat-commands/providers/emoji.ts
@@ -13,10 +13,34 @@ import {
 export class EmojiCommandProvider implements IChatCommandProvider {
   public id: string = 'jupyter-chat:emoji-commands';
   private _slash_commands: ChatCommand[] = [
-    { name: ':heart:', replaceWith: '❤ ', providerId: this.id },
-    { name: ':smile:', replaceWith: '🙂 ', providerId: this.id },
-    { name: ':thinking:', replaceWith: '🤔 ', providerId: this.id },
-    { name: ':cool:', replaceWith: '😎 ', providerId: this.id }
+    {
+      name: ':heart:',
+      replaceWith: '❤ ',
+      providerId: this.id,
+      description: 'Emoji',
+      icon: '❤'
+    },
+    {
+      name: ':smile:',
+      replaceWith: '🙂 ',
+      providerId: this.id,
+      description: 'Emoji',
+      icon: '🙂'
+    },
+    {
+      name: ':thinking:',
+      replaceWith: '🤔 ',
+      providerId: this.id,
+      description: 'Emoji',
+      icon: '🤔'
+    },
+    {
+      name: ':cool:',
+      replaceWith: '😎 ',
+      providerId: this.id,
+      description: 'Emoji',
+      icon: '😎'
+    }
   ];
 
   // regex used to test the current word


### PR DESCRIPTION
- Closes #175 

Issue: [Issue-175](https://github.com/jupyterlab/jupyter-chat/issues/175)

**Problem Statement**
The new chat commands menu needs to show icons & descriptions. The ChatCommand type will probably need updates accordingly.

**Expected behavior**
Updated UI showing icons & descriptions in menu of chat commands

**Testing**
* Tested in local environment

<img width="372" alt="Screenshot 2025-02-24 at 11 00 28 PM" src="https://github.com/user-attachments/assets/3fed4246-c595-4a48-9001-407b36580a63" />


