### PR TITLE
Fix the trailing hyphen in completion without description

### DIFF
--- a/packages/jupyter-chat/src/components/input/use-chat-commands.tsx
+++ b/packages/jupyter-chat/src/components/input/use-chat-commands.tsx
@@ -144,8 +144,14 @@ export function useChatCommands(
           <Box key={key} component="li" {...listItemProps}>
             {commandIcon}
             <p className="jp-chat-command-name">{command.name}</p>
-            <span> - </span>
-            <p className="jp-chat-command-description">{command.description}</p>
+            {command.description && (
+              <>
+                <span> - </span>
+                <p className="jp-chat-command-description">
+                  {command.description}
+                </p>
+              </>
+            )}
           </Box>
         );
       },


### PR DESCRIPTION
This PR deletes the trailing hyphen in the autocomplete suggestion (chat commands), if the description is empty.

Example:
<img src=https://github.com/user-attachments/assets/2b861de1-94fa-4562-b7f5-930e0e767d93 width=200>
