### PR TITLE
Display user writing notification when editing a message

### DIFF
--- a/packages/jupyter-chat/package.json
+++ b/packages/jupyter-chat/package.json
@@ -54,6 +54,7 @@
     "@jupyterlab/notebook": "^4.2.0",
     "@jupyterlab/rendermime": "^4.2.0",
     "@jupyterlab/ui-components": "^4.2.0",
+    "@lumino/algorithm": "^2.0.0",
     "@lumino/commands": "^2.0.0",
     "@lumino/coreutils": "^2.0.0",
     "@lumino/disposable": "^2.0.0",

--- a/packages/jupyter-chat/src/components/chat-messages.tsx
+++ b/packages/jupyter-chat/src/components/chat-messages.tsx
@@ -439,6 +439,7 @@ export const ChatMessage = forwardRef<HTMLDivElement, ChatMessageProps>(
       updatedMessage.attachments = inputModel.attachments;
       updatedMessage.mentions = inputModel.mentions;
       model.updateMessage!(id, updatedMessage);
+      model.getEditionModel(message.id)?.dispose();
       setEdit(false);
     };
 

--- a/packages/jupyter-chat/src/input-model.ts
+++ b/packages/jupyter-chat/src/input-model.ts
@@ -151,7 +151,7 @@ export interface IInputModel extends IDisposable {
   /**
    * A signal emitting when disposing of the model.
    */
-  readonly onDispose: ISignal<InputModel, void>;
+  readonly onDisposed: ISignal<InputModel, void>;
 }
 
 /**
@@ -416,15 +416,15 @@ export class InputModel implements IInputModel {
     if (this.isDisposed) {
       return;
     }
-    this._onDispose.emit();
+    this._onDisposed.emit();
     this._isDisposed = true;
   }
 
   /**
    * A signal emitting when disposing of the model.
    */
