### PR TITLE
Add a welcome message

### DIFF
--- a/docs/jupyter-chat-example/src/index.ts
+++ b/docs/jupyter-chat-example/src/index.ts
@@ -26,6 +26,21 @@ import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { UUID } from '@lumino/coreutils';
 
+const welcomeMessage = `
+### Welcome to Jupyter Chat!
+
+This is a simple chat panel that allows you to send messages and share files.
+
+The messages are rendered as markdown, allowing you to format the messages with e.g.:
+- **bold**
+- _italic_
+- \`\`\`python
+  # This is a code block
+  print('Hello world!')
+  \`\`\`
+- [link](https://jupyter.org)
+`;
+
 class ChatContext extends AbstractChatContext {
   get users() {
     return [];
@@ -138,7 +153,8 @@ const plugin: JupyterFrontEndPlugin<void> = {
       model,
       rmRegistry,
       themeManager,
-      attachmentOpenerRegistry
+      attachmentOpenerRegistry,
+      welcomeMessage
     });
     app.shell.add(panel, 'left');
   }

--- a/packages/jupyter-chat/src/components/chat-messages.tsx
+++ b/packages/jupyter-chat/src/components/chat-messages.tsx
@@ -19,7 +19,7 @@ import React, { useEffect, useState, useRef, forwardRef } from 'react';
 import { AttachmentPreviewList } from './attachments';
 import { ChatInput } from './chat-input';
 import { IInputToolbarRegistry } from './input';
-import { MarkdownRenderer } from './markdown-renderer';
+import { MessageRenderer } from './markdown-renderer';
 import { MessageFooter } from './messages/footer';
 import { ScrollContainer } from './scroll-container';
 import { IChatCommandRegistry } from '../chat-commands';
