### PR TITLE
Add export chat as Markdown feature

### DIFF
--- a/packages/jupyter-chat/src/index.ts
+++ b/packages/jupyter-chat/src/index.ts
@@ -13,4 +13,5 @@ export * from './registers';
 export * from './selection-watcher';
 export * from './tokens';
 export * from './types';
+export * from './utils';
 export * from './widgets';

--- a/packages/jupyter-chat/src/widgets/multichat-panel.tsx
+++ b/packages/jupyter-chat/src/widgets/multichat-panel.tsx
@@ -13,6 +13,7 @@ import { nullTranslator, TranslationBundle } from '@jupyterlab/translation';
 import {
   addIcon,
   closeIcon,
+  downloadIcon,
   launchIcon,
   PanelWithToolbar,
   ReactWidget,
@@ -36,6 +37,7 @@ import {
 import { TRANSLATION_DOMAIN } from '../context';
 import { chatIcon, readIcon } from '../icons';
 import { IChatModel } from '../model';
+import { downloadChatAsMarkdown } from '../utils';
 
 const SIDEPANEL_CLASS = 'jp-chat-sidepanel';
 const ADD_BUTTON_CLASS = 'jp-chat-add';
@@ -534,6 +536,19 @@ class SidePanelWidget extends PanelWithToolbar {
       this.toolbar.addItem('rename', renameButton);
     }
 
+    const exportButton = new ToolbarButton({
+      icon: downloadIcon,
+      iconLabel: 'Export chat as Markdown',
+      className: 'jp-mod-styled',
+      onClick: () => {
+        try {
+          downloadChatAsMarkdown(this.model.name, this.model.messages);
+        } catch (err) {
+          console.error('Failed to export chat:', err);
+        }
+      }
+    });
+    this.toolbar.addItem('export', exportButton);
     if (options.openInMain) {
       const moveToMain = new ToolbarButton({
         icon: launchIcon,

--- a/packages/jupyterlab-chat-extension/src/index.ts
+++ b/packages/jupyterlab-chat-extension/src/index.ts
@@ -52,7 +52,7 @@ import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 import { Contents } from '@jupyterlab/services';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { ITranslator, nullTranslator } from '@jupyterlab/translation';
-import { launchIcon } from '@jupyterlab/ui-components';
+import { downloadIcon, launchIcon } from '@jupyterlab/ui-components';
 import { PromiseDelegate } from '@lumino/coreutils';
 import {
   ChatWidgetFactory,
@@ -70,6 +70,7 @@ import {
   chatFileType,
   getDisplayName
 } from 'jupyterlab-chat';
+import { downloadChatAsMarkdown } from '@jupyter/chat';
 import { chatCommandRegistryPlugin } from './chat-commands/plugins';
 import { emojiCommandsPlugin } from './chat-commands/providers/emoji';
 import { mentionCommandsPlugin } from './chat-commands/providers/user-mention';
@@ -835,6 +836,23 @@ const chatCommands: JupyterFrontEndPlugin<void> = {
       }
     });
 
+    // Command to export the current chat as a Markdown file.
+    commands.addCommand(CommandIDs.exportChat, {
+      label: 'Export chat as Markdown',
+      icon: downloadIcon,
+      isEnabled: () => tracker.currentWidget !== null,
+      execute: () => {
+        const widget = tracker.currentWidget;
+        if (!widget) {
+          return;
+        }
+        try {
+          downloadChatAsMarkdown(widget.model.name, widget.model.messages);
+        } catch (err) {
+          console.error('Failed to export chat:', err);
+        }
+      }
+    });
     // The command to focus the input of the current chat widget.
     commands.addCommand(CommandIDs.focusInput, {
       caption: trans.__('Focus the input of the current chat widget'),
@@ -865,6 +883,10 @@ const chatCommands: JupyterFrontEndPlugin<void> = {
       commandPalette.addItem({
         category: trans.__('Chat'),
         command: CommandIDs.renameChat
+      });
+      commandPalette.addItem({
+        category: 'Chat',
+        command: CommandIDs.exportChat
       });
     }
 

--- a/packages/jupyterlab-chat/src/token.ts
+++ b/packages/jupyterlab-chat/src/token.ts
@@ -108,7 +108,11 @@ export const CommandIDs = {
   /**
    * Open a chat and send a message into it.
    */
-  openWithMessage: 'jupyterlab-chat:openWithMessage'
+  openWithMessage: 'jupyterlab-chat:openWithMessage',
+  /**
+   * Export the current chat as a Markdown file.
+   */
+  exportChat: 'jupyterlab-chat:exportChat'
 };
 
 /**


### PR DESCRIPTION
## Summary

- Adds a download button to the chat section toolbar that exports the conversation as a `.md` file
- Adds an `exportChat` command accessible from the command palette
- Introduces `downloadChatAsMarkdown` and `formatChatAsMarkdown` utility functions in `@jupyter/chat`

The exported Markdown includes sender names, timestamps, and preserves message formatting. The file downloads directly to the user's machine via a temporary anchor element.

## Changes

| Package | File | Change |
|-|-|-|
| `@jupyter/chat` | `src/utils.ts` | New `formatChatAsMarkdown` and `downloadChatAsMarkdown` functions |
| `@jupyter/chat` | `src/index.ts` | Re-export `downloadChatAsMarkdown` |
| `@jupyter/chat` | `src/widgets/multichat-panel.tsx` | Export button in `ChatSection` toolbar |
| `jupyterlab-chat` | `src/token.ts` | `exportChat` command ID |
| `jupyterlab-chat-extension` | `src/index.ts` | Command registration + palette entry |

## Test plan

- [ ] Open a chat with several messages, click the download icon — verify `.md` file downloads
- [ ] Open command palette, run "Export chat as Markdown" — same behavior
- [ ] Verify exported Markdown has correct sender names and timestamps
- [ ] Verify the command is disabled when no chat widget is focused

Closes #145