### PR TITLE
Hide command name from drop-down

### DIFF
--- a/packages/jupyter-chat/src/widgets/multichat-panel.tsx
+++ b/packages/jupyter-chat/src/widgets/multichat-panel.tsx
@@ -547,7 +547,9 @@ function ChatSelect({
 
   return (
     <HTMLSelect onChange={handleChange} value="-">
-      <option value="-">Open a chat</option>
+      <option value="-" disabled hidden>
+        Open a chat
+      </option>
       {Object.keys(chatNames).map(name => (
         <option value={chatNames[name]}>{name}</option>
       ))}


### PR DESCRIPTION
Hide command name `Open a chat` from drop-down. 

### Before
<img width="476" height="383" alt="Screenshot From 2025-12-09 15-21-58" src="https://github.com/user-attachments/assets/38fe6f0d-0e99-43e7-ab3d-0f50059fedc6" />

### After
<img width="476" height="383" alt="Screenshot From 2025-12-09 16-08-46" src="https://github.com/user-attachments/assets/b6fcfa20-165d-48b4-ba13-5bf6333391dd" />