-  get onDispose(): ISignal<InputModel, void> {
-    return this._onDispose;
+  get onDisposed(): ISignal<InputModel, void> {
+    return this._onDisposed;
   }
 
   /**
@@ -451,7 +451,7 @@ export class InputModel implements IInputModel {
   private _configChanged = new Signal<IInputModel, InputModel.IConfig>(this);
   private _focusInputSignal = new Signal<InputModel, void>(this);
   private _attachmentsChanged = new Signal<InputModel, IAttachment[]>(this);
-  private _onDispose = new Signal<InputModel, void>(this);
+  private _onDisposed = new Signal<InputModel, void>(this);
   private _isDisposed = false;
 }
 

--- a/packages/jupyter-chat/src/input-model.ts
+++ b/packages/jupyter-chat/src/input-model.ts
@@ -147,6 +147,11 @@ export interface IInputModel extends IDisposable {
    * Clear mentions list.
    */
   clearMentions(): void;
+
+  /**
+   * A signal emitting when disposing of the model.
+   */
+  readonly onDispose: ISignal<InputModel, void>;
 }
 
 /**
@@ -411,7 +416,15 @@ export class InputModel implements IInputModel {
     if (this.isDisposed) {
       return;
     }
+    this._onDispose.emit();
     this._isDisposed = true;
+  }
+
+  /**
+   * A signal emitting when disposing of the model.
+   */
+  get onDispose(): ISignal<InputModel, void> {
+    return this._onDispose;
   }
 
   /**
@@ -438,6 +451,7 @@ export class InputModel implements IInputModel {
   private _configChanged = new Signal<IInputModel, InputModel.IConfig>(this);
   private _focusInputSignal = new Signal<InputModel, void>(this);
   private _attachmentsChanged = new Signal<InputModel, IAttachment[]>(this);
+  private _onDispose = new Signal<InputModel, void>(this);
   private _isDisposed = false;
 }
 

--- a/packages/jupyter-chat/src/model.ts
+++ b/packages/jupyter-chat/src/model.ts
@@ -588,9 +588,9 @@ export abstract class AbstractChatModel implements IChatModel {
    * Add an input model of the edited message.
    */
   addEditionModel(messageID: string, inputModel: IInputModel): void {
-    if (this.getEditionModel(messageID)) {
-      this.getEditionModel(messageID)?.dispose();
-    }
+    // Dispose of an hypothetic previous model for this message.
+    this.getEditionModel(messageID)?.dispose();
+
     this._messageEditions.set(messageID, inputModel);
     this._messageEditionAdded.emit({ id: messageID, model: inputModel });
 

--- a/packages/jupyter-chat/src/model.ts
+++ b/packages/jupyter-chat/src/model.ts
@@ -45,6 +45,11 @@ export interface IChatModel extends IDisposable {
   messagesInViewport?: number[];
 
   /**
+   * The input model of the current message in edition (null if no message are edited).
+   */
+  messageEdition: IChatModel.IMessageEdition | null;
+
+  /**
    * The user connected to the chat panel.
    */
   readonly user?: IUser;
@@ -82,7 +87,7 @@ export interface IChatModel extends IDisposable {
   /**
    * A signal emitting when the messages list is updated.
    */
-  get configChanged(): ISignal<IChatModel, IConfig>;
+  readonly configChanged: ISignal<IChatModel, IConfig>;
 
   /**
    * A signal emitting when unread messages change.
@@ -97,7 +102,15 @@ export interface IChatModel extends IDisposable {
   /**
    * A signal emitting when the writers change.
    */
-  readonly writersChanged?: ISignal<IChatModel, IUser[]>;
+  readonly writersChanged?: ISignal<IChatModel, IChatModel.IWriter[]>;
+
+  /**
+   * A signal emitting when the message edition input changed change.
+   */
+  readonly messageEditionChanged: ISignal<
+    IChatModel,
+    IChatModel.IMessageEdition | null
+  >;
 
   /**
    * Send a message, to be defined depending on the chosen technology.
@@ -172,7 +185,7 @@ export interface IChatModel extends IDisposable {
   /**
    * Update the current writers list.
    */
-  updateWriters(writers: IUser[]): void;
+  updateWriters(writers: IChatModel.IWriter[]): void;
 
   /**
    * Create the chat context that will be passed to the input model.
@@ -388,6 +401,20 @@ export abstract class AbstractChatModel implements IChatModel {
   }
 
   /**
+   * The input model of the current message in edition (null if no message are edited).
+   */
+  get messageEdition(): IChatModel.IMessageEdition | null {
+    return this._messageEdition;
+  }
+  set messageEdition(editionModel: IChatModel.IMessageEdition | null) {
+    if (this._messageEdition) {
+      this._messageEdition.model.dispose();
+    }
+    this._messageEdition = editionModel;
+    this._messageEditionChanged.emit(this._messageEdition);
+  }
+
+  /**
    * A signal emitting when the messages list is updated.
    */
   get messagesUpdated(): ISignal<IChatModel, void> {
@@ -418,8 +445,18 @@ export abstract class AbstractChatModel implements IChatModel {
   /**
    * A signal emitting when the writers change.
    */
-  get writersChanged(): ISignal<IChatModel, IUser[]> {
+  get writersChanged(): ISignal<IChatModel, IChatModel.IWriter[]> {
     return this._writersChanged;
+  }
+
+  /**
+   * A signal emitting when the message edition input changed change.
+   */
+  get messageEditionChanged(): ISignal<
+    IChatModel,
+    IChatModel.IMessageEdition | null
+  > {
+    return this._messageEditionChanged;
   }
 
   /**
@@ -546,7 +583,7 @@ export abstract class AbstractChatModel implements IChatModel {
    * Update the current writers list.
    * This implementation only propagate the list via a signal.
    */
-  updateWriters(writers: IUser[]): void {
+  updateWriters(writers: IChatModel.IWriter[]): void {
     this._writersChanged.emit(writers);
   }
 
@@ -616,12 +653,17 @@ export abstract class AbstractChatModel implements IChatModel {
   private _activeCellManager: IActiveCellManager | null;
   private _selectionWatcher: ISelectionWatcher | null;
   private _documentManager: IDocumentManager | null;
+  private _messageEdition: IChatModel.IMessageEdition | null = null;
   private _notificationId: string | null = null;
   private _messagesUpdated = new Signal<IChatModel, void>(this);
   private _configChanged = new Signal<IChatModel, IConfig>(this);
   private _unreadChanged = new Signal<IChatModel, number[]>(this);
   private _viewportChanged = new Signal<IChatModel, number[]>(this);
-  private _writersChanged = new Signal<IChatModel, IUser[]>(this);
+  private _writersChanged = new Signal<IChatModel, IChatModel.IWriter[]>(this);
+  private _messageEditionChanged = new Signal<
+    IChatModel,
+    IChatModel.IMessageEdition | null
+  >(this);
 }
 
 /**
@@ -661,6 +703,34 @@ export namespace IChatModel {
      * Document manager.
      */
     documentManager?: IDocumentManager | null;
+  }
+
+  /**
+   * Representation of a message edition.
+   */
+  export interface IMessageEdition {
+    /**
+     * The id of the edited message.
+     */
+    id: string;
+    /**
+     * The model of the input editing the message.
+     */
+    model: IInputModel;
+  }
+
+  /**
+   * Writer interface, including the message ID if the writer is editing a message.
+   */
+  export interface IWriter {
+    /**
+     * The user currently writing.
+     */
+    user: IUser;
+    /**
+     * The message ID (optional)
+     */
+    messageID?: string;
   }
 }
 

--- a/packages/jupyterlab-chat/src/model.ts
+++ b/packages/jupyterlab-chat/src/model.ts
@@ -260,7 +260,10 @@ export class LabChatModel
   }
 
   /**
-   * Function called by the input on key pressed.
+   * Function called when the input content changed.
+   *
+   * @param value - The whole input content.
+   * @param messageID - The ID of the message being edited, if any.
    */
   onInputChanged = (value: string, messageID?: string): void => {
     if (!value || !this.config.sendTypingNotification) {

--- a/packages/jupyterlab-chat/src/model.ts
+++ b/packages/jupyterlab-chat/src/model.ts
@@ -304,7 +304,7 @@ export class LabChatModel
       if (!state || !state.user || state.user.username === this.user.username) {
         continue;
       }
-      if (state.isWriting) {
+      if (state.isWriting !== undefined && state.isWriting !== false) {
         const writer: IChatModel.IWriter = {
           user: state.user,
           messageID: state.isWriting === true ? undefined : state.isWriting

--- a/packages/jupyterlab-chat/src/model.ts
+++ b/packages/jupyterlab-chat/src/model.ts
@@ -68,7 +68,7 @@ export class LabChatModel
     this.sharedModel.awareness.on('change', this.onAwarenessChange);
 
     this.input.valueChanged.connect((_, value) => this.onInputChanged(value));
-    this.messageEditionChanged.connect(this.onMessageEditionChanged);
+    this.messageEditionAdded.connect(this.onMessageEditionAdded);
   }
 
   readonly collaborative = true;
@@ -279,9 +279,9 @@ export class LabChatModel
   /**
    * Listen to the message edition input.
    */
-  onMessageEditionChanged = (
+  onMessageEditionAdded = (
     _: IChatModel,
-    edition: IChatModel.IMessageEdition | null
+    edition: IChatModel.IMessageEdition
   ) => {
     if (edition !== null) {
       const _onInputChanged = (_: IInputModel, value: string) => {
@@ -289,9 +289,6 @@ export class LabChatModel
       };
 
       edition.model.valueChanged.connect(_onInputChanged);
-      edition.model.onDispose.connect(() =>
-        edition.model.valueChanged.disconnect(_onInputChanged)
-      );
     }
   };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2510,6 +2510,7 @@ __metadata:
     "@jupyterlab/rendermime": ^4.2.0
     "@jupyterlab/testing": ^4.2.0
     "@jupyterlab/ui-components": ^4.2.0
+    "@lumino/algorithm": ^2.0.0
     "@lumino/commands": ^2.0.0
     "@lumino/coreutils": ^2.0.0
     "@lumino/disposable": ^2.0.0
@@ -3555,7 +3556,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@lumino/algorithm@npm:^2.0.1, @lumino/algorithm@npm:^2.0.2":
+"@lumino/algorithm@npm:^2.0.0, @lumino/algorithm@npm:^2.0.1, @lumino/algorithm@npm:^2.0.2":
   version: 2.0.2
   resolution: "@lumino/algorithm@npm:2.0.2"
   checksum: 34b25684b845f1bdbf78ca45ebd99a97b67b2992440c9643aafe5fc5a99fae1ddafa9e5890b246b233dc3a12d9f66aa84afe4a2aac44cf31071348ed217740db


### PR DESCRIPTION
This PR improves the handling of the writers, by sending also the message being edited.

Related to https://github.com/jupyterlab/jupyter-chat/issues/202, see https://github.com/jupyterlab/jupyter-chat/issues/202#issuecomment-2785824848 for context (only the last change was required by #202).

### Changes
- when editing a message, the input model of the message edition is added to the chat model ~=> only one message can be edited at the same time~
- jupyterlab-chat also listen to the message edition to update the writer list
- the writer list can optionally contain a message ID if this is a message edition