### PR TITLE
Multichat: wait for the chat to be opened in main before disposing of the widget

### DIFF
--- a/packages/jupyter-chat/src/widgets/multichat-panel.tsx
+++ b/packages/jupyter-chat/src/widgets/multichat-panel.tsx
@@ -279,7 +279,7 @@ export class MultiChatPanel extends SidePanel {
     name?: string
   ) => Promise<MultiChatPanel.IAddChatArgs>;
   private _getChatNames?: () => Promise<{ [name: string]: string }>;
-  private _openInMain?: (name: string) => void;
+  private _openInMain?: (name: string) => Promise<boolean>;
   private _renameChat?: (oldName: string, newName: string) => Promise<boolean>;
 
   private _openChatWidget?: ReactWidget;
@@ -317,7 +317,7 @@ export namespace MultiChatPanel {
      *
      * @param name - the name of the chat to move.
      */
-    openInMain?: (name: string) => void;
+    openInMain?: (name: string) => Promise<boolean>;
     /**
      * An optional callback to rename a chat.
      *
@@ -406,11 +406,12 @@ export class ChatSection extends PanelWithToolbar {
         icon: launchIcon,
         iconLabel: 'Move the chat to the main area',
         className: 'jp-mod-styled',
-        onClick: () => {
+        onClick: async () => {
           const name = this.model.name;
-          this.model.dispose();
-          options.openInMain?.(name);
-          this.dispose();
+          if (await options.openInMain?.(name)) {
+            this.model.dispose();
+            this.dispose();
+          }
         }
       });
       this.toolbar.addItem('moveMain', moveToMain);
@@ -521,7 +522,7 @@ export namespace ChatSection {
      *
      * @param name - the name of the chat to move.
      */
-    openInMain?: (name: string) => void;
+    openInMain?: (name: string) => Promise<boolean>;
     /**
      * An optional callback to rename a chat.
      *

--- a/packages/jupyterlab-chat-extension/src/index.ts
+++ b/packages/jupyterlab-chat-extension/src/index.ts
@@ -595,7 +595,7 @@ const chatCommands: JupyterFrontEndPlugin<void> = {
          */
         commands.addCommand(CommandIDs.openChat, {
           label: 'Open a chat',
-          execute: async args => {
+          execute: async (args): Promise<any> => {
             const inSidePanel: boolean = (args.inSidePanel as boolean) ?? false;
             const startup: boolean = (args.startup as boolean) ?? false;
             let filepath: string | null = (args.filepath as string) ?? null;
@@ -610,7 +610,7 @@ const chatCommands: JupyterFrontEndPlugin<void> = {
             }
 
             if (!filepath) {
-              return;
+              return false;
             }
 
             let fileExist = true;
@@ -631,7 +631,7 @@ const chatCommands: JupyterFrontEndPlugin<void> = {
                   `'${filepath}' is not a valid path`
                 );
               }
-              return;
+              return false;
             }
 
             if (inSidePanel && chatPanel) {
@@ -655,7 +655,7 @@ const chatCommands: JupyterFrontEndPlugin<void> = {
               }
 
               if (chatPanel.openIfExists(filepath)) {
-                return;
+                return true;
               }
 
               const addChatArgs = await createChatModel(app, drive, filepath);
@@ -670,6 +670,7 @@ const chatCommands: JupyterFrontEndPlugin<void> = {
                 factory: FACTORY
               });
             }
+            return false;
           }
         });
 
@@ -835,7 +836,9 @@ const chatPanel: JupyterFrontEndPlugin<MultiChatPanel> = {
         );
       },
       openInMain: path => {
-        commands.execute(CommandIDs.openChat, { filepath: path });
+        return commands.execute(CommandIDs.openChat, {
+          filepath: path
+        }) as Promise<boolean>;
       },
       renameChat: (oldPath, newPath) => {
         return commands.execute(CommandIDs.renameChat, {


### PR DESCRIPTION
This PR updates the function called when moving a chat from the multi chat panel to the main area.
It now waits for the main area widget to be opened before disposing of the widget in the side panel.