### PR TITLE
Fix the toolbar registry for main area chat

### DIFF
--- a/packages/jupyterlab-chat/src/factory.ts
+++ b/packages/jupyterlab-chat/src/factory.ts
@@ -83,9 +83,7 @@ export class ChatWidgetFactory extends ABCWidgetFactory<
     this._rmRegistry = options.rmRegistry;
     this._chatCommandRegistry = options.chatCommandRegistry;
     this._attachmentOpenerRegistry = options.attachmentOpenerRegistry;
-    if (options.inputToolbarFactory) {
-      this._inputToolbarRegistry = options.inputToolbarFactory.create();
-    }
+    this._inputToolbarFactory = options.inputToolbarFactory;
   }
 
   /**
@@ -99,7 +97,9 @@ export class ChatWidgetFactory extends ABCWidgetFactory<
     context.themeManager = this._themeManager;
     context.chatCommandRegistry = this._chatCommandRegistry;
     context.attachmentOpenerRegistry = this._attachmentOpenerRegistry;
-    context.inputToolbarRegistry = this._inputToolbarRegistry;
+    if (this._inputToolbarFactory) {
+      context.inputToolbarRegistry = this._inputToolbarFactory.create();
+    }
     return new LabChatPanel({
       context,
       content: new ChatWidget(context)
@@ -110,7 +110,7 @@ export class ChatWidgetFactory extends ABCWidgetFactory<
   private _rmRegistry: IRenderMimeRegistry;
   private _chatCommandRegistry?: IChatCommandRegistry;
   private _attachmentOpenerRegistry?: IAttachmentOpenerRegistry;
-  private _inputToolbarRegistry?: IInputToolbarRegistry;
+  private _inputToolbarFactory?: IInputToolbarRegistryFactory;
 }
 
 export namespace ChatWidgetFactory {


### PR DESCRIPTION
Follow up #198.

Creates the toolbar registry when creating the widget, instead of creating it in the constructor of the widget factory.

Before this PR, the input toolbar registry was shared between all the main area widgets. This does not allow adding custom buttons, including for example the chat model. The button was added by the first opened chat, including its options.