### PR TITLE
Move the CSS rules of chat commands in @jupyter/chat

### DIFF
--- a/packages/jupyter-chat/style/chat.css
+++ b/packages/jupyter-chat/style/chat.css
@@ -130,3 +130,13 @@
 .jp-chat-attachment .jp-chat-attachment-clickable:hover {
   cursor: pointer;
 }
+
+.jp-chat-command-name {
+  font-weight: normal;
+  margin: 5px;
+}
+
+.jp-chat-command-description {
+  color: gray;
+  margin: 5px;
+}

--- a/packages/jupyterlab-chat/style/base.css
+++ b/packages/jupyterlab-chat/style/base.css
@@ -20,13 +20,3 @@
 .jp-lab-chat-title-unread .lm-TabBar-tabLabel::before {
   content: '* ';
 }
-
-.jp-chat-command-name {
-  font-weight: normal;
-  margin: 5px;
-}
-
-.jp-chat-command-description {
-  color: gray;
-  margin: 5px;
-}


### PR DESCRIPTION
This PR moves the CSS rules of chat commands from `jupyterlab-chat` to `@jupyter/chat` (where they are defined).

`@jupyter/chat` can be used as a frontend extension that does not depends on `jupyterlab-chat`.
Therefore, the CSS rules should be defined in `@jupyter/chat`.