### PR TITLE
Abstract ChatModel class

### DIFF
--- a/docs/jupyter-chat-example/src/index.ts
+++ b/docs/jupyter-chat-example/src/index.ts
@@ -7,7 +7,7 @@ import {
   ActiveCellManager,
   AttachmentOpenerRegistry,
   buildChatSidebar,
-  ChatModel,
+  AbstractChatModel,
   IAttachment,
   IChatMessage,
   INewMessage,
@@ -24,7 +24,7 @@ import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { UUID } from '@lumino/coreutils';
 
-class MyChatModel extends ChatModel {
+class MyChatModel extends AbstractChatModel {
   sendMessage(
     newMessage: INewMessage
   ): Promise<boolean | void> | boolean | void {

--- a/docs/source/developers/developing_extensions/extension-providing-chat.md
+++ b/docs/source/developers/developing_extensions/extension-providing-chat.md
@@ -52,9 +52,9 @@ As an example, here is a simple model that logs the message to the console and a
 the message list.
 
 ```typescript
-import { ChatModel, IChatMessage, INewMessage } from '@jupyter/chat';
+import { AbstractChatModel, IChatMessage, INewMessage } from '@jupyter/chat';
 
-class MyModel extends ChatModel {
+class MyModel extends AbstractChatModel {
   sendMessage(
     newMessage: INewMessage
   ): Promise<boolean | void> | boolean | void {
@@ -94,7 +94,7 @@ methods to correctly manage message transmission and reception.
 
 ```typescript
 import {
-  ChatModel,
+  AbstractChatModel,
   ChatWidget,
   IChatMessage,
   INewMessage
@@ -106,7 +106,7 @@ import {
 import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 import { UUID } from '@lumino/coreutils';
 
-class MyModel extends ChatModel {
+class MyModel extends AbstractChatModel {
   sendMessage(
     newMessage: INewMessage
   ): Promise<boolean | void> | boolean | void {
@@ -242,7 +242,7 @@ jupyterlab. In the previous example, the modification would be:
 ```typescript
 import {
   ActiveCellManager,
-  ChatModel,
+  AbstractChatModel,
   ChatWidget,
   IChatMessage,
   INewMessage
@@ -325,7 +325,7 @@ specific function for an attachment type.
 ```typescript
 import {
   AttachmentOpenerRegistry,
-  ChatModel,
+  AbstractChatModel,
   ChatWidget,
   IAttachment,
   IChatMessage,
@@ -335,7 +335,7 @@ import { IDefaultFileBrowser } from '@jupyterlab/filebrowser';
 
 ...
 
-class MyModel extends ChatModel {
+class MyModel extends AbstractChatModel {
   sendMessage(
     newMessage: INewMessage
   ): Promise<boolean | void> | boolean | void {

--- a/packages/jupyter-chat/src/__tests__/model.spec.ts
+++ b/packages/jupyter-chat/src/__tests__/model.spec.ts
@@ -7,10 +7,10 @@
  * Example of [Jest](https://jestjs.io/docs/getting-started) unit tests
  */
 
-import { ChatModel, IChatModel } from '../model';
+import { AbstractChatModel, IChatModel } from '../model';
 import { IChatMessage, INewMessage } from '../types';
 
-class MyChatModel extends ChatModel {
+class MyChatModel extends AbstractChatModel {
   sendMessage(message: INewMessage): Promise<boolean | void> | boolean | void {
     // No-op
   }
@@ -18,12 +18,12 @@ class MyChatModel extends ChatModel {
 
 describe('test chat model', () => {
   describe('model instantiation', () => {
-    it('should create a ChatModel', () => {
+    it('should create an AbstractChatModel', () => {
       const model = new MyChatModel();
-      expect(model).toBeInstanceOf(ChatModel);
+      expect(model).toBeInstanceOf(AbstractChatModel);
     });
 
-    it('should dispose a ChatModel', () => {
+    it('should dispose an AbstractChatModel', () => {
       const model = new MyChatModel();
       model.dispose();
       expect(model.isDisposed).toBeTruthy();
@@ -31,7 +31,7 @@ describe('test chat model', () => {
   });
 
   describe('incoming message', () => {
-    class TestChat extends ChatModel {
+    class TestChat extends AbstractChatModel {
       protected formatChatMessage(message: IChatMessage): IChatMessage {
         message.body = 'formatted msg';
         return message;

--- a/packages/jupyter-chat/src/__tests__/widgets.spec.ts
+++ b/packages/jupyter-chat/src/__tests__/widgets.spec.ts
@@ -11,11 +11,11 @@ import {
   IRenderMimeRegistry,
   RenderMimeRegistry
 } from '@jupyterlab/rendermime';
-import { ChatModel, IChatModel } from '../model';
+import { AbstractChatModel, IChatModel } from '../model';
 import { INewMessage } from '../types';
 import { ChatWidget } from '../widgets/chat-widget';
 
-class MyChatModel extends ChatModel {
+class MyChatModel extends AbstractChatModel {
   sendMessage(message: INewMessage): Promise<boolean | void> | boolean | void {
     // No-op
   }
@@ -31,12 +31,12 @@ describe('test chat widget', () => {
   });
 
   describe('model instantiation', () => {
-    it('should create a ChatModel', () => {
+    it('should create an AbstractChatModel', () => {
       const widget = new ChatWidget({ model, rmRegistry });
       expect(widget).toBeInstanceOf(ChatWidget);
     });
 
-    it('should dispose a ChatModel', () => {
+    it('should dispose an AbstractChatModel', () => {
       const widget = new ChatWidget({ model, rmRegistry });
       widget.dispose();
       expect(widget.isDisposed).toBeTruthy();

--- a/packages/jupyter-chat/src/model.ts
+++ b/packages/jupyter-chat/src/model.ts
@@ -180,11 +180,11 @@ export interface IChatModel extends IDisposable {
  * The class inheriting from it must implement at least:
  * - sendMessage(message: INewMessage)
  */
-export abstract class ChatModel implements IChatModel {
+export abstract class AbstractChatModel implements IChatModel {
   /**
    * Create a new chat model.
    */
-  constructor(options: ChatModel.IOptions = {}) {
+  constructor(options: IChatModel.IOptions = {}) {
     if (options.id) {
       this.id = options.id;
     }
@@ -612,7 +612,7 @@ export abstract class ChatModel implements IChatModel {
 /**
  * The chat model namespace.
  */
-export namespace ChatModel {
+export namespace IChatModel {
   /**
    * The instantiation options for a ChatModel.
    */

--- a/packages/jupyterlab-chat/src/model.ts
+++ b/packages/jupyterlab-chat/src/model.ts
@@ -4,9 +4,10 @@
  */
 
 import {
-  ChatModel,
+  AbstractChatModel,
   IAttachment,
   IChatMessage,
+  IChatModel,
   IInputModel,
   INewMessage,
   IUser
@@ -26,7 +27,7 @@ const WRITING_DELAY = 1000;
  * Chat model namespace.
  */
 export namespace LabChatModel {
-  export interface IOptions extends ChatModel.IOptions {
+  export interface IOptions extends IChatModel.IOptions {
     widgetConfig: IWidgetConfig;
     user: User.IIdentity | null;
     sharedModel?: YChat;
@@ -37,7 +38,10 @@ export namespace LabChatModel {
 /**
  * The chat model.
  */
-export class LabChatModel extends ChatModel implements DocumentRegistry.IModel {
+export class LabChatModel
+  extends AbstractChatModel
+  implements DocumentRegistry.IModel
+{
   constructor(options: LabChatModel.IOptions) {
     super(options);
 


### PR DESCRIPTION
The `ChatModel` class in `@jupyter/chat` package is not intended to be instantiated but extended, since it does not provide the `sendMessage()` implementation.

This PR abstracts this class for clarification.

Fixes #157 