### PR TITLE
Disable the copy button in insecure contexts

### DIFF
--- a/packages/jupyter-chat/src/components/code-blocks/copy-button.tsx
+++ b/packages/jupyter-chat/src/components/code-blocks/copy-button.tsx
@@ -12,13 +12,15 @@ import { TooltippedIconButton } from '../mui-extras/tooltipped-icon-button';
 enum CopyStatus {
   None,
   Copying,
-  Copied
+  Copied,
+  Disabled
 }
 
 const COPYBTN_TEXT_BY_STATUS: Record<CopyStatus, string> = {
   [CopyStatus.None]: 'Copy to clipboard',
   [CopyStatus.Copying]: 'Copying…',
-  [CopyStatus.Copied]: 'Copied!'
+  [CopyStatus.Copied]: 'Copied!',
+  [CopyStatus.Disabled]: 'Copy to clipboard disabled in insecure context'
 };
 
 type CopyButtonProps = {
@@ -27,7 +29,10 @@ type CopyButtonProps = {
 };
 
 export function CopyButton(props: CopyButtonProps): JSX.Element {
-  const [copyStatus, setCopyStatus] = useState<CopyStatus>(CopyStatus.None);
+  const isCopyDisabled = navigator.clipboard === undefined;
+  const [copyStatus, setCopyStatus] = useState<CopyStatus>(
+    isCopyDisabled ? CopyStatus.Disabled : CopyStatus.None
+  );
   const timeoutId = useRef<number | null>(null);
 
   const copy = useCallback(async () => {
@@ -56,6 +61,7 @@ export function CopyButton(props: CopyButtonProps): JSX.Element {
 
   return (
     <TooltippedIconButton
+      disabled={isCopyDisabled}
       className={props.className}
       tooltip={COPYBTN_TEXT_BY_STATUS[copyStatus]}
       placement="top"


### PR DESCRIPTION
- Closes #186

**Problem Statement**

The "Copy to Clipboard" button fails to function when the JupyterLab server is accessed over HTTP (insecure context). Clipboard functionality requires a secure context (HTTPS or localhost), and when the server runs on HTTP, the copy action is disabled. This can cause confusion for users who may expect the button to work even in insecure contexts. To improve the user experience and minimize confusion, the copy button should be disabled when the server is served over HTTP, with a tooltip explaining that copying requires a secure context.

**Changes Made**

- Updated the `useCopy` hook to include an additional boolean parameter that controls the button's enabled/disabled state.
- Added a new status, `Disabled`, to indicate the copy status along with an appropriate label.
- Modified Icon's to have extra parameter indicating button disabled status

**Expected Behavior**

- The copy button will be disabled when accessed over HTTP, and a clear message will be displayed indicating the button's disabled status with a meaningful explanation.

**Testing**

- Changes were tested locally.
