### PR TITLE
Improve file event handling in side panel

### DIFF
--- a/packages/jupyterlab-chat-extension/src/index.ts
+++ b/packages/jupyterlab-chat-extension/src/index.ts
@@ -760,23 +760,6 @@ const chatPanel: JupyterFrontEndPlugin<ChatPanel> = {
       restorer.add(chatPanel, 'jupyter-chat');
     }
 
-    // Use events system to watch changes on files, and update the chat list if a chat
-    // file has been created, deleted or renamed.
-    const schemaID =
-      'https://events.jupyter.org/jupyter_server/contents_service/v1';
-    const actions = ['create', 'delete', 'rename'];
-    app.serviceManager.events.stream.connect((_, emission) => {
-      if (emission.schema_id === schemaID) {
-        const action = emission.action as string;
-        if (
-          actions.includes(action) &&
-          (emission.path as string).endsWith(chatFileType.extensions[0])
-        ) {
-          chatPanel.updateChatList();
-        }
-      }
-    });
-
     /*
      * Command to move a chat from the main area to the side panel.
      */

--- a/packages/jupyterlab-chat/src/widget.tsx
+++ b/packages/jupyterlab-chat/src/widget.tsx
@@ -137,6 +137,24 @@ export class ChatPanel extends SidePanel {
 
     const content = this.content as AccordionPanel;
     content.expansionToggled.connect(this._onExpansionToggled, this);
+
+    this._contentsManager.fileChanged.connect((_, args) => {
+      if (args.type === 'delete') {
+        this.widgets.forEach(widget => {
+          if ((widget as ChatSection).path === args.oldValue?.path) {
+            widget.dispose();
+          }
+        });
+        this.updateChatList();
+      }
+      const updateActions = ['new', 'rename'];
+      if (
+        updateActions.includes(args.type) &&
+        args.newValue?.path?.endsWith(chatFileType.extensions[0])
+      ) {
+        this.updateChatList();
+      }
+    });
   }
 
   /**
@@ -238,7 +256,7 @@ export class ChatPanel extends SidePanel {
   /**
    * A message handler invoked on an `'after-show'` message.
    */
-  protected onAfterShow(msg: Message): void {
+  protected onAfterAttach(msg: Message): void {
     // Wait for the component to be rendered.
     this._openChat.renderPromise?.then(() => this.updateChatList());
   }


### PR DESCRIPTION
Follow up #259 (https://github.com/jupyterlab/jupyter-chat/pull/259#discussion_r2229948177) to dispose of the widget in side panel when a file is deleted.
Related to #239 

### Changes
- Do not rely anymore on the event system of Jupyter to update the chat list in the side panel, but rather on the signal of the content manager.
- dispose of the chat widget (in the side panel) if the file is deleted. This automatically removes the chat from from the restorer, which fixes #239.
- avoid updating the file list every time the side panel is shown, only when it is attached.