### PR TITLE
Fix the send button tooltip

### DIFF
--- a/packages/jupyter-chat/src/components/input/buttons/send-button.tsx
+++ b/packages/jupyter-chat/src/components/input/buttons/send-button.tsx
@@ -48,6 +48,9 @@ export function SendButton(
     };
     model.configChanged.connect(configChanged);
 
+    // Initialize the tooltip.
+    configChanged(model, model.config);
+
     return () => {
       model.valueChanged.disconnect(inputChanged);
       model.attachmentsChanged?.disconnect(inputChanged);


### PR DESCRIPTION
This PR fixes the tooltip on the send button.

~~This PR restore the helper text containing the shortcut to send a message.~~

Part of #303 


