### PR TITLE
Fix the active cell manager when closing all notebooks

### DIFF
--- a/packages/jupyter-chat/src/active-cell-manager.ts
+++ b/packages/jupyter-chat/src/active-cell-manager.ts
@@ -267,7 +267,9 @@ export class ActiveCellManager implements IActiveCellManager {
     activeCell: Cell<ICellModel> | null
   ): void => {
     if (this._activeCell !== activeCell) {
-      this._activeCell?.model.stateChanged.disconnect(this._cellStateChange);
+      if (!this._activeCell?.disposed) {
+        this._activeCell?.model.stateChanged.disconnect(this._cellStateChange);
+      }
       this._activeCell = activeCell;
 
       activeCell?.ready.then(() => {


### PR DESCRIPTION
This PR fixes an error in the `ActiveCelManager` when closing all the notebooks.

<img width="605" height="97" alt="Image" src="https://github.com/user-attachments/assets/10930432-4d06-45e8-9a04-f1b6a5c7d1f0" />

It seems that closing the last notebook doesn't set the active cell to null. 
I don't know if this is new, but I haven't realize that before.

Fixes https://github.com/jupyterlite/ai/issues/232