### PR TITLE
Add a placeholder widget in side panel

### DIFF
--- a/packages/jupyter-chat/src/__tests__/multichat-panel.spec.ts
+++ b/packages/jupyter-chat/src/__tests__/multichat-panel.spec.ts
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+import { RenderMimeRegistry } from '@jupyterlab/rendermime';
+import { Widget } from '@lumino/widgets';
+
+import { IChatPlaceholderFactory } from '../tokens';
+import { MultiChatPanel } from '../widgets/multichat-panel';
+import { defaultPlaceholder, Placeholder } from '../widgets/placeholder';
+
+describe('MultiChatPanel', () => {
+  let rmRegistry: RenderMimeRegistry;
+
+  beforeEach(() => {
+    rmRegistry = new RenderMimeRegistry();
+  });
+
+  describe('placeholderFactory', () => {
+    it('should use defaultPlaceholder when no factory is provided', () => {
+      const panel = new MultiChatPanel({ rmRegistry });
+      const placeholder = Array.from(panel.widgets).find(
+        w => w instanceof defaultPlaceholder
+      );
+      expect(placeholder).toBeInstanceOf(defaultPlaceholder);
+      panel.dispose();
+    });
+
+    it('should call factory.create when a factory is provided', () => {
+      const factory: IChatPlaceholderFactory = {
+        create: jest.fn().mockReturnValue(new Widget())
+      };
+      const panel = new MultiChatPanel({
+        rmRegistry,
+        placeholderFactory: factory
+      });
+      expect(factory.create).toHaveBeenCalledTimes(1);
+      panel.dispose();
+    });
+
+    it('should add the widget returned by the factory to the panel', () => {
+      const customWidget = new Widget();
+      const factory: IChatPlaceholderFactory = {
+        create: jest.fn().mockReturnValue(customWidget)
+      };
+      const panel = new MultiChatPanel({
+        rmRegistry,
+        placeholderFactory: factory
+      });
+      expect(Array.from(panel.widgets)).toContain(customWidget);
+      panel.dispose();
+    });
+
+    it('should not use defaultPlaceholder when a factory is provided', () => {
+      const factory: IChatPlaceholderFactory = {
+        create: jest.fn().mockReturnValue(new Widget())
+      };
+      const panel = new MultiChatPanel({
+        rmRegistry,
+        placeholderFactory: factory
+      });
+      const placeholder = Array.from(panel.widgets).find(
+        w => w instanceof defaultPlaceholder
+      );
+      expect(placeholder).toBeUndefined();
+      panel.dispose();
+    });
+
+    it('should pass empty chatNames in props when no chats are loaded', () => {
+      const factory: IChatPlaceholderFactory = {
+        create: jest.fn().mockReturnValue(new Widget())
+      };
+      const panel = new MultiChatPanel({
+        rmRegistry,
+        placeholderFactory: factory
+      });
+      const props = (factory.create as jest.Mock).mock
+        .calls[0][0] as Placeholder.IProps;
+      expect(props.chatNames).toEqual({});
+      panel.dispose();
+    });
+
+    it('should pass undefined onCreate when createModel is not provided', () => {
+      const factory: IChatPlaceholderFactory = {
+        create: jest.fn().mockReturnValue(new Widget())
+      };
+      const panel = new MultiChatPanel({
+        rmRegistry,
+        placeholderFactory: factory
+      });
+      const props = (factory.create as jest.Mock).mock
+        .calls[0][0] as Placeholder.IProps;
+      expect(props.onCreate).toBeUndefined();
+      panel.dispose();
+    });
+
+    it('should pass onCreate when createModel is provided', () => {
+      const factory: IChatPlaceholderFactory = {
+        create: jest.fn().mockReturnValue(new Widget())
+      };
+      const createModel = jest.fn().mockResolvedValue({});
+      const panel = new MultiChatPanel({
+        rmRegistry,
+        placeholderFactory: factory,
+        createModel
+      });
+      const props = (factory.create as jest.Mock).mock
+        .calls[0][0] as Placeholder.IProps;
+      expect(props.onCreate).toBeDefined();
+      panel.dispose();
+    });
+
+    it('should call factory.create again when the placeholder is re-added after closing a chat', async () => {
+      const factory: IChatPlaceholderFactory = {
+        create: jest.fn().mockReturnValue(new Widget())
+      };
+      const createModel = jest.fn().mockResolvedValue({});
+      const panel = new MultiChatPanel({
+        rmRegistry,
+        placeholderFactory: factory,
+        createModel
+      });
+
+      // Simulate opening and closing a chat to trigger _addPlaceholder again.
+      const { MockChatModel } = await import('./mocks');
+      const model = new MockChatModel();
+      panel.open({ model, displayName: 'test-chat' });
+      panel.disposeLoadedModel('test-chat');
+
+      expect(factory.create).toHaveBeenCalledTimes(2);
+      panel.dispose();
+    });
+  });
+});

