### PR TITLE
Allow Users to delete messages if sender is not human, add optional `human` bool to user models

### DIFF
--- a/packages/jupyter-chat/src/components/chat-messages.tsx
+++ b/packages/jupyter-chat/src/components/chat-messages.tsx
@@ -366,6 +366,10 @@ export const ChatMessage = forwardRef<HTMLDivElement, ChatMessageProps>(
         if (model.user.username === message.sender.username) {
           setCanEdit(model.updateMessage !== undefined);
           setCanDelete(model.deleteMessage !== undefined);
+          return;
+        }
+        if (!(message.sender.human ?? true)) {
+          setCanDelete(model.deleteMessage !== undefined);
         }
       } else {
         setCanEdit(false);

--- a/packages/jupyter-chat/src/types.ts
+++ b/packages/jupyter-chat/src/types.ts
@@ -17,6 +17,10 @@ export interface IUser {
    * The string to use to mention a user in the chat.
    */
   mention_name?: string;
+  /**
+   * Boolean identifying if user is a human.
+   */
+  human?: boolean;
 }
 
 /**

--- a/python/jupyterlab-chat/jupyterlab_chat/models.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/models.py
@@ -78,6 +78,9 @@ class User(JupyterUser):
     mention_name: Optional[str] = None
     """ The string to use as mention in chat """
 
+    human: Optional[bool] = None
+    """ Boolean identifying if user is a human """
+
 
 @dataclass
 class Attachment:


### PR DESCRIPTION
## Description
* Fixes #117

## Code changes
* Add optional `human` bool to `User` and `IUser` models
* Allow users to delete messages if sender is `sender.human` is set to `False`

If approach/change looks good, would be happy to add a test.

## User-facing changes
Any user can delete a message if sender is not human (sender.human is explicitly set to False).

![Screenshot 2025-04-17 at 10 41 34 AM](https://github.com/user-attachments/assets/2c195d8e-0752-4cc8-a35e-9ae558edfe0c)

Given chat below

```
{
  "messages": [
    {
      "body": "test",
      "type": "msg",
      "id": "f5f082f6-6d8b-40cb-bd0c-19166edc7c66",
      "time": 1744836704.329035,
      "raw_time": false,
      "sender": "853888eb11294e9696a37acf577b8b7c"
    },
    {
      "raw_time": false,
      "time": 1744836766.093413,
      "type": "msg",
      "sender": "3931ab15829e49cbb11f2cad35bea0ab",
      "body": "test",
      "id": "6bc81764-6271-4ad1-a7a8-bffec332a21a"
    }
  ],
  "users": {
    "853888eb11294e9696a37acf577b8b7c": {
      "avatar_url": null,
      "display_name": "Anonymous Euporie",
      "color": "var(--jp-collaborator-color3)",
      "username": "853888eb11294e9696a37acf577b8b7c",
      "name": "Anonymous Euporie",
      "initials": "AE"
    },
    "3931ab15829e49cbb11f2cad35bea0ab": {
      "display_name": "Anonymous Pasiphae",
      "avatar_url": null,
      "name": "Anonymous Pasiphae",
      "initials": "AP",
      "human": false,
      "username": "3931ab15829e49cbb11f2cad35bea0ab",
      "color": "var(--jp-collaborator-color1)"
    }
  },
  "attachments": {},
  "metadata": {
    "id": "d8cf100b-0f03-490e-943a-0b4b10125007"
  }
}
```
