### PR TITLE
Exporting function ChatSelect

### DIFF
--- a/packages/jupyter-chat/src/widgets/multichat-panel.tsx
+++ b/packages/jupyter-chat/src/widgets/multichat-panel.tsx
@@ -518,7 +518,7 @@ export namespace ChatSection {
   }
 }
 
-type ChatSelectProps = {
+export type ChatSelectProps = {
   /**
    * A signal emitting when the list of chat changed.
    */
@@ -532,7 +532,7 @@ type ChatSelectProps = {
 /**
  * A component to select a chat from the drive.
  */
-function ChatSelect({
+export function ChatSelect({
   chatNamesChanged,
   handleChange
 }: ChatSelectProps): JSX.Element {


### PR DESCRIPTION
Exporting function ChatSelect so  we can use it in `@jupyterlite/ai` to get list of chats.

