### PR TITLE
Refactor `buildChatSidebar` to use `ChatWidget` class.

### DIFF
--- a/packages/jupyter-chat/src/widgets/chat-sidebar.tsx
+++ b/packages/jupyter-chat/src/widgets/chat-sidebar.tsx
@@ -3,16 +3,14 @@
  * Distributed under the terms of the Modified BSD License.
  */
 
-import { ReactWidget } from '@jupyterlab/apputils';
-import React from 'react';
-
 import { Chat } from '../components/chat';
 import { chatIcon } from '../icons';
+import { ChatWidget } from './chat-widget';
 
-export function buildChatSidebar(options: Chat.IOptions): ReactWidget {
-  const ChatWidget = ReactWidget.create(<Chat {...options} />);
-  ChatWidget.id = 'jupyter-chat::side-panel';
-  ChatWidget.title.icon = chatIcon;
-  ChatWidget.title.caption = 'Jupyter Chat'; // TODO: i18n
-  return ChatWidget;
+export function buildChatSidebar(options: Chat.IOptions): ChatWidget {
+  const widget = new ChatWidget(options);
+  widget.id = 'jupyter-chat::side-panel';
+  widget.title.icon = chatIcon;
+  widget.title.caption = 'Jupyter Chat'; // TODO: i18n
+  return widget;
 }


### PR DESCRIPTION
This PR updates the `buildChatSidebar` helper to use the `ChatWidget` class instead of creating ReactWidget from the Chat component.

Previously, the sidebar widget did not include logic implemented in `ChatWidget`, such as:

- Drag-and-drop support for files and notebook cells

- Focusing the input on click

By switching to `ChatWidget`, the sidebar now gains these features for a consistent user experience across both the main area and the sidebar.

- Closes #283 