### PR TITLE
Fix chat focus behavior to allow copy/paste from messages

### DIFF
--- a/packages/jupyter-chat/src/components/messages/messages.tsx
+++ b/packages/jupyter-chat/src/components/messages/messages.tsx
@@ -21,8 +21,8 @@ import { IChatCommandRegistry, IMessageFooterRegistry } from '../../registers';
 import { IChatModel } from '../../model';
 import { IChatMessage, IUser } from '../../types';
 
+export const MESSAGE_CLASS = 'jp-chat-message';
 const MESSAGES_BOX_CLASS = 'jp-chat-messages-container';
-const MESSAGE_CLASS = 'jp-chat-message';
 const MESSAGE_STACKED_CLASS = 'jp-chat-message-stacked';
 
 /**

--- a/packages/jupyter-chat/src/widgets/chat-widget.tsx
+++ b/packages/jupyter-chat/src/widgets/chat-widget.tsx
@@ -43,15 +43,26 @@ export class ChatWidget extends ReactWidget {
     this.id = `jupyter-chat::widget::${options.model.name}`;
     this.node.addEventListener('click', (event: MouseEvent) => {
       const target = event.target as HTMLElement;
-      const selection = window.getSelection();
-      const hasTextSelected =
-        selection &&
-        selection.toString().length > 0 &&
-        target.closest(`.${MESSAGE_CLASS}`);
-
-      if (!hasTextSelected && !target.closest(`.${MESSAGE_CLASS}`)) {
-        this.model.input.focus();
+      if (
+        target.closest('button, a, input, textarea, select, summary, details')
+      ) {
+        return;
       }
+
+      const message = target.closest(`.${MESSAGE_CLASS}`);
+      if (message) {
+        const selection = window.getSelection();
+
+        if (
+          selection &&
+          selection.toString().trim() !== '' &&
+          message.contains(selection.anchorNode)
+        ) {
+          return;
+        }
+      }
+
+      this.model.input.focus();
     });
   }
 

--- a/packages/jupyter-chat/src/widgets/chat-widget.tsx
+++ b/packages/jupyter-chat/src/widgets/chat-widget.tsx
@@ -11,7 +11,7 @@ import React from 'react';
 import { Message } from '@lumino/messaging';
 import { Drag } from '@lumino/dragdrop';
 
-import { Chat, IInputToolbarRegistry } from '../components';
+import { Chat, IInputToolbarRegistry, MESSAGE_CLASS } from '../components';
 import { chatIcon } from '../icons';
 import { IChatModel } from '../model';
 import {
@@ -20,7 +20,6 @@ import {
   INotebookAttachmentCell
 } from '../types';
 import { ActiveCellManager } from '../active-cell-manager';
-import { MESSAGE_CLASS } from '../components/messages/messages';
 
 // MIME type constant for file browser drag events
 const FILE_BROWSER_MIME = 'application/x-jupyter-icontentsrich';

--- a/packages/jupyter-chat/src/widgets/chat-widget.tsx
+++ b/packages/jupyter-chat/src/widgets/chat-widget.tsx
@@ -30,6 +30,7 @@ const NOTEBOOK_CELL_MIME = 'application/vnd.jupyter.cells';
 // CSS class constants
 const INPUT_CONTAINER_CLASS = 'jp-chat-input-container';
 const DRAG_HOVER_CLASS = 'jp-chat-drag-hover';
+const MESSAGE_CLASS = 'jp-chat-message';
 
 export class ChatWidget extends ReactWidget {
   constructor(options: Chat.IOptions) {
@@ -40,7 +41,12 @@ export class ChatWidget extends ReactWidget {
 
     this._chatOptions = options;
     this.id = `jupyter-chat::widget::${options.model.name}`;
-    this.node.onclick = () => this.model.input.focus();
+    this.node.addEventListener('click', (event: MouseEvent) => {
+      const target = event.target as HTMLElement;
+      if (!target.closest(`.${MESSAGE_CLASS}`)) {
+        this.model.input.focus();
+      }
+    });
   }
 
   /**

--- a/packages/jupyter-chat/src/widgets/chat-widget.tsx
+++ b/packages/jupyter-chat/src/widgets/chat-widget.tsx
@@ -20,6 +20,7 @@ import {
   INotebookAttachmentCell
 } from '../types';
 import { ActiveCellManager } from '../active-cell-manager';
+import { MESSAGE_CLASS } from '../components/messages/messages';
 
 // MIME type constant for file browser drag events
 const FILE_BROWSER_MIME = 'application/x-jupyter-icontentsrich';
@@ -30,7 +31,6 @@ const NOTEBOOK_CELL_MIME = 'application/vnd.jupyter.cells';
 // CSS class constants
 const INPUT_CONTAINER_CLASS = 'jp-chat-input-container';
 const DRAG_HOVER_CLASS = 'jp-chat-drag-hover';
-const MESSAGE_CLASS = 'jp-chat-message';
 
 export class ChatWidget extends ReactWidget {
   constructor(options: Chat.IOptions) {
@@ -43,7 +43,13 @@ export class ChatWidget extends ReactWidget {
     this.id = `jupyter-chat::widget::${options.model.name}`;
     this.node.addEventListener('click', (event: MouseEvent) => {
       const target = event.target as HTMLElement;
-      if (!target.closest(`.${MESSAGE_CLASS}`)) {
+      const selection = window.getSelection();
+      const hasTextSelected =
+        selection &&
+        selection.toString().length > 0 &&
+        target.closest(`.${MESSAGE_CLASS}`);
+
+      if (!hasTextSelected && !target.closest(`.${MESSAGE_CLASS}`)) {
         this.model.input.focus();
       }
     });

--- a/packages/jupyter-chat/src/widgets/chat-widget.tsx
+++ b/packages/jupyter-chat/src/widgets/chat-widget.tsx
@@ -42,9 +42,7 @@ export class ChatWidget extends ReactWidget {
     this.id = `jupyter-chat::widget::${options.model.name}`;
     this.node.addEventListener('click', (event: MouseEvent) => {
       const target = event.target as HTMLElement;
-      if (
-        target.closest('button, a, input, textarea, select, summary, details')
-      ) {
+      if (this.node.contains(document.activeElement)) {
         return;
       }
 


### PR DESCRIPTION
Previously, clicking anywhere in the chat panel forced focus onto the input (`this.node.onclick = () => this.model.input.focus();`). This made it difficult to select or copy text from the chat history, since every click redirected focus.

Now we check if the user has selected text input loses focus, click on `button`,` interactive elements`, `<details>`, `<summary>` and else work like before



https://github.com/user-attachments/assets/4f9b995e-01f2-4b29-be33-ed6597782000




Closes #267 