### PR TITLE
Fix scrollbar in empty chat

### DIFF
--- a/packages/jupyter-chat/src/components/chat-messages.tsx
+++ b/packages/jupyter-chat/src/components/chat-messages.tsx
@@ -613,7 +613,10 @@ export function Navigation(props: NavigationProps): JSX.Element {
   // in viewport.
   useEffect(() => {
     const viewportChanged = (model: IChatModel, viewport: number[]) => {
-      setLastInViewport(viewport.includes(model.messages.length - 1));
+      setLastInViewport(
+        model.messages.length === 0 ||
+          viewport.includes(model.messages.length - 1)
+      );
     };
 
     model.viewportChanged?.connect(viewportChanged);

--- a/packages/jupyter-chat/src/components/scroll-container.tsx
+++ b/packages/jupyter-chat/src/components/scroll-container.tsx
@@ -43,7 +43,7 @@ export function ScrollContainer(props: ScrollContainerProps): JSX.Element {
         ...props.sx
       }}
     >
-      <Box sx={{ minHeight: '100.01%' }}>{props.children}</Box>
+      <Box>{props.children}</Box>
       <Box sx={{ overflowAnchor: 'auto', height: '1px' }} />
     </Box>
   );


### PR DESCRIPTION
This PR removes the overflowing size of the chat, which leads to a visible scrollbar on empty chat.
It also removes the navigation bottom button, which was also displayed on empty chat.

Fixes #220