@@ -463,7 +463,7 @@ export const ChatMessage = forwardRef<HTMLDivElement, ChatMessageProps>(
             toolbarRegistry={props.inputToolbarRegistry}
           />
         ) : (
-          <MarkdownRenderer
+          <MessageRenderer
             rmRegistry={rmRegistry}
             markdownStr={message.body}
             model={model}

--- a/packages/jupyter-chat/src/components/chat-messages.tsx
+++ b/packages/jupyter-chat/src/components/chat-messages.tsx
@@ -21,6 +21,7 @@ import { ChatInput } from './chat-input';
 import { IInputToolbarRegistry } from './input';
 import { MessageRenderer } from './markdown-renderer';
 import { MessageFooter } from './messages/footer';
+import { WelcomeMessage } from './messages/welcome';
 import { ScrollContainer } from './scroll-container';
 import { IChatCommandRegistry } from '../chat-commands';
 import { IMessageFooterRegistry } from '../footers';
@@ -64,6 +65,10 @@ type BaseMessageProps = {
    * The footer registry.
    */
   messageFooterRegistry?: IMessageFooterRegistry;
+  /**
+   * The welcome message.
+   */
+  welcomeMessage?: string;
 };
 
 /**
@@ -184,6 +189,12 @@ export function ChatMessages(props: BaseMessageProps): JSX.Element {
   return (
     <>
       <ScrollContainer sx={{ flexGrow: 1 }}>
+        {props.welcomeMessage && (
+          <WelcomeMessage
+            rmRegistry={props.rmRegistry}
+            content={props.welcomeMessage}
+          />
+        )}
         <Box ref={refMsgBox} className={clsx(MESSAGES_BOX_CLASS)}>
           {messages.map((message, i) => {
             renderedPromise.current[i] = new PromiseDelegate();

--- a/packages/jupyter-chat/src/components/chat.tsx
+++ b/packages/jupyter-chat/src/components/chat.tsx
@@ -36,6 +36,7 @@ export function ChatBody(props: Chat.IChatBodyProps): JSX.Element {
         chatCommandRegistry={props.chatCommandRegistry}
         inputToolbarRegistry={inputToolbarRegistry}
         messageFooterRegistry={props.messageFooterRegistry}
+        welcomeMessage={props.welcomeMessage}
       />
       <ChatInput
         sx={{
@@ -131,6 +132,10 @@ export namespace Chat {
      * The footer registry.
      */
     messageFooterRegistry?: IMessageFooterRegistry;
+    /**
+     * The welcome message.
+     */
+    welcomeMessage?: string;
   }
 
   /**

--- a/packages/jupyter-chat/src/components/messages/welcome.tsx
+++ b/packages/jupyter-chat/src/components/messages/welcome.tsx
@@ -1,0 +1,60 @@
+import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
+import { classes } from '@jupyterlab/ui-components';
+import React, { useEffect, useRef } from 'react';
+import { MarkdownRenderer, MD_RENDERED_CLASS } from '../markdown-renderer';
+
+const WELCOME_MESSAGE_CLASS = 'jp-chat-welcome-message';
+
+/**
+ * The welcome message props.
+ */
+export interface IWelcomeMessageProps {
+  /**
+   * The content of the welcome message.
+   */
+  content: string;
+  /**
+   * The rendermime registry.
+   */
+  rmRegistry: IRenderMimeRegistry;
+}
+
+/**
+ * The welcome message component.
+ */
+export function WelcomeMessage(props: IWelcomeMessageProps): JSX.Element {
+  const { rmRegistry } = props;
+  const content = props.content + '\n----\n';
+
+  // ref that tracks the content container to store the rendermime node in
+  const renderingContainer = useRef<HTMLDivElement | null>(null);
+  // ref that tracks whether the rendermime node has already been inserted
+  const renderingInserted = useRef<boolean>(false);
+
+  /**
+   * Effect: use Rendermime to render `props.markdownStr` into an HTML element,
+   * and insert it into `renderingContainer` if not yet inserted.
+   */
+  useEffect(() => {
+    const renderContent = async () => {
+      const renderer = await MarkdownRenderer.renderContent(
+        content,
+        rmRegistry
+      );
+
+      // insert the rendering into renderingContainer if not yet inserted
+      if (renderingContainer.current !== null && !renderingInserted.current) {
+        renderingContainer.current.appendChild(renderer.node);
+        renderingInserted.current = true;
+      }
+    };
+
+    renderContent();
+  }, [content]);
+
+  return (
+    <div className={classes(MD_RENDERED_CLASS, WELCOME_MESSAGE_CLASS)}>
+      <div ref={renderingContainer} />
+    </div>
+  );
+}

