### PR TITLE
Fix duplication after message edition

### DIFF
--- a/packages/jupyterlab-chat/src/model.ts
+++ b/packages/jupyterlab-chat/src/model.ts
@@ -133,10 +133,13 @@ export class LabChatModel extends ChatModel implements DocumentRegistry.IModel {
     // nothing to do
   }
 
-  messagesInserted(index: number, messages: IChatMessage[]): void {
+  async messagesInserted(
+    index: number,
+    messages: IChatMessage[]
+  ): Promise<void> {
     // Ensure the chat has an ID before inserting the messages, to properly catch the
     // unread messages (the last read message is saved using the chat ID).
-    this._ready.promise.then(() => {
+    return this._ready.promise.then(() => {
       super.messagesInserted(index, messages);
     });
   }
@@ -259,11 +262,11 @@ export class LabChatModel extends ChatModel implements DocumentRegistry.IModel {
     this._timeoutWriting = null;
   }
 
-  private _onchange = (_: YChat, changes: IChatChanges) => {
+  private _onchange = async (_: YChat, changes: IChatChanges) => {
     if (changes.messageChanges) {
       const msgDelta = changes.messageChanges;
       let index = 0;
-      msgDelta.forEach(delta => {
+      for (const delta of msgDelta) {
         if (delta.retain) {
           index += delta.retain;
         } else if (delta.insert) {
@@ -298,12 +301,12 @@ export class LabChatModel extends ChatModel implements DocumentRegistry.IModel {
 
             return msg;
           });
-          this.messagesInserted(index, messages);
+          await this.messagesInserted(index, messages);
           index += messages.length;
         } else if (delta.delete) {
           this.messagesDeleted(index, delta.delete);
         }
-      });
+      }
     }
 
     if (changes.metadataChanges) {


### PR DESCRIPTION
Fixes #183 
 
[record-2025-03-20_14.17.08.webm](https://github.com/user-attachments/assets/1e48815e-22cc-42a7-82c0-191cd5578597)

When a message is edited, the changes received from the `YChat` are an insertion and a deletion (in the order).
Inserting a message in the `LabChatModel` is asynchronous, because it needs to wait for the model to be ready (which means to have an ID). This is required for the initialization of the message list.

Before deleting the message, we now wait for the messages to be inserted, to get the correct index of the message to delete.
