### PR TITLE
Clean up dependencies in the Binder environment

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -10,9 +10,4 @@ dependencies:
   - hatchling >=1.5.0
   - hatch-jupyter-builder >=0.3.2
   - hatch-nodejs-version
-  # Use pip to get the the latest version
-  - pip:
-      - jupyter_server >=2.0.1,<3
-      - jupyter_collaboration >=2.1.4,<3
-      - jupyter_ydoc
-      - pycrdt
+


### PR DESCRIPTION
Checking if we still need these dependencies to be listed in the Binder environment.

Especially since they appear to be outdated, and already defined here?

https://github.com/jupyterlab/jupyter-chat/blob/825371829006c86814375c76220a5abc688a296b/python/jupyterlab-chat/pyproject.toml#L29-L34