### PR TITLE
Fix _version.py file version bump

### DIFF
--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -96,7 +96,10 @@ def bump(force, skip_if_dirty, spec):
                 f" expected __version__ assignment in the first line, found {variable}"
             )
         current = current.strip("'\"")
-        version_spec = increment_version(current, spec)
+        if spec in VERSION_SPEC:
+            version_spec = increment_version(current, spec)
+        else:
+            version_spec = spec
         version_file.write_text(f'__version__ = "{version_spec}"\n')
 
     # bump the local package.json file


### PR DESCRIPTION
Follow up #196 to fix the version of the `_version.py` file in python extension when bumping to a specific value (e.g `0.10.0`)