### PR TITLE
Code highlight in message

### DIFF
--- a/packages/jupyter-chat/package.json
+++ b/packages/jupyter-chat/package.json
@@ -48,6 +48,8 @@
     "@jupyter/react-components": "^0.15.2",
     "@jupyterlab/application": "^4.2.0",
     "@jupyterlab/apputils": "^4.3.0",
+    "@jupyterlab/codeeditor": "^4.2.0",
+    "@jupyterlab/codemirror": "^4.2.0",
     "@jupyterlab/docmanager": "^4.2.0",
     "@jupyterlab/filebrowser": "^4.2.0",
     "@jupyterlab/fileeditor": "^4.2.0",

--- a/packages/jupyter-chat/src/active-cell-manager.ts
+++ b/packages/jupyter-chat/src/active-cell-manager.ts
@@ -13,11 +13,13 @@ import { ISignal, Signal } from '@lumino/signaling';
 type CellContent = {
   type: string;
   source: string;
+  language?: string;
 };
 
 type CellWithErrorContent = {
   type: 'code';
   source: string;
+  language?: string;
   error: {
     name: string;
     value: string;
@@ -148,6 +150,11 @@ export class ActiveCellManager implements IActiveCellManager {
   getContent(withError: true): CellWithErrorContent | null;
   getContent(withError = false): CellContent | CellWithErrorContent | null {
     const sharedModel = this._notebookTracker.activeCell?.model.sharedModel;
+    const language =
+      sharedModel?.cell_type === 'code'
+        ? this._notebookTracker.currentWidget?.model?.defaultKernelLanguage
+        : '';
+
     if (!sharedModel) {
       return null;
     }
@@ -156,7 +163,8 @@ export class ActiveCellManager implements IActiveCellManager {
     if (!withError) {
       return {
         type: sharedModel.cell_type,
-        source: sharedModel.getSource()
+        source: sharedModel.getSource(),
+        language
       };
     }
 
@@ -166,6 +174,7 @@ export class ActiveCellManager implements IActiveCellManager {
       return {
         type: 'code',
         source: sharedModel.getSource(),
+        language,
         error: {
           name: error.ename,
           value: error.evalue,

--- a/packages/jupyter-chat/src/active-cell-manager.ts
+++ b/packages/jupyter-chat/src/active-cell-manager.ts
@@ -153,7 +153,7 @@ export class ActiveCellManager implements IActiveCellManager {
     const language =
       sharedModel?.cell_type === 'code'
         ? this._notebookTracker.currentWidget?.model?.defaultKernelLanguage
-        : '';
+        : undefined;
 
     if (!sharedModel) {
       return null;

--- a/packages/jupyter-chat/src/components/input/buttons/send-button.tsx
+++ b/packages/jupyter-chat/src/components/input/buttons/send-button.tsx
@@ -109,7 +109,7 @@ export function SendButton(
     // Run all chat command providers
     await chatCommandRegistry?.onSubmit(model);
 
-    let language = '';
+    let language: string | undefined;
     if (selectionWatcher?.selection) {
       // Append the selected text if exists.
       source = selectionWatcher.selection.text;
@@ -118,13 +118,13 @@ export function SendButton(
       // Append the active cell content if exists.
       const content = activeCellManager.getContent(false);
       source = content!.source;
-      language = content?.language || '';
+      language = content?.language;
     }
     let content = model.value;
     if (source) {
       content += `
 
-\`\`\`${language}
+\`\`\`${language ?? ''}
 ${source}
 \`\`\`
 `;

--- a/packages/jupyter-chat/src/components/input/buttons/send-button.tsx
+++ b/packages/jupyter-chat/src/components/input/buttons/send-button.tsx
@@ -109,18 +109,21 @@ export function SendButton(
     // Run all chat command providers
     await chatCommandRegistry?.onSubmit(model);
 
+    let language = '';
     if (selectionWatcher?.selection) {
       // Append the selected text if exists.
       source = selectionWatcher.selection.text;
     } else if (activeCellManager?.available) {
       // Append the active cell content if exists.
-      source = activeCellManager.getContent(false)!.source;
+      const content = activeCellManager.getContent(false);
+      source = content!.source;
+      language = content?.language || '';
     }
     let content = model.value;
     if (source) {
       content += `
 
-\`\`\`
+\`\`\`${language}
 ${source}
 \`\`\`
 `;

--- a/packages/jupyter-chat/src/components/input/buttons/send-button.tsx
+++ b/packages/jupyter-chat/src/components/input/buttons/send-button.tsx
@@ -113,6 +113,7 @@ export function SendButton(
     if (selectionWatcher?.selection) {
       // Append the selected text if exists.
       source = selectionWatcher.selection.text;
+      language = selectionWatcher.selection.language;
     } else if (activeCellManager?.available) {
       // Append the active cell content if exists.
       const content = activeCellManager.getContent(false);

--- a/packages/jupyter-chat/src/selection-watcher.ts
+++ b/packages/jupyter-chat/src/selection-watcher.ts
@@ -55,7 +55,7 @@ export namespace SelectionWatcher {
     /**
      * The language of the selection.
      */
-    language: string;
+    language?: string;
     /**
      * The ID of the cell in which the selection was made, if the original widget
      * was a notebook.
@@ -225,7 +225,7 @@ async function getTextSelection(
     [start, end] = [end, start];
   }
 
-  const language = await languages.getLanguage(editor?.model.mimeType);
+  const language = (await languages.getLanguage(editor?.model.mimeType))?.name;
   return {
     ...selectionObj,
     start,
@@ -233,7 +233,10 @@ async function getTextSelection(
     text,
     numLines: text.split('\n').length,
     widgetId: widget.id,
-    language: language?.name || '',
+
+    ...(language && {
+      language
+    }),
     ...(cellId && {
       cellId
     })

--- a/packages/jupyter-chat/src/selection-watcher.ts
+++ b/packages/jupyter-chat/src/selection-watcher.ts
@@ -6,6 +6,10 @@
 import { JupyterFrontEnd } from '@jupyterlab/application';
 import { DocumentWidget } from '@jupyterlab/docregistry';
 import { CodeEditor } from '@jupyterlab/codeeditor';
+import {
+  EditorLanguageRegistry,
+  IEditorLanguageRegistry
+} from '@jupyterlab/codemirror';
 import { Notebook } from '@jupyterlab/notebook';
 
 import { find } from '@lumino/algorithm';
@@ -26,6 +30,10 @@ export namespace SelectionWatcher {
      * The current shell of the application.
      */
     shell: JupyterFrontEnd.IShell;
+    /**
+     * Editor language registry.
+     */
+    languages?: IEditorLanguageRegistry;
   }
 
   /**
@@ -44,6 +52,10 @@ export namespace SelectionWatcher {
      * The ID of the document widget in which the selection was made.
      */
     widgetId: string;
+    /**
+     * The language of the selection.
+     */
+    language: string;
     /**
      * The ID of the cell in which the selection was made, if the original widget
      * was a notebook.
@@ -70,6 +82,7 @@ export interface ISelectionWatcher {
 export class SelectionWatcher {
   constructor(options: SelectionWatcher.IOptions) {
     this._shell = options.shell;
+    this._languages = options.languages || new EditorLanguageRegistry();
     this._shell.currentChanged?.connect((sender, args) => {
       // Do not change the main area widget if the new one has no editor, for example
       // a chat panel. However, the selected text is only available if the main area
@@ -149,12 +162,15 @@ export class SelectionWatcher {
     editor.setSelection({ start: newPosition, end: newPosition });
   }
 
-  protected _poll(): void {
+  protected async _poll(): Promise<void> {
     let currSelection: SelectionWatcher.Selection | null = null;
     const prevSelection = this._selection;
     // Do not return selected text if the main area widget is hidden.
     if (this._mainAreaDocumentWidget?.isVisible) {
-      currSelection = getTextSelection(this._mainAreaDocumentWidget);
+      currSelection = await getTextSelection(
+        this._mainAreaDocumentWidget,
+        this._languages
+      );
     }
     if (prevSelection?.text !== currSelection?.text) {
       this._selection = currSelection;
@@ -169,14 +185,16 @@ export class SelectionWatcher {
     this,
     SelectionWatcher.Selection | null
   >(this);
+  private _languages: IEditorLanguageRegistry;
 }
 
 /**
  * Gets a Selection object from a document widget. Returns `null` if unable.
  */
-function getTextSelection(
-  widget: Widget | null
-): SelectionWatcher.Selection | null {
+async function getTextSelection(
+  widget: Widget | null,
+  languages: IEditorLanguageRegistry
+): Promise<SelectionWatcher.Selection | null> {
   const editor = getEditor(widget);
   // widget type check is redundant but hints the type to TypeScript
   if (!editor || !(widget instanceof DocumentWidget)) {
@@ -207,6 +225,7 @@ function getTextSelection(
     [start, end] = [end, start];
   }
 
+  const language = await languages.getLanguage(editor?.model.mimeType);
   return {
     ...selectionObj,
     start,
@@ -214,6 +233,7 @@ function getTextSelection(
     text,
     numLines: text.split('\n').length,
     widgetId: widget.id,
+    language: language?.name || '',
     ...(cellId && {
       cellId
     })

--- a/packages/jupyterlab-chat-extension/package.json
+++ b/packages/jupyterlab-chat-extension/package.json
@@ -52,6 +52,7 @@
     "@jupyter/ydoc": "^3.0.0",
     "@jupyterlab/application": "^4.4.0",
     "@jupyterlab/apputils": "^4.5.0",
+    "@jupyterlab/codemirror": "^4.4.0",
     "@jupyterlab/coreutils": "^6.4.0",
     "@jupyterlab/docregistry": "^4.4.0",
     "@jupyterlab/filebrowser": "^4.4.0",

--- a/packages/jupyterlab-chat-extension/src/index.ts
+++ b/packages/jupyterlab-chat-extension/src/index.ts
@@ -35,6 +35,7 @@ import {
   createToolbarFactory,
   showErrorMessage
 } from '@jupyterlab/apputils';
+import { IEditorLanguageRegistry } from '@jupyterlab/codemirror';
 import { PathExt } from '@jupyterlab/coreutils';
 import { DocumentRegistry } from '@jupyterlab/docregistry';
 import { IDefaultFileBrowser } from '@jupyterlab/filebrowser';
@@ -813,9 +814,14 @@ const selectionWatcher: JupyterFrontEndPlugin<ISelectionWatcher> = {
   description: 'The selection watcher plugin.',
   autoStart: true,
   provides: ISelectionWatcherToken,
-  activate: (app: JupyterFrontEnd): ISelectionWatcher => {
+  optional: [IEditorLanguageRegistry],
+  activate: (
+    app: JupyterFrontEnd,
+    languages: IEditorLanguageRegistry
+  ): ISelectionWatcher => {
     return new SelectionWatcher({
-      shell: app.shell
+      shell: app.shell,
+      languages
     });
   }
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2269,6 +2269,8 @@ __metadata:
     "@jupyter/react-components": ^0.15.2
     "@jupyterlab/application": ^4.2.0
     "@jupyterlab/apputils": ^4.3.0
+    "@jupyterlab/codeeditor": ^4.2.0
+    "@jupyterlab/codemirror": ^4.2.0
     "@jupyterlab/docmanager": ^4.2.0
     "@jupyterlab/filebrowser": ^4.2.0
     "@jupyterlab/fileeditor": ^4.2.0
@@ -2534,7 +2536,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyterlab/codeeditor@npm:^4.2.3, @jupyterlab/codeeditor@npm:^4.4.3":
+"@jupyterlab/codeeditor@npm:^4.2.0, @jupyterlab/codeeditor@npm:^4.2.3, @jupyterlab/codeeditor@npm:^4.4.3":
   version: 4.4.3
   resolution: "@jupyterlab/codeeditor@npm:4.4.3"
   dependencies:
@@ -2558,7 +2560,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyterlab/codemirror@npm:^4.2.3, @jupyterlab/codemirror@npm:^4.4.3":
+"@jupyterlab/codemirror@npm:^4.2.0, @jupyterlab/codemirror@npm:^4.2.3, @jupyterlab/codemirror@npm:^4.4.0, @jupyterlab/codemirror@npm:^4.4.3":
   version: 4.4.3
   resolution: "@jupyterlab/codemirror@npm:4.4.3"
   dependencies:
@@ -9724,6 +9726,7 @@ __metadata:
     "@jupyterlab/application": ^4.4.0
     "@jupyterlab/apputils": ^4.5.0
     "@jupyterlab/builder": ^4.2.0
+    "@jupyterlab/codemirror": ^4.4.0
     "@jupyterlab/coreutils": ^6.4.0
     "@jupyterlab/docregistry": ^4.4.0
     "@jupyterlab/filebrowser": ^4.4.0


### PR DESCRIPTION
This PR add code highlighting when  it is attached from a cell or a selection.

![image](https://github.com/user-attachments/assets/8fa5091e-a3e3-4ee8-8ee3-639eb03ab4ea)

The language is added to the markdown code block when it is available.

- Code attached from a cell
  Get the language from the `defaultKernelLanguage` of the Notebook metadata. If not defined, there is no syntax highlighting.

- Code attached from a selection
  Retrieve the `DocumentWidget` mimetype from its editor [model](https://github.com/jupyterlab/jupyterlab/blob/1f18828225e5e16c569dcb810eb4c6137cd33d9b/packages/codeeditor/src/editor.ts#L144), and convert it to a language using the [`EditorLanguageRegistry`](https://github.com/jupyterlab/jupyterlab/blob/1f18828225e5e16c569dcb810eb4c6137cd33d9b/packages/codemirror/src/language.ts#L61). 
  If the mimetype cannot be converted to a language,there is no syntax highlighting.

### Context 

Fixes #222
Related to https://github.com/jupyterlab/jupyter-ai/issues/1356