### PR TITLE
Create new chat files in filebrowser's current directory when creating from launcher 

### DIFF
--- a/packages/jupyterlab-chat-extension/src/index.ts
+++ b/packages/jupyterlab-chat-extension/src/index.ts
@@ -399,6 +399,7 @@ const chatCommands: JupyterFrontEndPlugin<void> = {
       icon: args => (args.isPalette ? undefined : chatIcon),
       execute: async args => {
         const inSidePanel: boolean = (args.inSidePanel as boolean) ?? false;
+        const targetDirectory: string | undefined = args.path as string;
         let name: string | null = (args.name as string) ?? null;
         let filepath = '';
         if (!name) {
@@ -425,10 +426,15 @@ const chatCommands: JupyterFrontEndPlugin<void> = {
           // as "Open a chat" dropdown only discovers chat files in default
           // dir. Create new chat in file browser cwd if created from main
           // area (launcher, menu, palette).
-          if (inSidePanel) {
+          if (targetDirectory !== undefined) {
+            // Explicit directory provided - use it
+            filepath = PathExt.join(targetDirectory, filepath);
+          } else if (inSidePanel) {
+            // Side panel uses default directory
             const defaultDir = widgetConfig.config.defaultDirectory ?? '';
             filepath = PathExt.join(defaultDir, filepath);
           } else {
+            // Main area uses filebrowser cwd
             const cwd = filebrowser?.model.path ?? '';
             filepath = PathExt.join(cwd, filepath);
           }

--- a/ui-tests/tests/attachments.spec.ts
+++ b/ui-tests/tests/attachments.spec.ts
@@ -14,8 +14,9 @@ test.describe('#attachments', () => {
   let chatPath: string;
   test.beforeEach(async ({ page, tmpPath }) => {
     chatPath = PathExt.join(tmpPath, CHAT);
+
     // Create a chat, a notebook and a markdown file.
-    await createChat(page, chatPath);
+    await createChat(page, CHAT, false, tmpPath);
     await page.menu.clickMenuItem('File>New>Markdown File');
     await page.notebook.createNew(NOTEBOOK);
 
@@ -176,7 +177,7 @@ test.describe('#attachmentOpenerRegistry', () => {
     });
 
     const chatPath = PathExt.join(tmpPath, CHAT);
-    await createChat(page, chatPath);
+    await createChat(page, CHAT, false, tmpPath);
     const chatPanel = await openChat(page, chatPath);
 
     const input = chatPanel.locator('.jp-chat-input-container');

--- a/ui-tests/tests/chat-file.spec.ts
+++ b/ui-tests/tests/chat-file.spec.ts
@@ -48,7 +48,7 @@ test.describe('#chatCreation', () => {
   });
 
   test('should create a file in root directory', async ({ page }) => {
-    await createChat(page, CHAT_NAME);
+    await createChat(page, CHAT_NAME, true);
     expect(await page.filebrowser.contents.fileExists(FILENAME)).toBeTruthy();
   });
 

--- a/ui-tests/tests/input-toolbar.spec.ts
+++ b/ui-tests/tests/input-toolbar.spec.ts
@@ -45,7 +45,7 @@ test.describe('#inputToolbar', () => {
     });
 
     const chatPath = PathExt.join(tmpPath, CHAT);
-    await createChat(page, chatPath);
+    await createChat(page, CHAT, false, tmpPath);
     const chatPanel = await openChat(page, chatPath);
 
     // The main area chat input should not contain the 'attach' button.

--- a/ui-tests/tests/test-utils.ts
+++ b/ui-tests/tests/test-utils.ts
@@ -22,16 +22,25 @@ export const USER: User.IUser = {
 export const createChat = async (
   page: IJupyterLabPageFixture,
   filename: string,
-  inSidePanel: boolean = false
+  inSidePanel: boolean = false,
+  path?: string
 ): Promise<void> => {
   await page.evaluate(
-    async ({ name, inSidePanel }: { name: string; inSidePanel: boolean }) => {
+    async ({
+      name,
+      inSidePanel,
+      path
+    }: {
+      name: string;
+      inSidePanel: boolean;
+    }) => {
       await window.jupyterapp.commands.execute('jupyterlab-chat:create', {
         name,
-        inSidePanel
+        inSidePanel,
+        ...(path !== undefined && { path })
       });
     },
-    { name: filename, inSidePanel }
+    { name: filename, inSidePanel, path }
   );
 };
 


### PR DESCRIPTION
### Problem

There is no way to create chat files in non-default directory. 

### Proposed solution

Create new chat files in filebrowser's current directory when creating from launcher, via `menu>new>chat`, or via command palette (same as in JupyterLab). 

Sidepanel experience remains the same: chats created via sidepanel "+ Chat" button are created in the default dir to be automatically discovered and added to the "Open a chat" dropdown (as only chat files in default dir are discovered).

* Fixes https://github.com/jupyterlab/jupyter-ai/issues/1363.

### Demo

![demo_new_chat](https://github.com/user-attachments/assets/379cf780-0c14-4cba-8766-1f93ba312737)

