### PR TITLE
New chat default to untitled

### DIFF
--- a/packages/jupyterlab-chat-extension/src/index.ts
+++ b/packages/jupyterlab-chat-extension/src/index.ts
@@ -544,7 +544,19 @@ const chatCommands: JupyterFrontEndPlugin<void> = {
       icon: args => (args.isPalette ? undefined : chatIcon),
       execute: async (args): Promise<string | undefined> => {
         const inSidePanel: boolean = (args.inSidePanel as boolean) ?? false;
-        const targetDirectory: string | undefined = args.path as string;
+        let targetDirectory: string | undefined = args.path as string;
+
+        // Create new chat file in default dir if created from filebrowser
+        // as "Open a chat" dropdown only discovers chat files in default
+        // dir. Create new chat in file browser cwd if created from main
+        // area (launcher, menu, palette).
+        if (targetDirectory === undefined) {
+          if (inSidePanel) {
+            targetDirectory = widgetConfig.config.defaultDirectory ?? '';
+          } else {
+            targetDirectory = filebrowser?.model.path ?? '';
+          }
+        }
 
         const name: string = (args.name as string) ?? '';
         let filepath = '';
@@ -554,22 +566,7 @@ const chatCommands: JupyterFrontEndPlugin<void> = {
           } else {
             filepath = `${name}${chatFileType.extensions[0]}`;
           }
-          // Create new chat file in default dir if created from filebrowser
-          // as "Open a chat" dropdown only discovers chat files in default
-          // dir. Create new chat in file browser cwd if created from main
-          // area (launcher, menu, palette).
-          if (targetDirectory !== undefined) {
-            // Explicit directory provided - use it
-            filepath = PathExt.join(targetDirectory, filepath);
-          } else if (inSidePanel) {
-            // Side panel uses default directory
-            const defaultDir = widgetConfig.config.defaultDirectory ?? '';
-            filepath = PathExt.join(defaultDir, filepath);
-          } else {
-            // Main area uses filebrowser cwd
-            const cwd = filebrowser?.model.path ?? '';
-            filepath = PathExt.join(cwd, filepath);
-          }
+          filepath = PathExt.join(targetDirectory, filepath);
         }
 
         let fileExist = true;
@@ -588,6 +585,7 @@ const chatCommands: JupyterFrontEndPlugin<void> = {
           // Create a new untitled chat.
           let model: Contents.IModel | null =
             await app.serviceManager.contents.newUntitled({
+              path: targetDirectory,
               type: 'file',
               ext: chatFileType.extensions[0]
             });

--- a/packages/jupyterlab-chat-extension/src/index.ts
+++ b/packages/jupyterlab-chat-extension/src/index.ts
@@ -531,7 +531,7 @@ const chatCommands: JupyterFrontEndPlugin<void> = {
      *
      * args:
      *  name -        optional, the name of the chat to create.
-     *                Open a dialog if not provided.
+     *                Creates an untitled chat if not provided.
      *  inSidePanel - optional (default to false).
      *                Whether to open the chat in side panel or in main area.
      *  isPalette -   optional (default to false).
@@ -546,23 +546,9 @@ const chatCommands: JupyterFrontEndPlugin<void> = {
         const inSidePanel: boolean = (args.inSidePanel as boolean) ?? false;
         const targetDirectory: string | undefined = args.path as string;
 
-        let name: string | null = (args.name as string) ?? null;
+        const name: string = (args.name as string) ?? '';
         let filepath = '';
-        if (!name) {
-          name = (
-            await InputDialog.getText({
-              label: trans.__('Name'),
-              placeholder: trans.__('untitled'),
-              title: trans.__('Create a new chat')
-            })
-          ).value;
-        }
-        // no-op if the dialog has been cancelled.
-        // Fill the filepath if the dialog has been validated with content,
-        // otherwise create a new untitled chat (empty filepath).
-        if (name === null) {
-          return;
-        } else if (name) {
+        if (name) {
           if (name.endsWith(chatFileType.extensions[0])) {
             filepath = name;
           } else {

--- a/ui-tests/tests/commands.spec.ts
+++ b/ui-tests/tests/commands.spec.ts
@@ -23,8 +23,8 @@ test.describe('#commandPalette', () => {
     await page.keyboard.press('Control+Shift+c');
   });
 
-  test.afterEach(async ({ page }) => {
-    for (let filename of ['untitled.chat', FILENAME]) {
+  test.afterEach(async ({ page, tmpPath }) => {
+    for (let filename of [`${tmpPath}/untitled.chat`, FILENAME]) {
       if (await page.filebrowser.contents.fileExists(filename)) {
         await page.filebrowser.contents.deleteFile(filename);
       }
@@ -38,7 +38,8 @@ test.describe('#commandPalette', () => {
   });
 
   test('should create an untitled chat from command palette', async ({
-    page
+    page,
+    tmpPath
   }) => {
     await page
       .locator(
@@ -46,7 +47,8 @@ test.describe('#commandPalette', () => {
       )
       .click();
     await page.waitForCondition(
-      async () => await page.filebrowser.contents.fileExists('untitled.chat')
+      async () =>
+        await page.filebrowser.contents.fileExists(`${tmpPath}/untitled.chat`)
     );
     await expect(page.activity.getTabLocator('untitled.chat')).toBeVisible();
   });
@@ -74,15 +76,18 @@ test.describe('#menuNew', () => {
     );
   });
 
-  test('should create a chat from the menu', async ({ page }) => {
+  test('should create a chat from the menu', async ({ page, tmpPath }) => {
     await page.menu.clickMenuItem('File>New>Chat');
     await page.waitForCondition(
-      async () => await page.filebrowser.contents.fileExists('untitled.chat')
+      async () =>
+        await page.filebrowser.contents.fileExists(`${tmpPath}/untitled.chat`)
     );
 
     // Delete chat file
-    if (await page.filebrowser.contents.fileExists('untitled.chat')) {
-      await page.filebrowser.contents.deleteFile('untitled.chat');
+    if (
+      await page.filebrowser.contents.fileExists(`${tmpPath}/untitled.chat`)
+    ) {
+      await page.filebrowser.contents.deleteFile(`${tmpPath}/untitled.chat`);
     }
   });
 });
@@ -98,15 +103,18 @@ test.describe('#launcher', () => {
     expect(await tile.screenshot()).toMatchSnapshot('launcher-tile.png');
   });
 
-  test('should create a chat from the launcher', async ({ page }) => {
+  test('should create a chat from the launcher', async ({ page, tmpPath }) => {
     await page.locator('.jp-LauncherCard').getByTitle('Create a chat').click();
     await page.waitForCondition(
-      async () => await page.filebrowser.contents.fileExists('untitled.chat')
+      async () =>
+        await page.filebrowser.contents.fileExists(`${tmpPath}/untitled.chat`)
     );
 
     // Delete chat file
-    if (await page.filebrowser.contents.fileExists('untitled.chat')) {
-      await page.filebrowser.contents.deleteFile('untitled.chat');
+    if (
+      await page.filebrowser.contents.fileExists(`${tmpPath}/untitled.chat`)
+    ) {
+      await page.filebrowser.contents.deleteFile(`${tmpPath}/untitled.chat`);
     }
   });
 });

--- a/ui-tests/tests/commands.spec.ts
+++ b/ui-tests/tests/commands.spec.ts
@@ -19,8 +19,6 @@ const fillModal = async (
 };
 
 test.describe('#commandPalette', () => {
-  const name = FILENAME.replace('.chat', '');
-
   test.beforeEach(async ({ page }) => {
     await page.keyboard.press('Control+Shift+c');
   });
@@ -39,23 +37,6 @@ test.describe('#commandPalette', () => {
     ).toHaveCount(3);
   });
 
-  test('should create a chat with name from command palette', async ({
-    page,
-    tmpPath
-  }) => {
-    await page
-      .locator(
-        '#modal-command-palette li[data-command="jupyterlab-chat:createAndOpen"]'
-      )
-      .click();
-    await fillModal(page, name);
-    await page.waitForCondition(
-      async () =>
-        await page.filebrowser.contents.fileExists(`${tmpPath}/${FILENAME}`)
-    );
-    await expect(page.activity.getTabLocator(FILENAME)).toBeVisible();
-  });
-
   test('should create an untitled chat from command palette', async ({
     page
   }) => {
@@ -64,22 +45,10 @@ test.describe('#commandPalette', () => {
         '#modal-command-palette li[data-command="jupyterlab-chat:createAndOpen"]'
       )
       .click();
-    await fillModal(page);
     await page.waitForCondition(
       async () => await page.filebrowser.contents.fileExists('untitled.chat')
     );
     await expect(page.activity.getTabLocator('untitled.chat')).toBeVisible();
-  });
-
-  test('should not create a chat if modal is cancelled', async ({ page }) => {
-    await page
-      .locator(
-        '#modal-command-palette li[data-command="jupyterlab-chat:createAndOpen"]'
-      )
-      .click();
-    await fillModal(page, '', 'Cancel');
-    const tab = page.getByRole('main').getByRole('tab');
-    await expect(tab).toHaveCount(1);
   });
 
   test('should open an existing chat', async ({ page }) => {
@@ -105,11 +74,16 @@ test.describe('#menuNew', () => {
     );
   });
 
-  test('should open modal create from the menu', async ({ page }) => {
+  test('should create a chat from the menu', async ({ page }) => {
     await page.menu.clickMenuItem('File>New>Chat');
-    await expect(page.locator('dialog .jp-Dialog-header')).toHaveText(
-      'Create a new chat'
+    await page.waitForCondition(
+      async () => await page.filebrowser.contents.fileExists('untitled.chat')
     );
+
+    // Delete chat file
+    if (await page.filebrowser.contents.fileExists('untitled.chat')) {
+      await page.filebrowser.contents.deleteFile('untitled.chat');
+    }
   });
 });
 
@@ -124,11 +98,16 @@ test.describe('#launcher', () => {
     expect(await tile.screenshot()).toMatchSnapshot('launcher-tile.png');
   });
 
-  test('should open modal create from the launcher', async ({ page }) => {
+  test('should create a chat from the launcher', async ({ page }) => {
     await page.locator('.jp-LauncherCard').getByTitle('Create a chat').click();
-    await expect(page.locator('dialog .jp-Dialog-header')).toHaveText(
-      'Create a new chat'
+    await page.waitForCondition(
+      async () => await page.filebrowser.contents.fileExists('untitled.chat')
     );
+
+    // Delete chat file
+    if (await page.filebrowser.contents.fileExists('untitled.chat')) {
+      await page.filebrowser.contents.deleteFile('untitled.chat');
+    }
   });
 });
 

--- a/ui-tests/tests/side-panel.spec.ts
+++ b/ui-tests/tests/side-panel.spec.ts
@@ -42,48 +42,12 @@ test.describe('#sidepanel', () => {
   });
 
   test.describe('#creation', () => {
-    const name = FILENAME.replace('.chat', '');
-    let panel: Locator;
-    let dialog: Locator;
-    let addButton: Locator;
-
-    test.beforeEach(async ({ page }) => {
-      panel = await openSidePanel(page);
-      addButton = panel.locator('> .jp-Toolbar .jp-Toolbar-item.jp-chat-add');
+    test('should create an untitled chat', async ({ page }) => {
+      const panel = await openSidePanel(page);
+      const addButton = panel.locator(
+        '> .jp-Toolbar .jp-Toolbar-item.jp-chat-add'
+      );
       await addButton.click();
-
-      dialog = page.locator('.jp-Dialog');
-      await dialog.waitFor();
-    });
-
-    test.afterEach(async ({ page }) => {
-      for (let filename of ['untitled.chat', FILENAME]) {
-        if (await page.filebrowser.contents.fileExists(filename)) {
-          await page.filebrowser.contents.deleteFile(filename);
-        }
-      }
-    });
-
-    test('should create a chat', async ({ page }) => {
-      await dialog.locator('input[type="text"]').pressSequentially(name);
-      await dialog.getByRole('button').getByText('Ok').click();
-      await page.waitForCondition(
-        async () => await page.filebrowser.contents.fileExists(FILENAME)
-      );
-
-      const chatToolbar = panel.locator(
-        '.jp-chat-sidepanel-widget .jp-chat-sidepanel-widget-toolbar'
-      );
-      await expect(chatToolbar).toBeAttached();
-      await expect(
-        chatToolbar.locator('.jp-chat-sidepanel-widget-title')
-      ).toHaveText(name);
-    });
-
-    test('should create an untitled file if no name is provided', async ({
-      page
-    }) => {
-      await dialog.getByRole('button').getByText('Ok').click();
       await page.waitForCondition(
         async () => await page.filebrowser.contents.fileExists('untitled.chat')
       );
@@ -95,13 +59,11 @@ test.describe('#sidepanel', () => {
       await expect(
         chatToolbar.locator('.jp-chat-sidepanel-widget-title')
       ).toHaveText('untitled');
-    });
 
-    test('should not create a chat if dialog is cancelled', async () => {
-      await dialog.getByRole('button').getByText('Cancel').click();
-
-      const content = panel.locator('.jp-chat-sidepanel-widget');
-      await expect(content).not.toBeAttached();
+      // Cleanup files
+      if (await page.filebrowser.contents.fileExists('untitled.chat')) {
+        await page.filebrowser.contents.deleteFile('untitled.chat');
+      }
     });
   });
 
@@ -195,13 +157,9 @@ test.describe('#sidepanel', () => {
         '> .jp-Toolbar .jp-Toolbar-item.jp-chat-add'
       );
       await addButton.click();
-      const dialog = page.locator('.jp-Dialog');
-      await dialog.waitFor();
-      await dialog.locator('input[type="text"]').pressSequentially('new-chat');
-      await dialog.getByRole('button').getByText('Ok').click();
 
       await expect(chatList.locator('li')).toHaveCount(1);
-      await expect(chatList.locator('li').last()).toHaveText(/^new-chat/);
+      await expect(chatList.locator('li').last()).toHaveText(/^untitled/);
 
       // Changing the default directory (to root) should update the chat list.
       await defaultDirectory.clear();
@@ -218,7 +176,7 @@ test.describe('#sidepanel', () => {
 
       await expect(chatList.locator('li')).toHaveCount(2);
       const textRegex = new RegExp(`^${name}.*`);
-      await expect(await chatList.locator('li').last()).toHaveText(textRegex);
+      await expect(chatList.locator('li').last()).toHaveText(textRegex);
     });
   });
 


### PR DESCRIPTION
This PR removes the dialog when creating a new chat file in `jupyterlab-chat`.

The new chat files are named `untitled[0-9]*.chat`, the number depending of the existence of other untitled chats in the same directory.

Fixes #373 