### PR TITLE
Adding token counts and pricing for the Jupyternaut persona

### DIFF
--- a/packages/jupyter-chat/src/components/index.ts
+++ b/packages/jupyter-chat/src/components/index.ts
@@ -11,4 +11,5 @@ export * from './jl-theme-provider';
 export * from './messages';
 export * from './mui-extras';
 export * from './scroll-container';
+export * from './token-usage-display';
 export * from './writing-indicator';

--- a/packages/jupyter-chat/src/components/token-usage-display.tsx
+++ b/packages/jupyter-chat/src/components/token-usage-display.tsx
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+import { ITokenUsage } from '../types';
+import { Box, Typography } from '@mui/material';
+import React from 'react';
+
+export interface ITokenUsageDisplayProps {
+  usage?: ITokenUsage;
+}
+
+/**
+ * Component to display cumulative token usage and estimated cost.
+ */
+export function TokenUsageDisplay(props: ITokenUsageDisplayProps): JSX.Element | null {
+  const { usage } = props;
+
+  if (!usage || (!usage.total_tokens && !usage.input_tokens && !usage.output_tokens)) {
+    return null;
+  }
+
+  const formatNumber = (num: number | undefined): string => {
+    if (num === undefined) {
+      return '0';
+    }
+    if (num >= 1000000) {
+      return `${(num / 1000000).toFixed(2)}M`;
+    }
+    if (num >= 1000) {
+      return `${(num / 1000).toFixed(1)}K`;
+    }
+    return num.toString();
+  };
+
+  const formatCost = (cost: number | undefined): string => {
+    if (cost === undefined || cost === 0) {
+      return '$0.00';
+    }
+    if (cost < 0.01) {
+      return '<$0.01';
+    }
+    return `$${cost.toFixed(2)}`;
+  };
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 1,
+        padding: '4px 8px',
+        fontSize: '0.75rem',
+        color: 'var(--jp-ui-font-color2)',
+        borderRadius: '4px',
+        backgroundColor: 'var(--jp-layout-color2)'
+      }}
+    >
+      <Typography
+        variant="caption"
+        sx={{
+          fontFamily: 'var(--jp-code-font-family)',
+          fontSize: '0.75rem'
+        }}
+        title={`Input: ${usage.input_tokens || 0} | Output: ${usage.output_tokens || 0} | Total: ${usage.total_tokens || 0}`}
+      >
+        {formatNumber(usage.total_tokens || (usage.input_tokens || 0) + (usage.output_tokens || 0))} tokens
+      </Typography>
+      {usage.cost !== undefined && usage.cost > 0 && (
+        <>
+          <Typography
+            variant="caption"
+            sx={{
+              color: 'var(--jp-ui-font-color3)'
+            }}
+          >
+            •
+          </Typography>
+          <Typography
+            variant="caption"
+            sx={{
+              fontFamily: 'var(--jp-code-font-family)',
+              fontSize: '0.75rem',
+              fontWeight: 500
+            }}
+            title="Estimated cost based on model pricing"
+          >
+            {formatCost(usage.cost)}
+          </Typography>
+        </>
+      )}
+    </Box>
+  );
+}

