### PR TITLE
Typing notification improvements

### DIFF
--- a/packages/jupyter-chat/src/components/messages/messages.tsx
+++ b/packages/jupyter-chat/src/components/messages/messages.tsx
@@ -14,7 +14,7 @@ import { ChatMessageHeader } from './header';
 import { ChatMessage } from './message';
 import { Navigation } from './navigation';
 import { WelcomeMessage } from './welcome';
-import { Writers } from './writers';
+import { WritingUsersList } from './writers';
 import { IInputToolbarRegistry } from '../input';
 import { ScrollContainer } from '../scroll-container';
 import { IChatCommandRegistry, IMessageFooterRegistry } from '../../registers';
@@ -211,7 +211,7 @@ export function ChatMessages(props: BaseMessageProps): JSX.Element {
           })}
         </Box>
       </ScrollContainer>
-      <Writers writers={currentWriters}></Writers>
+      <WritingUsersList writers={currentWriters}></WritingUsersList>
       <Navigation {...props} refMsgBox={refMsgBox} allRendered={allRendered} />
     </>
   );

--- a/packages/jupyter-chat/src/components/messages/writers.tsx
+++ b/packages/jupyter-chat/src/components/messages/writers.tsx
@@ -4,7 +4,7 @@
  */
 
 import { Box, Typography } from '@mui/material';
-import React from 'react';
+import React, { useMemo } from 'react';
 
 import { Avatar } from '../avatar';
 import { IUser } from '../../types';
@@ -35,7 +35,7 @@ const TypingIndicator = (): JSX.Element => (
 /**
  * The writers component, displaying the current writers.
  */
-export function Writers(props: writersProps): JSX.Element | null {
+export function WritingUsersList(props: writersProps): JSX.Element | null {
   const { writers } = props;
 
   // Don't render if no writers
@@ -45,24 +45,30 @@ export function Writers(props: writersProps): JSX.Element | null {
 
   const writersText = writers.length > 1 ? ' are writing' : ' is writing';
 
+  const writingUsers: JSX.Element[] = useMemo(
+    () =>
+      writers.map((writer, index) => (
+        <Box key={writer.username || index} className="jp-chat-writer-item">
+          <Avatar user={writer} small />
+          <Typography variant="body2" className="jp-chat-writer-name">
+            {writer.display_name ??
+              writer.name ??
+              (writer.username || 'User undefined')}
+          </Typography>
+          {index < writers.length - 1 && (
+            <Typography variant="body2" className="jp-chat-writer-separator">
+              {index < writers.length - 2 ? ', ' : ' and '}
+            </Typography>
+          )}
+        </Box>
+      )),
+    [writers]
+  );
+
   return (
     <Box className={`${WRITERS_CLASS}`}>
       <Box className="jp-chat-writers-content">
-        {writers.map((writer, index) => (
-          <Box key={writer.username || index} className="jp-chat-writer-item">
-            <Avatar user={writer} small />
-            <Typography variant="body2" className="jp-chat-writer-name">
-              {writer.display_name ??
-                writer.name ??
-                (writer.username || 'User undefined')}
-            </Typography>
-            {index < writers.length - 1 && (
-              <Typography variant="body2" className="jp-chat-writer-separator">
-                {index < writers.length - 2 ? ', ' : ' and '}
-              </Typography>
-            )}
-          </Box>
-        ))}
+        {writingUsers}
         <Box className="jp-chat-writing-status">
           <Typography variant="body2" className="jp-chat-writing-text">
             {writersText}

--- a/packages/jupyter-chat/style/chat.css
+++ b/packages/jupyter-chat/style/chat.css
@@ -112,12 +112,10 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  margin-left: 4px;
 }
 
 .jp-chat-writing-text {
   color: var(--jp-ui-font-color2);
-  font-style: italic;
 }
 
 /* Animated typing indicator */


### PR DESCRIPTION
Currently the typing notification "moves down" as more text is added to the chat, which looks a bit odd at first, for example when playing around with Jupyter AI v3:


https://github.com/user-attachments/assets/e5b5555c-e7ef-429e-abd2-09f7c9e6714b



This PR proposes a couple of small improvements:

- make the typing message sticky at the bottom, which is a pattern commonly used in chat apps
- add a three animated dots to give the feeling something is happening


https://github.com/user-attachments/assets/c37c56a8-ab11-4812-8dd9-1a646ae579a9

