### PR TITLE
Lift the typing indicator out of the input component

### DIFF
--- a/packages/jupyter-chat/src/components/index.ts
+++ b/packages/jupyter-chat/src/components/index.ts
@@ -11,3 +11,4 @@ export * from './jl-theme-provider';
 export * from './messages';
 export * from './mui-extras';
 export * from './scroll-container';
+export * from './writing-indicator';

--- a/packages/jupyter-chat/src/components/input/chat-input.tsx
+++ b/packages/jupyter-chat/src/components/input/chat-input.tsx
@@ -19,8 +19,6 @@ import { useChatCommands } from './use-chat-commands';
 import { AttachmentPreviewList } from '../attachments';
 import { useChatContext } from '../../context';
 import { IInputModel, InputModel } from '../../input-model';
-import { IChatModel } from '../../model';
-import { InputWritingIndicator } from './writing-indicator';
 import { IAttachment } from '../../types';
 
 const INPUT_BOX_CLASS = 'jp-chat-input-container';
@@ -46,7 +44,6 @@ export function ChatInput(props: ChatInput.IProps): JSX.Element {
   const [toolbarElements, setToolbarElements] = useState<
     InputToolbarRegistry.IToolbarItem[]
   >([]);
-  const [writers, setWriters] = useState<IChatModel.IWriter[]>([]);
 
   /**
    * Auto-focus the input when the component is first mounted.
@@ -108,30 +105,6 @@ export function ChatInput(props: ChatInput.IProps): JSX.Element {
       inputToolbarRegistry?.itemsChanged.disconnect(updateToolbar);
     };
   }, [inputToolbarRegistry]);
-
-  /**
-   * Handle the changes in the writers list.
-   */
-  useEffect(() => {
-    if (!chatModel) {
-      return;
-    }
-
-    const updateWriters = (_: IChatModel, writers: IChatModel.IWriter[]) => {
-      // Show all writers for now - AI generating responses will have messageID
-      setWriters(writers);
-    };
-
-    // Set initial writers state
-    const initialWriters = chatModel.writers;
-    setWriters(initialWriters);
-
-    chatModel.writersChanged?.connect(updateWriters);
-
-    return () => {
-      chatModel?.writersChanged?.disconnect(updateWriters);
-    };
-  }, [chatModel]);
 
   const inputExists = !!input.trim();
 
@@ -337,7 +310,6 @@ export function ChatInput(props: ChatInput.IProps): JSX.Element {
           ))}
         </Box>
       </Box>
-      <InputWritingIndicator writers={writers} />
     </Box>
   );
 }

--- a/packages/jupyter-chat/src/components/input/index.ts
+++ b/packages/jupyter-chat/src/components/input/index.ts
@@ -7,4 +7,3 @@ export * from './buttons';
 export * from './chat-input';
 export * from './toolbar-registry';
 export * from './use-chat-commands';
-export * from './writing-indicator';

--- a/packages/jupyter-chat/src/components/writing-indicator.tsx
+++ b/packages/jupyter-chat/src/components/writing-indicator.tsx
@@ -3,10 +3,10 @@
  * Distributed under the terms of the Modified BSD License.
  */
 
-import { Box, Typography } from '@mui/material';
+import { Box, SxProps, Theme, Typography } from '@mui/material';
 import React from 'react';
 
-import { IChatModel } from '../../model';
+import { IChatModel } from '../model';
 
 /**
  * Classname on the root element. Used in E2E tests.
@@ -21,6 +21,10 @@ export interface IInputWritingIndicatorProps {
    * The list of users currently writing.
    */
   writers: IChatModel.IWriter[];
+  /**
+   * Custom mui/material styles.
+   */
+  sx?: SxProps<Theme>;
 }
 
 /**
@@ -48,9 +52,9 @@ function formatWritersText(writers: IChatModel.IWriter[]): string {
 }
 
 /**
- * The input writing indicator component, displaying typing status in the chat input area.
+ * The writing indicator component, displaying typing status.
  */
-export function InputWritingIndicator(
+export function WritingIndicator(
   props: IInputWritingIndicatorProps
 ): JSX.Element {
   const { writers } = props;
@@ -62,6 +66,7 @@ export function InputWritingIndicator(
     <Box
       className={WRITERS_ELEMENT_CLASSNAME}
       sx={{
+        ...props.sx,
         minHeight: '16px'
       }}
     >


### PR DESCRIPTION
Fixes #301

This PR move the typing indicator out of the input component. This is mostly for convenience, there is no rational reason to bring the typing indicator when using the input component.
The UI does not change, the typing indicator is still displayed below the input.