### PR TITLE
Return docmanager widget from createChat/openChat commands to ensure launcher disposal

### DIFF
--- a/packages/jupyterlab-chat-extension/src/index.ts
+++ b/packages/jupyterlab-chat-extension/src/index.ts
@@ -487,7 +487,7 @@ const chatCommands: JupyterFrontEndPlugin<void> = {
             inSidePanel
           });
         } else {
-          commands.execute('docmanager:open', {
+          return commands.execute('docmanager:open', {
             // TODO: support JCollab v3 by optionally prefixing 'RTC:'
             path: `${filepath}`,
             factory: FACTORY
@@ -640,7 +640,7 @@ const chatCommands: JupyterFrontEndPlugin<void> = {
             } else {
               // The chat is opened in the main area
               // TODO: support JCollab v3 by optionally prefixing 'RTC:'
-              commands.execute('docmanager:open', {
+              return commands.execute('docmanager:open', {
                 path: `${filepath}`,
                 factory: FACTORY
               });


### PR DESCRIPTION
### References

* Fixes #256
> In JupyterLab, the launcher closes when you create a new document on widget from it. Basically, the new doc replaces the launcher. In Jupyter Chat, when you create a chat file from the launcher, the launcher stays open. 

### Code changes

Returns docmanager widget from createChat/openChat commands to ensure proper launcher disposal.

### User-facing changes

New chats created in main area replace launcher.

### Backwards-incompatible changes

None.

Before this PR: 
![Kapture 2025-07-24 at 15 14 08-2](https://github.com/user-attachments/assets/f5bba067-dd9c-44d5-9fee-6592c4fcac6e)

After this PR:
![tab_replaced](https://github.com/user-attachments/assets/a1d55c38-74f4-40b1-a050-bd0556133098)
