### PR TITLE
Don't render deleted messages

### DIFF
--- a/packages/jupyter-chat/src/components/messages/messages.tsx
+++ b/packages/jupyter-chat/src/components/messages/messages.tsx
@@ -115,7 +115,12 @@ export function ChatMessages(props: BaseMessageProps): JSX.Element {
     const observer = new IntersectionObserver(entries => {
       // Used on first rendering, to ensure all the message as been rendered once.
       if (!allRendered) {
-        Promise.all(renderedPromise.current.map(p => p.promise)).then(() => {
+        const activePromises = renderedPromise.current
+          // Filter out nulls signigying deleted messages
+          .filter(p => p)
+          .map(p => p.promise);
+
+        Promise.all(activePromises).then(() => {
           setAllRendered(true);
         });
       }
@@ -181,6 +186,11 @@ export function ChatMessages(props: BaseMessageProps): JSX.Element {
         )}
         <Box ref={refMsgBox} className={clsx(MESSAGES_BOX_CLASS)}>
           {messages.map((message, i) => {
+            // Skip rendering deleted messages while preventing sparse array
+            if (message.deleted) {
+              listRef.current[i] = null;
+              return null;
+            }
             renderedPromise.current[i] = new PromiseDelegate();
             return (
               // extra div needed to ensure each bubble is on a new line

--- a/packages/jupyter-chat/src/components/messages/messages.tsx
+++ b/packages/jupyter-chat/src/components/messages/messages.tsx
@@ -116,7 +116,7 @@ export function ChatMessages(props: BaseMessageProps): JSX.Element {
       // Used on first rendering, to ensure all the message as been rendered once.
       if (!allRendered) {
         const activePromises = renderedPromise.current
-          // Filter out nulls signigying deleted messages
+          // Filter out nulls signifying deleted messages
           .filter(p => p)
           .map(p => p.promise);
 

--- a/ui-tests/tests/message-toolbar.spec.ts
+++ b/ui-tests/tests/message-toolbar.spec.ts
@@ -129,20 +129,27 @@ test.describe('#messageToolbar', () => {
     ).not.toContain('(edited)');
   });
 
-  test('should set the message as deleted', async ({ page }) => {
+  test('should not render deleted message', async ({ page }) => {
     const chatPanel = await openChat(page, FILENAME);
-    const message = chatPanel
-      .locator('.jp-chat-messages-container .jp-chat-message')
-      .first();
+    const messagesContainer = chatPanel.locator('.jp-chat-messages-container');
+
+    const messageCountBefore = await messagesContainer
+      .locator('.jp-chat-message')
+      .count();
+    expect(messageCountBefore).toBe(1);
+
+    const message = messagesContainer.locator('.jp-chat-message').first();
     const messageContent = message.locator('.jp-chat-rendered-markdown');
 
     // Should display the message toolbar
     await messageContent.hover({ position: { x: 5, y: 5 } });
     await messageContent.locator('.jp-chat-toolbar jp-button').last().click();
 
-    await expect(messageContent).not.toBeVisible();
-    expect(
-      await message.locator('.jp-chat-message-header').textContent()
-    ).toContain('(message deleted)');
+    await expect(message).not.toBeVisible();
+
+    const messageCountAfter = await messagesContainer
+      .locator('.jp-chat-message')
+      .count();
+    expect(messageCountAfter).toBe(0);
   });
 });


### PR DESCRIPTION
### Problem

Currently when message is deleted it is still rendered in UI as `(message deleted)`. It seems to not bring any useful information and increase visual clutter.

### Proposed solution 

Do not render deleted messages. 

#### Before this PR:
![Screenshot 2025-06-18 at 5 21 05 PM](https://github.com/user-attachments/assets/27a1e949-9a67-4ef8-921e-4e5c0700d216)
![Screenshot 2025-06-18 at 5 21 18 PM](https://github.com/user-attachments/assets/220ea62f-d9ea-4d50-ac97-028e6dea9c20)
![Screenshot 2025-06-18 at 5 22 10 PM](https://github.com/user-attachments/assets/d9ea77da-ea09-4f4f-9e5d-746a60574275)

#### After this PR:
![Screenshot 2025-06-18 at 5 24 29 PM](https://github.com/user-attachments/assets/b5764883-49bc-43c6-a666-c716785fc734)
![Screenshot 2025-06-18 at 5 24 33 PM](https://github.com/user-attachments/assets/efb3d5f9-258b-4a94-b778-28804d3aab3b)
![Screenshot 2025-06-18 at 5 25 03 PM](https://github.com/user-attachments/assets/254fc0bb-9a17-4b96-b841-aa0a928278a7)
