### PR TITLE
Make `user.mention_name` optional in frontend

### DIFF
--- a/packages/jupyter-chat/src/types.ts
+++ b/packages/jupyter-chat/src/types.ts
@@ -14,14 +14,14 @@ export interface IUser {
   color?: string;
   avatar_url?: string;
   /**
-   * The string to use to mention a user in the chat. This is computed via the
-   * following procedure:
+   * The string to use to mention a user in the chat. This should be computed
+   * via the following procedure:
    *
    * 1. Let `mention_name = user.display_name || user.name || user.username`.
    *
    * 2. Replace each ' ' character with '-' in `mention_name`.
    */
-  mention_name: string;
+  mention_name?: string;
   /**
    * Boolean identifying if user is a bot.
    */

--- a/packages/jupyterlab-chat-extension/src/chat-commands/providers/user-mention.tsx
+++ b/packages/jupyterlab-chat-extension/src/chat-commands/providers/user-mention.tsx
@@ -126,6 +126,8 @@ class MentionCommandProvider implements IChatCommandProvider {
    */
   _getUsers(inputModel: IInputModel): Map<string, Private.CommandUser> {
     const users = new Map();
+    // chatContext should be of type `LabChatContext`, so `users` should be of
+    // type `LabChatUser[]`, where `mention_name` is always defined.
     const userList = inputModel.chatContext.users;
     userList.forEach(user => {
       users.set(user.mention_name, {

--- a/packages/jupyterlab-chat-extension/src/chat-commands/providers/user-mention.tsx
+++ b/packages/jupyterlab-chat-extension/src/chat-commands/providers/user-mention.tsx
@@ -130,6 +130,14 @@ class MentionCommandProvider implements IChatCommandProvider {
     // type `LabChatUser[]`, where `mention_name` is always defined.
     const userList = inputModel.chatContext.users;
     userList.forEach(user => {
+      if (!user.mention_name) {
+        console.error(
+          `No 'mention_name' property for user '${user.username}'. ` +
+            'This user is being omitted from ' +
+            "'MentionCommandProvider._getUsers()'."
+        );
+        return;
+      }
       users.set(user.mention_name, {
         user,
         icon: <Avatar user={user} />

--- a/packages/jupyterlab-chat/src/model.ts
+++ b/packages/jupyterlab-chat/src/model.ts
@@ -509,9 +509,9 @@ export class LabChatContext extends AbstractChatContext {
   /**
    * The list of users who have connected to this chat.
    */
-  get users(): IUser[] {
+  get users(): LabChatUser[] {
     const model = this._model as LabChatModel;
-    const users: Record<string, IUser> = {};
+    const users: Record<string, LabChatUser> = {};
 
     // Add existing users from the YChat
     // This only includes users who have sent a message in the chat.


### PR DESCRIPTION
## Description

- Closes #245.

Makes `user.mention_name` optional in the frontend. See discussion in #245 for context.