### PR TITLE
Dark mode: use black color for text in buttons

### DIFF
--- a/packages/jupyter-chat/src/theme-provider.ts
+++ b/packages/jupyter-chat/src/theme-provider.ts
@@ -40,8 +40,9 @@ export async function pollUntilReady(): Promise<void> {
 
 export async function getJupyterLabTheme(): Promise<Theme> {
   await pollUntilReady();
-  const light = document.body.getAttribute('data-jp-theme-light');
+  const light = document.body.getAttribute('data-jp-theme-light') === 'true';
   return createTheme({
+    cssVariables: true,
     spacing: 4,
     components: {
       MuiButton: {
@@ -65,12 +66,12 @@ export async function getJupyterLabTheme(): Promise<Theme> {
             // The default style for input toolbar button variant.
             props: { variant: 'input-toolbar' },
             style: {
-              backgroundColor: 'var(--jp-brand-color1)',
-              color: 'white',
+              backgroundColor: `var(--jp-brand-color${light ? '1' : '2'})`,
+              color: 'var(--jp-ui-inverse-font-color1)',
               borderRadius: '4px',
               boxShadow: 'none',
               '&:hover': {
-                backgroundColor: 'var(--jp-brand-color0)',
+                backgroundColor: `var(--jp-brand-color${light ? '0' : '1'})`,
                 boxShadow: 'none'
               },
               '&:disabled': {
@@ -122,12 +123,12 @@ export async function getJupyterLabTheme(): Promise<Theme> {
             // The default style for input toolbar button variant.
             props: { variant: 'input-toolbar' },
             style: {
-              backgroundColor: 'var(--jp-brand-color1)',
-              color: 'white',
+              backgroundColor: `var(--jp-brand-color${light ? '1' : '2'})`,
+              color: 'var(--jp-ui-inverse-font-color1)',
               borderRadius: '4px',
               boxShadow: 'none',
               '&:hover': {
-                backgroundColor: 'var(--jp-brand-color0)',
+                backgroundColor: `var(--jp-brand-color${light ? '0' : '1'})`,
                 boxShadow: 'none'
               },
               '&:disabled': {
@@ -187,9 +188,9 @@ export async function getJupyterLabTheme(): Promise<Theme> {
         paper: getCSSVariable('--jp-layout-color1'),
         default: getCSSVariable('--jp-layout-color1')
       },
-      mode: light === 'true' ? 'light' : 'dark',
+      mode: light ? 'light' : 'dark',
       primary: {
-        main: getCSSVariable('--jp-brand-color1'),
+        main: getCSSVariable(`--jp-brand-color${light ? '1' : '2'}`),
         light: getCSSVariable('--jp-brand-color2'),
         dark: getCSSVariable('--jp-brand-color0')
       },

--- a/packages/jupyter-chat/style/input.css
+++ b/packages/jupyter-chat/style/input.css
@@ -20,7 +20,7 @@
   position: absolute;
   inset: 0;
   background: rgb(33 150 243 / 10%);
-  border: 2px dashed var(--jp-brand-color1);
+  border: 2px dashed var(--mui-palette-primary-main);
   border-radius: 4px;
   pointer-events: none;
   z-index: 1;
@@ -32,7 +32,7 @@
   top: -24px;
   left: 50%;
   transform: translateX(-50%);
-  color: var(--jp-brand-color1);
+  color: var(--mui-palette-primary-main);
   font-size: 12px;
   font-weight: 500;
   pointer-events: none;
@@ -47,5 +47,5 @@
 }
 
 .jp-chat-input-container:focus-within > div:first-of-type {
-  border-color: var(--jp-brand-color1);
+  border-color: var(--mui-palette-primary-main);
 }


### PR DESCRIPTION
This PR update the color of the text in button, using 
- white in light mode (with dark button)
- black in dark mode (button slightly lighter)

This changes fix issue with some themes redefining `--jp-brand-color`, which can be light for dark theme. Therefore, the text is not visible anymore, white on light color.

<img width="300" alt="Screenshot from 2026-02-12 14-58-39" src="https://github.com/user-attachments/assets/af71e566-ed47-486e-a35f-7aa13d0c1626" />
<img width="300" alt="Screenshot from 2026-02-12 14-58-29" src="https://github.com/user-attachments/assets/43462c44-4c5a-41a0-b250-c6a003fda604" />

cc @IsabelParedes