--- a/packages/jupyter-chat/src/components/messages/welcome.tsx
+++ b/packages/jupyter-chat/src/components/messages/welcome.tsx
@@ -21,6 +21,8 @@ export interface IWelcomeMessageProps {
 
 /**
  * The welcome message component.
+ * This message is displayed on top of the chat messages, and is rendered using a
+ * markdown renderer.
  */
 export function WelcomeMessage(props: IWelcomeMessageProps): JSX.Element {
   const { rmRegistry } = props;

--- a/packages/jupyter-chat/src/components/messages/welcome.tsx
+++ b/packages/jupyter-chat/src/components/messages/welcome.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
 import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 import { classes } from '@jupyterlab/ui-components';
 import React, { useEffect, useRef } from 'react';

--- a/packages/jupyter-chat/style/chat.css
+++ b/packages/jupyter-chat/style/chat.css
@@ -26,6 +26,10 @@
  * See: https://jupyterlab.readthedocs.io/en/latest/extension/extension_migration.html#css-styling
  * See also: https://github.com/jupyterlab/jupyter-ai/issues/1090
  */
+.jp-ThemedContainer .jp-chat-rendered-markdown.jp-chat-welcome-message {
+  padding: 0 1em;
+}
+
 .jp-ThemedContainer .jp-chat-rendered-markdown .jp-RenderedHTMLCommon {
   padding-right: 0;
 }

--- a/packages/jupyterlab-chat-extension/src/index.ts
+++ b/packages/jupyterlab-chat-extension/src/index.ts
@@ -59,6 +59,7 @@ import {
   IChatPanel,
   IInputToolbarRegistryFactory,
   ISelectionWatcherToken,
+  IWelcomeMessage,
   LabChatModel,
   LabChatModelFactory,
   LabChatPanel,
@@ -122,7 +123,8 @@ const docFactories: JupyterFrontEndPlugin<IChatFactory> = {
     ISettingRegistry,
     IThemeManager,
     IToolbarWidgetRegistry,
-    ITranslator
+    ITranslator,
+    IWelcomeMessage
   ],
   provides: IChatFactory,
   activate: (
@@ -140,7 +142,8 @@ const docFactories: JupyterFrontEndPlugin<IChatFactory> = {
     settingRegistry: ISettingRegistry | null,
     themeManager: IThemeManager | null,
     toolbarRegistry: IToolbarWidgetRegistry | null,
-    translator_: ITranslator | null
+    translator_: ITranslator | null,
+    welcomeMessage: string
   ): IChatFactory => {
     const translator = translator_ ?? nullTranslator;
 
@@ -306,7 +309,8 @@ const docFactories: JupyterFrontEndPlugin<IChatFactory> = {
       chatCommandRegistry,
       attachmentOpenerRegistry,
       inputToolbarFactory,
-      messageFooterRegistry
+      messageFooterRegistry,
+      welcomeMessage
     });
 
     // Add the widget to the tracker when it's created
@@ -671,7 +675,8 @@ const chatPanel: JupyterFrontEndPlugin<ChatPanel> = {
     IInputToolbarRegistryFactory,
     ILayoutRestorer,
     IMessageFooterRegistry,
-    IThemeManager
+    IThemeManager,
+    IWelcomeMessage
   ],
   activate: (
     app: JupyterFrontEnd,
@@ -683,7 +688,8 @@ const chatPanel: JupyterFrontEndPlugin<ChatPanel> = {
     inputToolbarFactory: IInputToolbarRegistryFactory,
     restorer: ILayoutRestorer | null,
     messageFooterRegistry: IMessageFooterRegistry,
-    themeManager: IThemeManager | null
+    themeManager: IThemeManager | null,
+    welcomeMessage: string
   ): ChatPanel => {
     const { commands } = app;
 
@@ -701,7 +707,8 @@ const chatPanel: JupyterFrontEndPlugin<ChatPanel> = {
       chatCommandRegistry,
       attachmentOpenerRegistry,
       inputToolbarFactory,
-      messageFooterRegistry
+      messageFooterRegistry,
+      welcomeMessage
     });
     chatPanel.id = 'JupyterlabChat:sidepanel';
     chatPanel.title.icon = chatIcon;

--- a/packages/jupyterlab-chat/src/factory.ts
+++ b/packages/jupyterlab-chat/src/factory.ts
@@ -86,6 +86,7 @@ export class ChatWidgetFactory extends ABCWidgetFactory<
     this._attachmentOpenerRegistry = options.attachmentOpenerRegistry;
     this._inputToolbarFactory = options.inputToolbarFactory;
     this._messageFooterRegistry = options.messageFooterRegistry;
+    this._welcomeMessage = options.welcomeMessage;
   }
 
   /**
@@ -100,6 +101,7 @@ export class ChatWidgetFactory extends ABCWidgetFactory<
     context.chatCommandRegistry = this._chatCommandRegistry;
     context.attachmentOpenerRegistry = this._attachmentOpenerRegistry;
     context.messageFooterRegistry = this._messageFooterRegistry;
+    context.welcomeMessage = this._welcomeMessage;
     if (this._inputToolbarFactory) {
       context.inputToolbarRegistry = this._inputToolbarFactory.create();
     }
@@ -115,6 +117,7 @@ export class ChatWidgetFactory extends ABCWidgetFactory<
   private _attachmentOpenerRegistry?: IAttachmentOpenerRegistry;
   private _inputToolbarFactory?: IInputToolbarRegistryFactory;
   private _messageFooterRegistry?: IMessageFooterRegistry;
+  private _welcomeMessage?: string;
 }
 
 export namespace ChatWidgetFactory {
@@ -126,6 +129,7 @@ export namespace ChatWidgetFactory {
     attachmentOpenerRegistry?: IAttachmentOpenerRegistry;
     inputToolbarRegistry?: IInputToolbarRegistry;
     messageFooterRegistry?: IMessageFooterRegistry;
+    welcomeMessage?: string;
   }
 
   export interface IOptions<T extends LabChatPanel>
@@ -136,6 +140,7 @@ export namespace ChatWidgetFactory {
     attachmentOpenerRegistry?: IAttachmentOpenerRegistry;
     inputToolbarFactory?: IInputToolbarRegistryFactory;
     messageFooterRegistry?: IMessageFooterRegistry;
+    welcomeMessage?: string;
   }
 }
 

--- a/packages/jupyterlab-chat/src/token.ts
+++ b/packages/jupyterlab-chat/src/token.ts
@@ -144,3 +144,12 @@ export const IInputToolbarRegistryFactory =
   new Token<IInputToolbarRegistryFactory>(
     'jupyterlab-chat:IInputToolbarRegistryFactory'
   );
+
+/**
+ * The token to add a welcome message to the chat.
+ * This token is not provided by default, but can be provided by third party extensions
+ * willing to add a welcome message to the chat.
+ */
+export const IWelcomeMessage = new Token<string>(
+  'jupyterlab-chat:IWelcomeMessage'
+);

--- a/packages/jupyterlab-chat/src/widget.tsx
+++ b/packages/jupyterlab-chat/src/widget.tsx
@@ -113,6 +113,7 @@ export class ChatPanel extends SidePanel {
     this._attachmentOpenerRegistry = options.attachmentOpenerRegistry;
     this._inputToolbarFactory = options.inputToolbarFactory;
     this._messageFooterRegistry = options.messageFooterRegistry;
+    this._welcomeMessage = options.welcomeMessage;
 
     const addChat = new CommandToolbarButton({
       commands: this._commands,
@@ -183,7 +184,8 @@ export class ChatPanel extends SidePanel {
       chatCommandRegistry: this._chatCommandRegistry,
       attachmentOpenerRegistry: this._attachmentOpenerRegistry,
       inputToolbarRegistry,
-      messageFooterRegistry: this._messageFooterRegistry
+      messageFooterRegistry: this._messageFooterRegistry,
+      welcomeMessage: this._welcomeMessage
     });
 
     this.addWidget(
@@ -306,6 +308,7 @@ export class ChatPanel extends SidePanel {
   private _attachmentOpenerRegistry?: IAttachmentOpenerRegistry;
   private _inputToolbarFactory?: IInputToolbarRegistryFactory;
   private _messageFooterRegistry?: IMessageFooterRegistry;
+  private _welcomeMessage?: string;
 }
 
 /**
@@ -325,6 +328,7 @@ export namespace ChatPanel {
     attachmentOpenerRegistry?: IAttachmentOpenerRegistry;
     inputToolbarFactory?: IInputToolbarRegistryFactory;
     messageFooterRegistry?: IMessageFooterRegistry;
+    welcomeMessage?: string;
   }
 }
 


### PR DESCRIPTION
This PR adds an optional welcome message to the chat, rendered as markdown.
This message is displayed on top of all the messages in the chat widget.

<img src=https://github.com/user-attachments/assets/cbed859f-5184-4251-aaf4-b41b51976839 width=500px>


It also adds a token to `jupyterlab-chat`, to allow third party extensions to provide their own message with a plugin. There is no default message in `jupyterlab-chat`.

---

Fixes #217 
Related to https://github.com/jupyterlite/ai/issues/44
