### PR TITLE
Fix the attachments on message edition and on python Message model

### DIFF
--- a/packages/jupyterlab-chat/src/model.ts
+++ b/packages/jupyterlab-chat/src/model.ts
@@ -162,13 +162,13 @@ export class LabChatModel extends ChatModel implements DocumentRegistry.IModel {
     }
 
     // Add the attachments to the message.
-    if (this.input.attachments.length) {
-      const attachmentIds = this.input.attachments.map(attachment =>
-        this.sharedModel.setAttachment(attachment)
-      );
+    const attachmentIds = this.input.attachments?.map(attachment =>
+      this.sharedModel.setAttachment(attachment)
+    );
+    if (attachmentIds?.length) {
       msg.attachments = attachmentIds;
-      this.input.clearAttachments();
     }
+    this.input.clearAttachments();
 
     this.sharedModel.addMessage(msg);
   }
@@ -204,9 +204,12 @@ export class LabChatModel extends ChatModel implements DocumentRegistry.IModel {
     const attachmentIds = updatedMessage.attachments?.map(attachment =>
       this.sharedModel.setAttachment(attachment)
     );
-    if (attachmentIds) {
+    if (attachmentIds?.length) {
       message.attachments = attachmentIds;
+    } else {
+      delete message.attachments;
     }
+
     this.sharedModel.updateMessage(index, message as IYmessage);
   }
 

--- a/python/jupyterlab-chat/jupyterlab_chat/models.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/models.py
@@ -35,6 +35,9 @@ class Message:
     # 3.9 reaches EOL.
     type: Literal["msg"] = "msg"
 
+    attachments: Optional[list[str]] = None
+    """ The message attachments, a list of attachment ID """
+
     raw_time: Optional[bool] = None
     """
     Whether the timestamp is raw (from client) or not (from server, unified)


### PR DESCRIPTION
Follow up #148.

The python `Message` model was missing the `attachments` property, which led to error when trying to cast some message dict to `Message` objects:

```bash
TypeError: Message.__init__() got an unexpected keyword argument 'attachments'
```

Should fixes issues [2] and [4] in https://github.com/jupyterlab/jupyter-ai/issues/1293