### PR TITLE
Allow users to be mentioned via Python API

### DIFF
--- a/python/jupyterlab-chat/jupyterlab_chat/models.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/models.py
@@ -75,11 +75,14 @@ class NewMessage:
 class User(JupyterUser):
     """ Object representing a user """
 
-    mention_name: Optional[str] = None
-    """ The string to use as mention in chat """
-
     bot: Optional[bool] = None
     """ Boolean identifying if user is a bot """
+
+    @property
+    def mention_name(self) -> str:
+        name: str = self.display_name or self.name or self.username
+        name = name.replace(" ", "-")
+        return name
 
 
 @dataclass

--- a/python/jupyterlab-chat/jupyterlab_chat/tests/test_ychat.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/tests/test_ychat.py
@@ -22,6 +22,11 @@ USER2 = User(
     display_name="Test user 2"
 )
 
+USER3 = User(
+    username=str(uuid4()),
+    name="Test user 3",
+    display_name="Test user 3"
+)
 
 def create_new_message(body="This is a test message") -> NewMessage:
     return NewMessage(
@@ -42,6 +47,11 @@ def test_add_user():
     chat.set_user(USER)
     assert USER.username in chat._get_users().keys()
     assert chat._get_users()[USER.username] == asdict(USER)
+
+def test_mention_names():
+    assert USER.mention_name == "Test-user"
+    assert USER2.mention_name == "Test-user-2"
+    assert USER3.mention_name == "Test-user-3"
 
 
 def test_get_user_type():
@@ -82,6 +92,21 @@ def test_add_message():
     message_dict = chat._get_messages()[0]
     assert message_dict["body"] == msg.body
     assert message_dict["sender"] == msg.sender
+
+
+def test_add_message_includes_mentions():
+    chat = YChat()
+    chat.set_user(USER)
+    chat.set_user(USER2)
+    chat.set_user(USER3)
+
+    new_msg = create_new_message(
+        f"@{USER2.mention_name} @{USER3.mention_name} Hello!"
+    )
+    msg_id = chat.add_message(new_msg)
+    msg = chat.get_message(msg_id)
+
+    assert set(msg.mentions) == set([USER2.username, USER3.username])
 
 
 def test_get_message_should_return_the_message():


### PR DESCRIPTION
## Description

- Addresses https://github.com/jupyterlab/jupyter-ai/issues/1365
- Updates the `YChat.add_message()` method to parse for `@`-mentions using the same logic implemented in the frontend. 
- `@`-mentioned usernames are added to the `mentions` field of the new message.
- `YChat.mention_name` has been updated to be a computed property that will always be defined, ensuring type safety.
- Adds unit test coverage for this change.