--- a/packages/jupyter-chat/src/tokens.ts
+++ b/packages/jupyter-chat/src/tokens.ts
@@ -5,8 +5,9 @@
 
 import { IWidgetTracker, MainAreaWidget } from '@jupyterlab/apputils';
 import { Token } from '@lumino/coreutils';
+import { Widget } from '@lumino/widgets';
 
-import { ChatWidget } from './widgets';
+import { ChatWidget, Placeholder } from './widgets';
 import { IChatModel } from './model';
 
 /**
@@ -27,4 +28,27 @@ export type IChatTracker = IWidgetTracker<ChatWidget | MainAreaChat>;
 export const IChatTracker = new Token<IChatTracker>(
   '@jupyter/chat:IChatTracker',
   'The chat widget tracker'
+);
+
+/**
+ * The interface for the placeholder factory.
+ */
+export interface IChatPlaceholderFactory {
+  /**
+   * Create a placeholder widget for the multi-chat panel.
+   *
+   * @param props - the props passed to the placeholder.
+   * @returns a widget to display as placeholder.
+   */
+  create(props: Placeholder.IProps): Widget;
+}
+
+/**
+ * The token for the placeholder factory.
+ * Not provided by default — extensions can provide it to replace the default
+ * placeholder shown when no chat is open in the multi-chat panel.
+ */
+export const IChatPlaceholderFactory = new Token<IChatPlaceholderFactory>(
+  '@jupyter/chat:IChatPlaceholderFactory',
+  'The placeholder factory for the multi-chat panel'
 );

--- a/packages/jupyter-chat/src/widgets/index.ts
+++ b/packages/jupyter-chat/src/widgets/index.ts
@@ -8,3 +8,4 @@ export * from './chat-selector-popup';
 export * from './chat-sidebar';
 export * from './chat-widget';
 export * from './multichat-panel';
+export * from './placeholder';

--- a/packages/jupyter-chat/src/widgets/multichat-panel.tsx
+++ b/packages/jupyter-chat/src/widgets/multichat-panel.tsx
@@ -26,8 +26,9 @@ import { ISignal, Signal } from '@lumino/signaling';
 import { Widget } from '@lumino/widgets';
 import React, { useEffect, useRef, useState } from 'react';
 
-import { ChatWidget } from './chat-widget';
 import { ChatSelectorPopup } from './chat-selector-popup';
