### PR TITLE
Fix chat input when it's an attachment

### DIFF
--- a/packages/jupyter-chat/src/components/input/chat-input.tsx
+++ b/packages/jupyter-chat/src/components/input/chat-input.tsx
@@ -107,7 +107,7 @@ export function ChatInput(props: ChatInput.IProps): JSX.Element {
     };
   }, [inputToolbarRegistry]);
 
-  const inputExists = !!input.trim() || attachments.length > 0;
+  const inputExists = !!input.trim();
 
   /**
    * `handleKeyDown()`: callback invoked when the user presses any key in the
@@ -156,18 +156,19 @@ export function ChatInput(props: ChatInput.IProps): JSX.Element {
      */
     event.stopPropagation();
 
+    const isSendCombination =
+      (sendWithShiftEnter && event.shiftKey) ||
+      (!sendWithShiftEnter && !event.shiftKey);
+
     // Do not send empty messages, and avoid adding new line in empty message.
-    if (!inputExists) {
+    if (!inputExists && (!isSendCombination || attachments.length === 0)) {
       event.stopPropagation();
       event.preventDefault();
       return;
     }
 
     // Finally, send the message when all other conditions are met.
-    if (
-      (sendWithShiftEnter && event.shiftKey) ||
-      (!sendWithShiftEnter && !event.shiftKey)
-    ) {
+    if (isSendCombination) {
       // Run all command providers
       await chatCommandRegistry?.onSubmit(model);
       model.send(model.value);

--- a/packages/jupyter-chat/src/components/input/chat-input.tsx
+++ b/packages/jupyter-chat/src/components/input/chat-input.tsx
@@ -107,7 +107,7 @@ export function ChatInput(props: ChatInput.IProps): JSX.Element {
     };
   }, [inputToolbarRegistry]);
 
-  const inputExists = !!input.trim();
+  const inputExists = !!input.trim() || attachments.length > 0;
 
   /**
    * `handleKeyDown()`: callback invoked when the user presses any key in the


### PR DESCRIPTION
I came across this issue while working on a [jupyterlite-ai PR](https://github.com/jupyterlite/ai/pull/306).
The issue is that when the user message contains only an attachment and no text, it can't be sent using the 'Enter' key but can be sent with the 'Send Message' button.
Looking closely at the code the `inputExists` constant in the `ChatInput` component only looked at the text input and ignored the attachments unlike the [`SendButton`](https://github.com/jupyterlab/jupyter-chat/blob/main/packages/jupyter-chat/src/components/input/buttons/send-button.tsx#L35) component which handles this correctly.