### PR TITLE
Export of mui-extra module

### DIFF
--- a/packages/jupyter-chat/src/components/index.ts
+++ b/packages/jupyter-chat/src/components/index.ts
@@ -9,4 +9,5 @@ export * from './code-blocks';
 export * from './input';
 export * from './jl-theme-provider';
 export * from './messages';
+export * from './mui-extras';
 export * from './scroll-container';


### PR DESCRIPTION
This module has been removed from exported module in https://github.com/jupyterlab/jupyter-chat/pull/298.