### PR TITLE
Log warning instead of showing error dialog when chat file path not found during startup restoration

### DIFF
--- a/packages/jupyterlab-chat-extension/src/index.ts
+++ b/packages/jupyterlab-chat-extension/src/index.ts
@@ -346,7 +346,8 @@ const docFactories: JupyterFrontEndPlugin<IChatFactory> = {
         command: CommandIDs.openChat,
         args: widget => ({
           filepath: widget.model.name ?? '',
-          inSidePanel: widget instanceof ChatWidget
+          inSidePanel: widget instanceof ChatWidget,
+          startup: true
         }),
         name: widget => widget.model.name,
         when: openCommandReady.promise
@@ -551,11 +552,14 @@ const chatCommands: JupyterFrontEndPlugin<void> = {
          *
          * args:
          *  filepath - the chat file to open.
+         *  startup - optional (default to false).
+         *            Whether the command is called during startup restoration.
          */
         commands.addCommand(CommandIDs.openChat, {
           label: 'Open a chat',
           execute: async args => {
             const inSidePanel: boolean = (args.inSidePanel as boolean) ?? false;
+            const startup: boolean = (args.startup as boolean) ?? false;
             let filepath: string | null = (args.filepath as string) ?? null;
             if (filepath === null) {
               filepath = (
@@ -579,10 +583,16 @@ const chatCommands: JupyterFrontEndPlugin<void> = {
               });
 
             if (!fileExist) {
-              showErrorMessage(
-                'Error opening chat',
-                `'${filepath}' is not a valid path`
-              );
+              if (startup) {
+                console.warn(
+                  `Chat file '${filepath}' not found during startup restoration`
+                );
+              } else {
+                showErrorMessage(
+                  'Error opening chat',
+                  `'${filepath}' is not a valid path`
+                );
+              }
               return;
             }
 


### PR DESCRIPTION
### References 

* Fixes #239 

### Code changes 

* Added `startup` parameter to `openChat` command to distinguish startup restoration from intentional file opening
* Updated layout restorer to pass `startup: true` during workspace restoration
* Modified error handling to log warning instead of showing error dialog when chat path not found during startup restoration

### User-facing changes 

During startup restoration, console warnings is logged (visible in browser dev tools) instead of showing error dialog when chat path is not found. 

Before this PR:
<img width="1090" height="524" alt="image" src="https://github.com/user-attachments/assets/fde28acd-d17f-4374-9f51-92668232e627" />

After this PR:
<img width="671" height="38" alt="Screenshot 2025-07-24 at 4 38 11 PM" src="https://github.com/user-attachments/assets/39ecae8f-c640-45b3-af08-bd9e4e13d63b" />