### PR TITLE
Fix Enter key submitting message during IME composition

### DIFF
--- a/packages/jupyter-chat/src/components/input/chat-input.tsx
+++ b/packages/jupyter-chat/src/components/input/chat-input.tsx
@@ -129,7 +129,14 @@ export function ChatInput(props: ChatInput.IProps): JSX.Element {
     }
 
     // remainder of this function only handles the "Enter" key.
-    if (event.key !== 'Enter') {
+    // Ignore Enter keypress during IME composition (e.g. Chinese, Japanese,
+    // Korean input methods), where Enter confirms the candidate selection
+    // rather than sending the message.
+    if (
+      event.key !== 'Enter' ||
+      event.nativeEvent.isComposing ||
+      event.nativeEvent.keyCode === 229
+    ) {
       return;
     }
 

--- a/packages/jupyter-chat/src/components/input/chat-input.tsx
+++ b/packages/jupyter-chat/src/components/input/chat-input.tsx
@@ -129,9 +129,7 @@ export function ChatInput(props: ChatInput.IProps): JSX.Element {
     }
 
     // remainder of this function only handles the "Enter" key.
-    // Ignore Enter keypress during IME composition (e.g. Chinese, Japanese,
-    // Korean input methods), where Enter confirms the candidate selection
-    // rather than sending the message.
+    // Ignore Enter keypress during IME composition 
     if (
       event.key !== 'Enter' ||
       event.nativeEvent.isComposing ||

--- a/packages/jupyter-chat/src/widgets/multichat-panel.tsx
+++ b/packages/jupyter-chat/src/widgets/multichat-panel.tsx
@@ -767,6 +767,11 @@ function ChatSearchInput({
       return;
     }
 
+    // Ignore key events during IME composition (e.g. CJK input methods).
+    if (event.nativeEvent.isComposing || event.nativeEvent.keyCode === 229) {
+      return;
+    }
+
     let value: string | null;
     switch (event.key) {
       case 'ArrowDown':

--- a/packages/jupyter-chat/src/widgets/multichat-panel.tsx
+++ b/packages/jupyter-chat/src/widgets/multichat-panel.tsx
@@ -767,7 +767,7 @@ function ChatSearchInput({
       return;
     }
 
-    // Ignore key events during IME composition (e.g. CJK input methods).
+    // Ignore key events during IME composition.
     if (event.nativeEvent.isComposing || event.nativeEvent.keyCode === 229) {
       return;
     }


### PR DESCRIPTION
## Description

When using an Input Method Editor (IME) — such as Chinese Pinyin, Japanese, or Korean — pressing **Enter** to confirm a candidate character incorrectly submits the chat message instead of completing the IME composition.

This adds checks for `event.isComposing` and `event.keyCode === 229` to ignore Enter key events during IME composition in two places:

- `chat-input.tsx` — the main chat input
- `multichat-panel.tsx` — the chat selector search input

## Reproduce

1. Open a chat in JupyterLab
2. Switch to a CJK input method (e.g. Chinese Pinyin)
3. Type `jupyter` in the chat input — the IME shows a candidate list
4. Press **Enter** to confirm the selected candidate
5. The message is submitted immediately with incomplete/unintended text

## Fix

During IME composition, the browser fires `keydown` events with `event.isComposing === true` (and `event.keyCode === 229` for legacy compatibility). These are now detected and ignored so Enter only sends the message outside of IME composition.

References: [MDN: KeyboardEvent.isComposing](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/isComposing)