--- a/packages/jupyter-chat/src/types.ts
+++ b/packages/jupyter-chat/src/types.ts
@@ -59,6 +59,32 @@ export interface IConfig {
 }
 
 /**
+ * Token usage information for LLM responses.
+ */
+export interface ITokenUsage {
+  /**
+   * Number of input tokens consumed.
+   */
+  input_tokens?: number;
+  /**
+   * Number of output tokens generated.
+   */
+  output_tokens?: number;
+  /**
+   * Total tokens (input + output).
+   */
+  total_tokens?: number;
+  /**
+   * Model identifier (e.g., 'gpt-4', 'claude-3-opus').
+   */
+  model?: string;
+  /**
+   * Estimated cost in USD.
+   */
+  cost?: number;
+}
+
+/**
  * The chat message description.
  */
 export interface IChatMessage<T = IUser, U = IAttachment> {
@@ -73,6 +99,10 @@ export interface IChatMessage<T = IUser, U = IAttachment> {
   deleted?: boolean;
   edited?: boolean;
   stacked?: boolean;
+  /**
+   * Token usage information for this message (if from an LLM).
+   */
+  usage?: ITokenUsage;
 }
 
 /**

--- a/python/jupyterlab-chat/jupyterlab_chat/models.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/models.py
@@ -12,6 +12,26 @@ def message_asdict_factory(data):
 
 
 @dataclass
+class TokenUsage:
+    """Token usage information for LLM responses"""
+
+    input_tokens: Optional[int] = None
+    """Number of input tokens consumed"""
+
+    output_tokens: Optional[int] = None
+    """Number of output tokens generated"""
+
+    total_tokens: Optional[int] = None
+    """Total tokens (input + output)"""
+
+    model: Optional[str] = None
+    """Model identifier (e.g., 'gpt-4', 'claude-3-opus')"""
+
+    cost: Optional[float] = None
+    """Estimated cost in USD"""
+
+
+@dataclass
 class Message:
     """ Object representing a message """
 
@@ -56,6 +76,12 @@ class Message:
     edited: Optional[bool] = None
     """
     Whether the message has been edited or not
+    Default to None.
+    """
+
+    usage: Optional[TokenUsage] = None
+    """
+    Token usage information for this message (if from an LLM)
     Default to None.
     """
 

--- a/python/jupyterlab-chat/jupyterlab_chat/pricing.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/pricing.py
@@ -1,0 +1,173 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+"""
+Model pricing database for LLM token usage cost calculation.
+
+Pricing is specified as cost per 1 million tokens (input and output).
+Prices are in USD and should be updated periodically to reflect current rates.
+
+Sources:
+- OpenAI: https://openai.com/api/pricing/
+- Anthropic: https://anthropic.com/pricing
+- Google: https://ai.google.dev/pricing
+- Other providers: respective documentation
+"""
+
+from typing import Optional
+
+# Pricing database: model_name -> (input_cost_per_1m, output_cost_per_1m)
+# Costs are in USD per 1 million tokens
+MODEL_PRICING = {
+    # OpenAI GPT-4 models
+    "gpt-4": (30.0, 60.0),
+    "gpt-4-32k": (60.0, 120.0),
+    "gpt-4-turbo": (10.0, 30.0),
+    "gpt-4-turbo-preview": (10.0, 30.0),
+    "gpt-4o": (2.5, 10.0),
+    "gpt-4o-mini": (0.15, 0.6),
+
+    # OpenAI GPT-3.5 models
+    "gpt-3.5-turbo": (0.5, 1.5),
+    "gpt-3.5-turbo-16k": (3.0, 4.0),
+
+    # OpenAI O1 models
+    "o1-preview": (15.0, 60.0),
+    "o1-mini": (3.0, 12.0),
+
+    # Anthropic Claude models
+    "claude-3-opus-20240229": (15.0, 75.0),
+    "claude-3-sonnet-20240229": (3.0, 15.0),
+    "claude-3-haiku-20240307": (0.25, 1.25),
+    "claude-3-5-sonnet-20241022": (3.0, 15.0),
+    "claude-3-5-haiku-20241022": (0.8, 4.0),
+    "claude-3-5-sonnet-20250929": (3.0, 15.0),
+    "claude-opus-4-5-20251101": (15.0, 75.0),
+
+    # Shorter model names (common aliases)
+    "claude-3-opus": (15.0, 75.0),
+    "claude-3-sonnet": (3.0, 15.0),
+    "claude-3-haiku": (0.25, 1.25),
+    "claude-3.5-sonnet": (3.0, 15.0),
+    "claude-3-5-sonnet": (3.0, 15.0),
+    "claude-3.5-haiku": (0.8, 4.0),
+    "claude-3-5-haiku": (0.8, 4.0),
+    "claude-opus-4.5": (15.0, 75.0),
+    "claude-opus-4-5": (15.0, 75.0),
+
+    # Google Gemini models
+    "gemini-pro": (0.5, 1.5),
+    "gemini-1.5-pro": (3.5, 10.5),
+    "gemini-1.5-flash": (0.075, 0.3),
+    "gemini-2.0-flash-exp": (0.075, 0.3),
+
+    # Meta Llama models (via various providers)
+    "llama-2-70b": (0.7, 0.9),
+    "llama-3-70b": (0.88, 0.88),
+    "llama-3.1-405b": (5.0, 15.0),
+    "llama-3.1-70b": (0.88, 0.88),
+    "llama-3.1-8b": (0.2, 0.2),
+    "llama-3.2-90b": (0.88, 0.88),
+    "llama-3.2-11b": (0.3, 0.3),
+    "llama-3.2-3b": (0.1, 0.1),
+    "llama-3.2-1b": (0.05, 0.05),
+
+    # Mistral models
+    "mistral-large": (4.0, 12.0),
+    "mistral-medium": (2.7, 8.1),
+    "mistral-small": (1.0, 3.0),
+    "mistral-tiny": (0.25, 0.25),
+
+    # Cohere models
+    "command": (1.0, 2.0),
+    "command-light": (0.3, 0.6),
+    "command-r": (0.5, 1.5),
+    "command-r-plus": (3.0, 15.0),
+}
+
+
+def calculate_cost(
+    model: str,
+    input_tokens: int = 0,
+    output_tokens: int = 0
+) -> Optional[float]:
+    """
+    Calculate the cost of token usage for a given model.
+
+    Args:
+        model: The model identifier (e.g., 'gpt-4', 'claude-3-opus')
+        input_tokens: Number of input tokens
+        output_tokens: Number of output tokens
+
+    Returns:
+        The estimated cost in USD, or None if pricing is not available for the model
+    """
+    # Normalize model name: remove provider prefixes and version suffixes
+    normalized_model = _normalize_model_name(model)
+
+    # Look up pricing
+    pricing = MODEL_PRICING.get(normalized_model)
+    if not pricing:
+        # Try to find a partial match
+        for model_name, model_pricing in MODEL_PRICING.items():
+            if model_name in normalized_model or normalized_model in model_name:
+                pricing = model_pricing
+                break
+
+    if not pricing:
+        return None
+
+    input_cost_per_1m, output_cost_per_1m = pricing
+
+    # Calculate cost
+    input_cost = (input_tokens / 1_000_000) * input_cost_per_1m
+    output_cost = (output_tokens / 1_000_000) * output_cost_per_1m
+
+    return input_cost + output_cost
+
+
+def _normalize_model_name(model: str) -> str:
+    """
+    Normalize a model name by removing common prefixes and making lowercase.
+
+    Examples:
+        'openai/gpt-4' -> 'gpt-4'
+        'anthropic.claude-3-opus-20240229' -> 'claude-3-opus-20240229'
+        'bedrock/anthropic.claude-3-opus-20240229-v1:0' -> 'claude-3-opus-20240229'
+    """
+    # Remove provider prefixes
+    prefixes = [
+        "openai/", "openai.", "anthropic/", "anthropic.", "google/", "google.",
+        "meta/", "meta.", "mistral/", "mistral.", "cohere/", "cohere.",
+        "bedrock/", "bedrock.", "azure/", "azure.", "together/", "together.",
+        "replicate/", "replicate.", "huggingface/", "huggingface.",
+        "ollama/", "ollama."
+    ]
+
+    normalized = model.lower()
+    for prefix in prefixes:
+        if normalized.startswith(prefix):
+            normalized = normalized[len(prefix):]
+            break
+
+    # Remove version suffixes like '-v1:0'
+    if "-v" in normalized:
+        normalized = normalized.split("-v")[0]
+
+    # Remove trailing version patterns
+    if normalized.endswith(":latest") or normalized.endswith(":0"):
+        normalized = normalized.rsplit(":", 1)[0]
+
+    return normalized
+
+
+def add_custom_pricing(model: str, input_cost_per_1m: float, output_cost_per_1m: float) -> None:
+    """
+    Add or update pricing for a custom model.
+
+    Args:
+        model: The model identifier
+        input_cost_per_1m: Cost per 1 million input tokens in USD
+        output_cost_per_1m: Cost per 1 million output tokens in USD
+    """
+    MODEL_PRICING[model.lower()] = (input_cost_per_1m, output_cost_per_1m)


### PR DESCRIPTION
This PR is one of three PRs created to add a cumulative token counter to the top of each chat panel when Jupyternaut is used, along with cumulative cost if the LLM used has pricing data available (stored in the new file `pricing.py`). The two corresponding PRs are:

1. https://github.com/jupyter-ai-contrib/jupyter-ai-persona-manager/pull/25
2. https://github.com/jupyter-ai-contrib/jupyter-ai-persona-manager/pull/25

If you hover over the token counts at the top right on the chat panel, you can also see the cumulative counts for input and output tokens separately.

<img width="1679" height="928" alt="Screenshot 2026-02-25 at 12 05 07 AM" src="https://github.com/user-attachments/assets/9ef0bf94-fd64-4025-96c2-dd6f5e5777c7" />


## Features

A brief listing of the features is as follows:

✅ **Cumulative Token Tracking**: Automatically tracks tokens across all LLM interactions
✅ **Cost Estimation**: Calculates USD cost based on model pricing
✅ **Real-time Updates**: Uses Yjs for collaborative updates across clients
✅ **Smart Formatting**: Displays tokens as "1.2K" or "3.5M" for readability
✅ **Model Support**: Pricing for OpenAI, Anthropic, Google, Meta, Mistral, Cohere
✅ **Extensible**: Easy to add custom model pricing
✅ **Per-Message Storage**: Each message can store its usage (for future features)
✅ **Visual Display**: Shows in chat header with tooltips for details

## How It Works

1. User sends message → Persona processes with LLM
2. LLM streams response → Usage metadata captured
3. Usage added to message → `TokenUsage` object created
4. Cost calculated → Pricing database lookup
5. Cumulative updated → YChat adds to running total
6. UI displays → Token counter shows cumulative data
7. Real-time sync → Yjs syncs to all clients

## Data Flow

```
User Message
    ↓
Jupyternaut.process_message()
    ↓
LangChain/LiteLLM Stream (usage_metadata)
    ↓
TokenUsage(input_tokens, output_tokens, model)
    ↓
pricing.calculate_cost() → adds cost field
    ↓
BasePersona.stream_message(usage=...)
    ↓
YChat.update_message(msg.usage = TokenUsage)
    ↓
YChat.add_usage() → cumulative total in metadata
    ↓
React Component observes metadata change
    ↓
TokenUsageDisplay shows updated total + cost
```

## Testing

Follow the instructions for contributors to Jupyter AI, here: https://jupyter-ai.readthedocs.io/en/v3/contributors/index.html#dev-install-using-just-and-uv, but pull in the branch for this PR and the related two PRs noted above.

You will need to also run (from the `jupyter-chat` subfolder under `jupyter-ai-devrepo`, before running the commands below:
```
just build
```

Then run from the `jupyter-ai-devrepo` folder:

```
just sync
just install-all
```


Then start Jupyter Lab:

```bash
# Start JupyterLab
just start
```

Open a chat, send messages to Jupyternaut
Token counter will appear at top showing:
- Total tokens (formatted)
- Estimated cost in USD
- Updates in real-time