+import { ChatWidget } from './chat-widget';
+import { defaultPlaceholder, Placeholder } from './placeholder';
 import {
   Chat,
   IInputToolbarRegistry,
@@ -36,7 +37,7 @@ import {
 import { TRANSLATION_DOMAIN } from '../context';
 import { chatIcon, readIcon } from '../icons';
 import { IChatModel } from '../model';
-import { defaultPlaceholder } from './placeholder';
+import { IChatPlaceholderFactory } from '../tokens';
 
 const SIDEPANEL_CLASS = 'jp-chat-sidepanel';
 const ADD_BUTTON_CLASS = 'jp-chat-add';
@@ -70,6 +71,7 @@ export class MultiChatPanel extends PanelWithToolbar {
     this._createModel = options.createModel;
     this._openInMain = options.openInMain;
     this._renameChat = options.renameChat;
+    this._placeholderFactory = options.placeholderFactory;
 
     if (this._createModel) {
       // Add chat button calls the createChat callback
@@ -216,7 +218,7 @@ export class MultiChatPanel extends PanelWithToolbar {
    * Add a placeholder in the panel.
    */
   private _addPlaceholder(): void {
-    const placeholder = new defaultPlaceholder({
+    const props: Placeholder.IProps = {
       chatNames: this._chatNames,
       open: this._onSelectChat,
       onCreate: this._createModel
@@ -226,7 +228,10 @@ export class MultiChatPanel extends PanelWithToolbar {
           }
         : undefined,
       chatNamesChanged: this._chatNamesChanged
-    });
+    };
+    const placeholder = this._placeholderFactory
+      ? this._placeholderFactory.create(props)
+      : new defaultPlaceholder(props);
     this.addWidget(placeholder);
     this._currentWidget = placeholder;
   }
@@ -423,6 +428,7 @@ export class MultiChatPanel extends PanelWithToolbar {
   private _getChatNames?: () => Promise<{ [name: string]: string }>;
   private _openInMain?: (name: string) => Promise<boolean>;
   private _renameChat?: boolean | ((oldName: string) => Promise<string | null>);
+  private _placeholderFactory?: IChatPlaceholderFactory;
   private _openChatWidget?: ReactWidget;
   private _chatSelectorPopup?: ChatSelectorPopup;
   private _loadedModels: Map<string, IChatModel> = new Map();
@@ -474,9 +480,13 @@ export namespace MultiChatPanel {
      */
     renameChat?: boolean | ((oldName: string) => Promise<string | null>);
     /**
-     * An optional placeholder widget, displayed when no chat is opened.
+     * An optional factory to create a placeholder widget displayed when no chat
+     * is opened. Falls back to the default placeholder if not provided.
+     *
+     * @param props - the props passed to the placeholder.
+     * @returns a widget to display as placeholder.
      */
-    placeholder?: Widget;
+    placeholderFactory?: IChatPlaceholderFactory;
   }
   /**
    * The options for the add chat method.

--- a/packages/jupyter-chat/src/widgets/multichat-panel.tsx
+++ b/packages/jupyter-chat/src/widgets/multichat-panel.tsx
@@ -227,7 +227,8 @@ export class MultiChatPanel extends PanelWithToolbar {
             this.open(args);
           }
         : undefined,
-      chatNamesChanged: this._chatNamesChanged
+      chatNamesChanged: this._chatNamesChanged,
+      trans: this._trans
     };
     const placeholder = this._placeholderFactory
       ? this._placeholderFactory.create(props)

--- a/packages/jupyter-chat/src/widgets/multichat-panel.tsx
+++ b/packages/jupyter-chat/src/widgets/multichat-panel.tsx
@@ -36,6 +36,7 @@ import {
 import { TRANSLATION_DOMAIN } from '../context';
 import { chatIcon, readIcon } from '../icons';
 import { IChatModel } from '../model';
+import { defaultPlaceholder } from './placeholder';
 
 const SIDEPANEL_CLASS = 'jp-chat-sidepanel';
 const ADD_BUTTON_CLASS = 'jp-chat-add';
@@ -111,13 +112,18 @@ export class MultiChatPanel extends PanelWithToolbar {
     // Insert the toolbar as first child.
     this.insertWidget(0, this.toolbar);
     this._updateChatListDebouncer = new Debouncer(this._updateChatList, 200);
+
+    // Add the placeholder by default.
+    this._addPlaceholder();
   }
 
   /**
    * The currently displayed chat widget.
    */
   get current(): SidePanelWidget | undefined {
-    return this._currentWidget;
+    return this._currentWidget instanceof SidePanelWidget
+      ? this._currentWidget
+      : undefined;
   }
 
   /**
@@ -178,15 +184,16 @@ export class MultiChatPanel extends PanelWithToolbar {
     const model = this._loadedModels.get(name);
     if (model) {
       // If this is the currently displayed chat, remove it.
-      if (this._currentWidget?.model === model) {
-        this._currentWidget.nameChanged.disconnect(this._modelNameChanged);
-        this._currentWidget.dispose();
+      if (this.current?.model === model) {
+        this.current.nameChanged.disconnect(this._modelNameChanged);
+        this.current.dispose();
         this._currentWidget = undefined;
 
         // Clear current chat in selector
         if (this._chatSelectorPopup) {
           this._chatSelectorPopup.setCurrentChat(null);
         }
+        this._addPlaceholder();
       }
 
       model.dispose();
@@ -206,6 +213,25 @@ export class MultiChatPanel extends PanelWithToolbar {
   }
 
   /**
+   * Add a placeholder in the panel.
+   */
+  private _addPlaceholder(): void {
+    const placeholder = new defaultPlaceholder({
+      chatNames: this._chatNames,
+      open: this._onSelectChat,
+      onCreate: this._createModel
+        ? async () => {
+            const args = await this._createModel!();
+            this.open(args);
+          }
+        : undefined,
+      chatNamesChanged: this._chatNamesChanged
+    });
+    this.addWidget(placeholder);
+    this._currentWidget = placeholder;
+  }
+
+  /**
    * Open a specific chat by name, creating a new sidepanel widget.
    */
   private _open(name: string): ChatWidget | undefined {
@@ -214,9 +240,9 @@ export class MultiChatPanel extends PanelWithToolbar {
       return;
     }
 
-    // Dispose current chat widget if any
+    // Dispose of the current chat widget or placeholder.
     if (this._currentWidget) {
-      this._currentWidget.nameChanged.disconnect(this._modelNameChanged);
+      this.current?.nameChanged.disconnect(this._modelNameChanged);
       this._currentWidget.dispose();
     }
 
@@ -251,7 +277,7 @@ export class MultiChatPanel extends PanelWithToolbar {
     this.update();
     this._currentWidget = widget;
 
-    this._currentWidget.nameChanged.connect(this._modelNameChanged);
+    this.current?.nameChanged.connect(this._modelNameChanged);
 
     // Update selector to show current chat
     if (this._chatSelectorPopup) {
@@ -283,6 +309,7 @@ export class MultiChatPanel extends PanelWithToolbar {
       ) {
         this._chatNames = chatNames ?? {};
         this._chatSelectorPopup?.updateChats(Object.keys(this._chatNames));
+        this._chatNamesChanged.emit(this._chatNames);
       }
     } catch (e) {
       console.error('Error getting chat files', e);
@@ -355,7 +382,7 @@ export class MultiChatPanel extends PanelWithToolbar {
       this._loadedModels.set(change.new, model);
       this._loadedModels.delete(change.old);
       this._chatSelectorPopup?.setLoadedModels(this.getLoadedModelNames());
-      if (this._currentWidget?.model.name === model.name) {
+      if (this.current?.model.name === model.name) {
         this._chatSelectorPopup?.setCurrentChat(change.new);
       }
     }
@@ -382,6 +409,10 @@ export class MultiChatPanel extends PanelWithToolbar {
   };
 
   private _chatOpened = new Signal<MultiChatPanel, ChatWidget>(this);
+  private _chatNamesChanged = new Signal<
+    MultiChatPanel,
+    { [name: string]: string }
+  >(this);
   private _chatOptions: Omit<Chat.IOptions, 'model' | 'inputToolbarRegistry'>;
   private _inputToolbarFactory?: IInputToolbarRegistryFactory;
   private _updateChatListDebouncer: Debouncer;
@@ -395,7 +426,7 @@ export class MultiChatPanel extends PanelWithToolbar {
   private _openChatWidget?: ReactWidget;
   private _chatSelectorPopup?: ChatSelectorPopup;
   private _loadedModels: Map<string, IChatModel> = new Map();
-  private _currentWidget?: SidePanelWidget;
+  private _currentWidget?: SidePanelWidget | Widget;
   private _chatNames: { [name: string]: string } = {};
   private _visibilityChanged = new Signal<MultiChatPanel, boolean>(this);
   private _trans: TranslationBundle;
@@ -442,6 +473,10 @@ export namespace MultiChatPanel {
      * @returns - a boolean, whether the chat has been renamed or not.
      */
     renameChat?: boolean | ((oldName: string) => Promise<string | null>);
+    /**
+     * An optional placeholder widget, displayed when no chat is opened.
+     */
+    placeholder?: Widget;
   }
   /**
    * The options for the add chat method.

--- a/packages/jupyter-chat/src/widgets/placeholder.tsx
+++ b/packages/jupyter-chat/src/widgets/placeholder.tsx
@@ -3,6 +3,7 @@
  * Distributed under the terms of the Modified BSD License.
  */
 
+import { IRenderMime } from '@jupyterlab/rendermime';
 import {
   addIcon,
   ReactWidget,
@@ -55,6 +56,10 @@ export namespace Placeholder {
      * An optional signal emitting when the chat list changes.
      */
     chatNamesChanged?: ISignal<any, { [name: string]: string }>;
+    /**
+     * An optional translation bundle.
+     */
+    trans?: IRenderMime.TranslationBundle;
   }
 }
 
@@ -62,7 +67,8 @@ export namespace Placeholder {
  * The default placeholder component.
  */
 const PlaceholderComponent = (props: Placeholder.IProps): JSX.Element => {
-  const trans = useTranslator();
+  const trans = props.trans ?? useTranslator();
+
   const [chatNames, setChatNames] = useState<{ [name: string]: string }>(
     props.chatNames
   );

--- a/packages/jupyter-chat/src/widgets/placeholder.tsx
+++ b/packages/jupyter-chat/src/widgets/placeholder.tsx
@@ -11,6 +11,8 @@ import {
 import { ISignal } from '@lumino/signaling';
 import React, { useEffect, useState } from 'react';
 
+import { useTranslator } from '../context';
+
 /**
  * The default placeholder widget.
  */
@@ -60,6 +62,7 @@ export namespace Placeholder {
  * The default placeholder component.
  */
 const PlaceholderComponent = (props: Placeholder.IProps): JSX.Element => {
+  const trans = useTranslator();
   const [chatNames, setChatNames] = useState<{ [name: string]: string }>(
     props.chatNames
   );
@@ -81,22 +84,21 @@ const PlaceholderComponent = (props: Placeholder.IProps): JSX.Element => {
 
   return (
     <div className="jp-chat-placeholder">
-      <h3>No chat opened</h3>
+      <h3>{trans.__('No chat opened')}</h3>
       {props.onCreate && (
         <div className="jp-chat-placeholder-hint">
-          Click{' '}
           <ToolbarButtonComponent
+            label={trans.__('New chat')}
             icon={addIcon}
             onClick={props.onCreate}
-            tooltip="Create a new chat"
+            tooltip={trans.__('Create a new chat')}
             className="jp-chat-add"
-          />{' '}
-          to create a new chat.
+          />
         </div>
       )}
       {names.length > 0 && (
         <div className="jp-chat-placeholder-list">
-          <p>Open an existing chat:</p>
+          <p>{trans.__('Open an existing chat:')}</p>
           {names.map(name => (
             <div key={name}>
               <button

--- a/packages/jupyter-chat/src/widgets/placeholder.tsx
+++ b/packages/jupyter-chat/src/widgets/placeholder.tsx
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+import {
+  addIcon,
+  ReactWidget,
+  ToolbarButtonComponent
+} from '@jupyterlab/ui-components';
+import { ISignal } from '@lumino/signaling';
+import React, { useEffect, useState } from 'react';
+
+/**
+ * The default placeholder widget.
+ */
+export class defaultPlaceholder extends ReactWidget {
+  constructor(options: Placeholder.IProps) {
+    super();
+    this._props = options;
+  }
+
+  render() {
+    return <PlaceholderComponent {...this._props} />;
+  }
+
+  private _props: Placeholder.IProps;
+}
+
+/**
+ * The placeholder namespace.
+ */
+export namespace Placeholder {
+  /**
+   * The options of the placeholder widget.
+   */
+  export interface IProps {
+    /**
+     * The initial chat names.
+     */
+    chatNames: { [name: string]: string };
+    /**
+     * A callback to open an existing chat by name.
+     *
+     * @param name - the display name of the chat to open.
+     */
+    open: (name: string) => Promise<void>;
+    /**
+     * A callback to create and open a new chat.
+     */
+    onCreate?: () => Promise<void>;
+    /**
+     * An optional signal emitting when the chat list changes.
+     */
+    chatNamesChanged?: ISignal<any, { [name: string]: string }>;
+  }
+}
+
+/**
+ * The default placeholder component.
+ */
+const PlaceholderComponent = (props: Placeholder.IProps): JSX.Element => {
+  const [chatNames, setChatNames] = useState<{ [name: string]: string }>(
+    props.chatNames
+  );
+
+  useEffect(() => {
+    if (!props.chatNamesChanged) {
+      return;
+    }
+    const onChanged = (_: any, names: { [name: string]: string }) => {
+      setChatNames(names);
+    };
+    props.chatNamesChanged.connect(onChanged);
+    return () => {
+      props.chatNamesChanged!.disconnect(onChanged);
+    };
+  }, [props.chatNamesChanged]);
+
+  const names = Object.keys(chatNames).sort((a, b) => a.localeCompare(b));
+
+  return (
+    <div className="jp-chat-placeholder">
+      <h3>No chat opened</h3>
+      {props.onCreate && (
+        <div className="jp-chat-placeholder-hint">
+          Click{' '}
+          <ToolbarButtonComponent
+            icon={addIcon}
+            onClick={props.onCreate}
+            tooltip="Create a new chat"
+            className="jp-chat-add"
+          />{' '}
+          to create a new chat.
+        </div>
+      )}
+      {names.length > 0 && (
+        <div className="jp-chat-placeholder-list">
+          <p>Open an existing chat:</p>
+          {names.map(name => (
+            <div key={name}>
+              <button
+                className="jp-chat-placeholder-chat-item"
+                onClick={() => props.open(name)}
+              >
+                {name}
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/packages/jupyter-chat/style/base.css
+++ b/packages/jupyter-chat/style/base.css
@@ -13,3 +13,4 @@
 @import url('./chat-settings.css');
 @import url('./chat-selector.css');
 @import url('./input.css');
+@import url('./placeholder.css');

--- a/packages/jupyter-chat/style/placeholder.css
+++ b/packages/jupyter-chat/style/placeholder.css
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+.jp-chat-placeholder {
+  text-align: center;
+  color: var(--jp-content-font-color2);
+}
+
+.jp-chat-placeholder > h3 {
+  margin-bottom: var(--jp-content-heading-margin-bottom);
+}
+
+.jp-chat-placeholder-hint {
+  display: inline-flex;
+  align-items: center;
+}
+
+.jp-chat-placeholder-chat-item {
+  color: var(--jp-content-font-color1);
+  background: none;
+  border: none;
+  padding: 2px 0;
+  font: inherit;
+  cursor: pointer;
+  text-align: left;
+  text-decoration: none;
+}
+
+.jp-chat-placeholder-chat-item:hover {
+  text-decoration: underline;
+  font-weight: bold;
+}

--- a/packages/jupyter-chat/style/placeholder.css
+++ b/packages/jupyter-chat/style/placeholder.css
@@ -12,11 +12,6 @@
   margin-bottom: var(--jp-content-heading-margin-bottom);
 }
 
-.jp-chat-placeholder-hint {
-  display: inline-flex;
-  align-items: center;
-}
-
 .jp-chat-placeholder-chat-item {
   color: var(--jp-content-font-color1);
   background: none;

--- a/packages/jupyterlab-chat-extension/src/index.ts
+++ b/packages/jupyterlab-chat-extension/src/index.ts
@@ -15,6 +15,7 @@ import {
   IChatTracker,
   IMessageFooterRegistry,
   IMessagePreambleRegistry,
+  IChatPlaceholderFactory,
   ISelectionWatcher,
   InputToolbarRegistry,
   MessageFooterRegistry,
@@ -920,6 +921,7 @@ const chatPanel: JupyterFrontEndPlugin<MultiChatPanel> = {
     ILayoutRestorer,
     IMessageFooterRegistry,
     IMessagePreambleRegistry,
+    IChatPlaceholderFactory,
     IThemeManager,
     ITranslator,
     IWelcomeMessage
@@ -935,6 +937,7 @@ const chatPanel: JupyterFrontEndPlugin<MultiChatPanel> = {
     restorer: ILayoutRestorer | null,
     messageFooterRegistry: IMessageFooterRegistry,
     messagePreambleRegistry: IMessagePreambleRegistry,
+    placeholderFactory: IChatPlaceholderFactory | null,
     themeManager: IThemeManager | null,
     translator_: ITranslator | null,
     welcomeMessage: string
@@ -988,7 +991,8 @@ const chatPanel: JupyterFrontEndPlugin<MultiChatPanel> = {
       inputToolbarFactory,
       messageFooterRegistry,
       messagePreambleRegistry,
-      welcomeMessage
+      welcomeMessage,
+      placeholderFactory: placeholderFactory ?? undefined
     });
     chatPanel.id = 'JupyterlabChat:sidepanel';
 

--- a/packages/jupyterlab-chat/src/token.ts
+++ b/packages/jupyterlab-chat/src/token.ts
@@ -5,14 +5,14 @@
 
 import {
   IConfig,
-  chatIcon,
   IActiveCellManager,
-  ISelectionWatcher
+  ISelectionWatcher,
+  MultiChatPanel,
+  chatIcon
 } from '@jupyter/chat';
 import { DocumentRegistry } from '@jupyterlab/docregistry';
 import { Token } from '@lumino/coreutils';
 import { ISignal } from '@lumino/signaling';
-import { MultiChatPanel } from '@jupyter/chat';
 import { ChatWidgetFactory } from './factory';
 
 /**

--- a/ui-tests/tests/placeholder.spec.ts
+++ b/ui-tests/tests/placeholder.spec.ts
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+import { expect, test } from '@jupyterlab/galata';
+
+import { openSidePanel } from './test-utils';
+
+const CHAT_NAME = 'my-chat';
+const FILENAME = `${CHAT_NAME}.chat`;
+
+test.describe('#placeholder', () => {
+  test.describe('#initialization', () => {
+    test('should show the placeholder when no chat is opened', async ({
+      page
+    }) => {
+      const panel = await openSidePanel(page);
+      const placeholder = panel.locator('.jp-chat-placeholder');
+      await expect(placeholder).toBeVisible();
+    });
+
+    test('should show the hint to create a new chat', async ({ page }) => {
+      const panel = await openSidePanel(page);
+      const hint = panel.locator('.jp-chat-placeholder-hint');
+      await expect(hint).toBeVisible();
+    });
+
+    test('should show no chat list when no chat file exists', async ({
+      page
+    }) => {
+      const panel = await openSidePanel(page);
+      const items = panel.locator('.jp-chat-placeholder-chat-item');
+      await expect(items).toHaveCount(0);
+    });
+  });
+
+  test.describe('#chatList', () => {
+    test.beforeEach(async ({ page }) => {
+      await page.filebrowser.contents.uploadContent('{}', 'text', FILENAME);
+    });
+
+    test.afterEach(async ({ page }) => {
+      if (await page.filebrowser.contents.fileExists(FILENAME)) {
+        await page.filebrowser.contents.deleteFile(FILENAME);
+      }
+    });
+
+    test('should list an existing chat file', async ({ page }) => {
+      await page.waitForCondition(
+        async () =>
+          await page.filebrowser.contents.fileExists(FILENAME)
+      );
+
+      const panel = await openSidePanel(page);
+      const items = panel.locator('.jp-chat-placeholder-chat-item');
+      await expect(items).toHaveCount(1);
+      await expect(items.first()).toHaveText(CHAT_NAME);
+    });
+
+    test('should list multiple chat files sorted alphabetically', async ({
+      page
+    }) => {
+      const files = ['charlie.chat', 'alpha.chat', 'bravo.chat'];
+      for (const file of files) {
+        await page.filebrowser.contents.uploadContent('{}', 'text', file);
+      }
+      await page.waitForCondition(async () => {
+        for (const file of files) {
+          if (!(await page.filebrowser.contents.fileExists(file))) {
+            return false;
+          }
+        }
+        return true;
+      });
+
+      const panel = await openSidePanel(page);
+      const items = panel.locator('.jp-chat-placeholder-chat-item');
+      await expect(items).toHaveCount(4);
+      await expect(items.nth(0)).toHaveText('alpha');
+      await expect(items.nth(1)).toHaveText('bravo');
+      await expect(items.nth(2)).toHaveText('charlie');
+      await expect(items.nth(3)).toHaveText(CHAT_NAME);
+
+      for (const file of files) {
+        await page.filebrowser.contents.deleteFile(file);
+      }
+    });
+
+    test('should open a chat when clicking its name in the list', async ({
+      page
+    }) => {
+      await page.waitForCondition(
+        async () => await page.filebrowser.contents.fileExists(FILENAME)
+      );
+
+      const panel = await openSidePanel(page);
+      await panel.locator('.jp-chat-placeholder-chat-item').first().click();
+
+      const chatToolbar = panel.locator(
+        '.jp-chat-sidepanel-widget .jp-chat-sidepanel-widget-toolbar'
+      );
+      await expect(chatToolbar).toBeVisible();
+      await expect(
+        chatToolbar.locator('.jp-chat-sidepanel-widget-title')
+      ).toHaveText(CHAT_NAME);
+    });
+
+    test('should hide the placeholder after opening a chat', async ({
+      page
+    }) => {
+      await page.waitForCondition(
+        async () => await page.filebrowser.contents.fileExists(FILENAME)
+      );
+
+      const panel = await openSidePanel(page);
+      await panel.locator('.jp-chat-placeholder-chat-item').first().click();
+
+      await expect(panel.locator('.jp-chat-placeholder')).not.toBeAttached();
+    });
+  });
+
+  test.describe('#dynamicUpdate', () => {
+    test.afterEach(async ({ page }) => {
+      if (await page.filebrowser.contents.fileExists(FILENAME)) {
+        await page.filebrowser.contents.deleteFile(FILENAME);
+      }
+    });
+
+    test('should update the list when a chat file is created or deleted', async ({
+      page
+    }) => {
+      const panel = await openSidePanel(page);
+      const items = panel.locator('.jp-chat-placeholder-chat-item');
+
+      // No chat initially.
+      await expect(items).toHaveCount(0);
+
+      // Create a chat file and expect the list to update.
+      await page.filebrowser.contents.uploadContent('{}', 'text', FILENAME);
+      await expect(items).toHaveCount(1);
+      await expect(items.first()).toHaveText(CHAT_NAME);
+
+      // Delete the file and expect the list to update.
+      await page.filebrowser.contents.deleteFile(FILENAME);
+      await expect(items).toHaveCount(0);
+    });
+  });
+});

--- a/ui-tests/tests/placeholder.spec.ts
+++ b/ui-tests/tests/placeholder.spec.ts
@@ -48,8 +48,7 @@ test.describe('#placeholder', () => {
 
     test('should list an existing chat file', async ({ page }) => {
       await page.waitForCondition(
-        async () =>
-          await page.filebrowser.contents.fileExists(FILENAME)
+        async () => await page.filebrowser.contents.fileExists(FILENAME)
       );
 
       const panel = await openSidePanel(page);


### PR DESCRIPTION
Add a placeholder to the empty chat panel.

<img width="500" alt="image" src="https://github.com/user-attachments/assets/7dff609d-1458-454b-a96c-e40434eb5cfd" />

It add a "+" button and the list of available chats. This panel is displayed by default, and when the current chat is closed.

There is also an extension point, the plugin in `jupyterlab-chat` has an optional dependency on `IChatPlaceholderFactory` that can be provided by an extension, and propagated to the chat side panel.

Fixes #408