### PR TITLE
Restore send with selection

### DIFF
--- a/docs/source/users/index.md
+++ b/docs/source/users/index.md
@@ -119,15 +119,30 @@ These settings includes:
 
 - **stackMessages**
 
-  Whether to stack consecutive messages from same user.\
+  Whether or not to stack consecutive messages from same user.\
   Default: true
 
 - **unreadNotifications**
 
-  Whether to enable or not the notifications on unread messages.\
+  Whether or not to enable the notifications on unread messages.\
   Default: true
 
 - **enableCodeToolbar**
 
-  Whether to enable or not the code toolbar.\
+  Whether or not to enable the code toolbar.\
   Default: true
+
+- **sendTypingNotification**
+
+  Whether or not to let collaborators know that you're typing.\
+  Default: true
+
+- **showDeleted**
+
+  Whether or not to display deleted messages in the chat UI.\
+  Default: false
+
+- **sendWithSelection**
+
+  Whether to display the button for adding selected text when sending a message.\
+  Default: false

--- a/packages/jupyter-chat/src/components/input/buttons/send-button.tsx
+++ b/packages/jupyter-chat/src/components/input/buttons/send-button.tsx
@@ -4,22 +4,29 @@
  */
 
 import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
-import React, { useEffect, useState } from 'react';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import { Box, Menu, MenuItem, Typography } from '@mui/material';
+import React, { useCallback, useEffect, useState } from 'react';
 
 import { InputToolbarRegistry } from '../toolbar-registry';
 import { TooltippedIconButton } from '../../mui-extras';
 import { useTranslator } from '../../../context';
+import { includeSelectionIcon } from '../../../icons';
 import { IInputModel, InputModel } from '../../../input-model';
 
 const SEND_BUTTON_CLASS = 'jp-chat-send-button';
+const SEND_INCLUDE_OPENER_CLASS = 'jp-chat-send-include-opener';
+const SEND_INCLUDE_LI_CLASS = 'jp-chat-send-include';
 
 /**
- * The send button.
+ * The send button, with optional 'include selection' menu.
  */
 export function SendButton(
   props: InputToolbarRegistry.IToolbarItemProps
 ): JSX.Element {
   const { model, chatCommandRegistry, edit } = props;
+  const { activeCellManager, selectionWatcher } = model;
+  const hideIncludeSelection = !activeCellManager || !selectionWatcher;
   const trans = useTranslator();
 
   // Don't show this button when in edit mode
@@ -27,8 +34,21 @@ export function SendButton(
     return <></>;
   }
 
+  const [menuAnchorEl, setMenuAnchorEl] = useState<HTMLElement | null>(null);
+  const [menuOpen, setMenuOpen] = useState(false);
   const [disabled, setDisabled] = useState(false);
   const [tooltip, setTooltip] = useState<string>('');
+  const [selectionTooltip, setSelectionTooltip] = useState<string>('');
+  const [disableInclude, setDisableInclude] = useState<boolean>(true);
+
+  const openMenu = useCallback((el: HTMLElement | null) => {
+    setMenuAnchorEl(el);
+    setMenuOpen(true);
+  }, []);
+
+  const closeMenu = useCallback(() => {
+    setMenuOpen(false);
+  }, []);
 
   useEffect(() => {
     const inputChanged = () => {
@@ -60,6 +80,30 @@ export function SendButton(
     };
   }, [model]);
 
+  useEffect(() => {
+    const toggleIncludeState = () => {
+      setDisableInclude(
+        !(selectionWatcher?.selection || activeCellManager?.available)
+      );
+      const tip = selectionWatcher?.selection
+        ? trans.__('%1 line(s) selected', selectionWatcher.selection.numLines)
+        : activeCellManager?.available
+          ? trans.__('Code from 1 active cell')
+          : trans.__('No selection or active cell');
+      setSelectionTooltip(tip);
+    };
+
+    if (!hideIncludeSelection) {
+      selectionWatcher?.selectionChanged.connect(toggleIncludeState);
+      activeCellManager?.availabilityChanged.connect(toggleIncludeState);
+      toggleIncludeState();
+    }
+    return () => {
+      selectionWatcher?.selectionChanged.disconnect(toggleIncludeState);
+      activeCellManager?.availabilityChanged.disconnect(toggleIncludeState);
+    };
+  }, [activeCellManager, selectionWatcher]);
+
   async function send() {
     // Run all command providers
     await chatCommandRegistry?.onSubmit(model);
@@ -71,18 +115,112 @@ export function SendButton(
     model.focus();
   }
 
+  async function sendWithSelection() {
+    await chatCommandRegistry?.onSubmit(model);
+
+    let source = '';
+    let language: string | undefined;
+
+    if (selectionWatcher?.selection) {
+      source = selectionWatcher.selection.text;
+      language = selectionWatcher.selection.language;
+    } else if (activeCellManager?.available) {
+      const content = activeCellManager.getContent(false);
+      source = content!.source;
+      language = content?.language;
+    }
+
+    let body = model.value;
+    if (source) {
+      body += `\n\n\`\`\`${language ?? ''}\n${source}\n\`\`\`\n`;
+    }
+
+    model.value = '';
+    closeMenu();
+    model.send(body);
+    model.focus();
+  }
+
   return (
-    <TooltippedIconButton
-      onClick={send}
-      tooltip={tooltip}
-      disabled={disabled}
-      buttonProps={{
-        title: tooltip,
-        className: SEND_BUTTON_CLASS
-      }}
-      aria-label={tooltip}
-    >
-      <ArrowUpwardIcon />
-    </TooltippedIconButton>
+    <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: '1px' }}>
+      <TooltippedIconButton
+        onClick={send}
+        tooltip={tooltip}
+        disabled={disabled}
+        sx={{
+          borderRadius: hideIncludeSelection
+            ? 'var(--jp-border-radius)'
+            : 'var(--jp-border-radius) 0 0 var(--jp-border-radius) !important'
+        }}
+        buttonProps={{
+          title: tooltip,
+          className: SEND_BUTTON_CLASS
+        }}
+        aria-label={tooltip}
+      >
+        <ArrowUpwardIcon />
+      </TooltippedIconButton>
+      {!hideIncludeSelection && (
+        <>
+          <TooltippedIconButton
+            onClick={e => openMenu(e.currentTarget)}
+            tooltip={trans.__('Send with selection')}
+            disabled={disabled}
+            sx={{
+              borderRadius:
+                '0 var(--jp-border-radius) var(--jp-border-radius) 0 !important',
+              width: '16px',
+              minWidth: '16px'
+            }}
+            buttonProps={{
+              onKeyDown: e => {
+                if (e.key !== 'Enter' && e.key !== ' ') {
+                  return;
+                }
+                openMenu(e.currentTarget);
+                e.stopPropagation();
+              },
+              className: SEND_INCLUDE_OPENER_CLASS
+            }}
+          >
+            <KeyboardArrowDownIcon sx={{ fontSize: '12px' }} />
+          </TooltippedIconButton>
+          <Menu
+            open={menuOpen}
+            onClose={closeMenu}
+            anchorEl={menuAnchorEl}
+            anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
+            transformOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+            sx={{
+              '& .MuiMenuItem-root': {
+                display: 'flex',
+                alignItems: 'center',
+                gap: '8px'
+              },
+              '& svg': { lineHeight: 0 }
+            }}
+          >
+            <MenuItem
+              onClick={e => {
+                sendWithSelection();
+                e.stopPropagation();
+              }}
+              disabled={disableInclude}
+              className={SEND_INCLUDE_LI_CLASS}
+            >
+              <includeSelectionIcon.react />
+              <Box>
+                <Typography display="block">
+                  {trans.__('Send message with selection')}
+                </Typography>
+                <Typography display="block" sx={{ opacity: 0.618 }}>
+                  {selectionTooltip}
+                </Typography>
+              </Box>
+            </MenuItem>
+          </Menu>
+        </>
+      )}
+    </Box>
   );
 }

--- a/packages/jupyter-chat/src/components/input/buttons/send-button.tsx
+++ b/packages/jupyter-chat/src/components/input/buttons/send-button.tsx
@@ -26,7 +26,7 @@ export function SendButton(
 ): JSX.Element {
   const { model, chatCommandRegistry, edit } = props;
   const { activeCellManager, selectionWatcher } = model;
-  const hideIncludeSelection = !activeCellManager || !selectionWatcher;
+  const supportSelection = !!activeCellManager || !!selectionWatcher;
   const trans = useTranslator();
 
   // Don't show this button when in edit mode
@@ -40,6 +40,9 @@ export function SendButton(
   const [tooltip, setTooltip] = useState<string>('');
   const [selectionTooltip, setSelectionTooltip] = useState<string>('');
   const [disableInclude, setDisableInclude] = useState<boolean>(true);
+  const [showSendWithSelection, setShowSendWithSelection] = useState<boolean>(
+    supportSelection && (model.config.sendWithSelection ?? true)
+  );
 
   const openMenu = useCallback((el: HTMLElement | null) => {
     setMenuAnchorEl(el);
@@ -67,6 +70,9 @@ export function SendButton(
           ? trans.__('Send message (SHIFT+ENTER)')
           : trans.__('Send message (ENTER)')
       );
+      setShowSendWithSelection(
+        supportSelection && (config.sendWithSelection ?? true)
+      );
     };
     model.configChanged.connect(configChanged);
 
@@ -93,7 +99,7 @@ export function SendButton(
       setSelectionTooltip(tip);
     };
 
-    if (!hideIncludeSelection) {
+    if (supportSelection) {
       selectionWatcher?.selectionChanged.connect(toggleIncludeState);
       activeCellManager?.availabilityChanged.connect(toggleIncludeState);
       toggleIncludeState();
@@ -148,9 +154,9 @@ export function SendButton(
         tooltip={tooltip}
         disabled={disabled}
         sx={{
-          borderRadius: hideIncludeSelection
-            ? 'var(--jp-border-radius)'
-            : 'var(--jp-border-radius) 0 0 var(--jp-border-radius) !important'
+          borderRadius: showSendWithSelection
+            ? 'var(--jp-border-radius) 0 0 var(--jp-border-radius) !important'
+            : 'var(--jp-border-radius)'
         }}
         buttonProps={{
           title: tooltip,
@@ -160,7 +166,7 @@ export function SendButton(
       >
         <ArrowUpwardIcon />
       </TooltippedIconButton>
-      {!hideIncludeSelection && (
+      {showSendWithSelection && (
         <>
           <TooltippedIconButton
             onClick={e => openMenu(e.currentTarget)}

--- a/packages/jupyter-chat/src/components/input/buttons/send-button.tsx
+++ b/packages/jupyter-chat/src/components/input/buttons/send-button.tsx
@@ -99,7 +99,7 @@ export function SendButton(
       setSelectionTooltip(tip);
     };
 
-    if (supportSelection) {
+    if (showSendWithSelection) {
       selectionWatcher?.selectionChanged.connect(toggleIncludeState);
       activeCellManager?.availabilityChanged.connect(toggleIncludeState);
       toggleIncludeState();
@@ -108,7 +108,7 @@ export function SendButton(
       selectionWatcher?.selectionChanged.disconnect(toggleIncludeState);
       activeCellManager?.availabilityChanged.disconnect(toggleIncludeState);
     };
-  }, [activeCellManager, selectionWatcher]);
+  }, [activeCellManager, selectionWatcher, showSendWithSelection]);
 
   async function send() {
     // Run all command providers

--- a/packages/jupyter-chat/src/input-model.ts
+++ b/packages/jupyter-chat/src/input-model.ts
@@ -579,6 +579,10 @@ export namespace InputModel {
      * Whether to send a message via Shift-Enter instead of Enter.
      */
     sendWithShiftEnter?: boolean;
+    /**
+     * Whether to display the 'send with selection' button.
+     */
+    sendWithSelection?: boolean;
   }
 }
 

--- a/packages/jupyter-chat/src/theme-provider.ts
+++ b/packages/jupyter-chat/src/theme-provider.ts
@@ -68,7 +68,7 @@ export async function getJupyterLabTheme(): Promise<Theme> {
             style: {
               backgroundColor: `var(--jp-brand-color${light ? '1' : '2'})`,
               color: 'var(--jp-ui-inverse-font-color1)',
-              borderRadius: '4px',
+              borderRadius: 'var(--jp-border-radius)',
               boxShadow: 'none',
               '&:hover': {
                 backgroundColor: `var(--jp-brand-color${light ? '0' : '1'})`,
@@ -125,7 +125,7 @@ export async function getJupyterLabTheme(): Promise<Theme> {
             style: {
               backgroundColor: `var(--jp-brand-color${light ? '1' : '2'})`,
               color: 'var(--jp-ui-inverse-font-color1)',
-              borderRadius: '4px',
+              borderRadius: 'var(--jp-border-radius)',
               boxShadow: 'none',
               '&:hover': {
                 backgroundColor: `var(--jp-brand-color${light ? '0' : '1'})`,

--- a/packages/jupyter-chat/src/types.ts
+++ b/packages/jupyter-chat/src/types.ts
@@ -59,6 +59,10 @@ export interface IConfig {
    * Whether to display deleted messages.
    */
   showDeleted?: boolean;
+  /**
+   * Whether to display the 'send with selection' button.
+   */
+  sendWithSelection?: boolean;
 }
 
 /**

--- a/packages/jupyterlab-chat-extension/schema/factory.json
+++ b/packages/jupyterlab-chat-extension/schema/factory.json
@@ -46,7 +46,7 @@
     "sendWithSelection": {
       "description": "Show the 'send with selection' button in the chat input.",
       "type": "boolean",
-      "default": true,
+      "default": false,
       "readOnly": false
     },
     "defaultDirectory": {

--- a/packages/jupyterlab-chat-extension/schema/factory.json
+++ b/packages/jupyterlab-chat-extension/schema/factory.json
@@ -43,6 +43,12 @@
       "default": false,
       "readOnly": false
     },
+    "sendWithSelection": {
+      "description": "Show the 'send with selection' button in the chat input.",
+      "type": "boolean",
+      "default": true,
+      "readOnly": false
+    },
     "defaultDirectory": {
       "description": "Default directory where to create and look for chat, the jupyter root directory if empty.",
       "type": "string",

--- a/packages/jupyterlab-chat-extension/src/index.ts
+++ b/packages/jupyterlab-chat-extension/src/index.ts
@@ -252,6 +252,8 @@ const chatConfig: JupyterFrontEndPlugin<IWidgetConfig> = {
           sendTypingNotification: setting.get('sendTypingNotification')
             .composite as boolean,
           showDeleted: setting.get('showDeleted').composite as boolean,
+          sendWithSelection: setting.get('sendWithSelection')
+            .composite as boolean,
           defaultDirectory: currentDirectory
         };
       });

--- a/ui-tests/tests/input-toolbar.spec.ts
+++ b/ui-tests/tests/input-toolbar.spec.ts
@@ -53,7 +53,8 @@ test.describe('#inputToolbar', () => {
       '.jp-chat-input-container .jp-chat-input-toolbar'
     );
     await expect(inputToolbar).toBeVisible();
-    await expect(inputToolbar.locator('button')).toHaveCount(1);
+    // send button + send-with-selection opener
+    await expect(inputToolbar.locator('button')).toHaveCount(2);
     expect(inputToolbar.locator('.jp-chat-attach-button')).not.toBeAttached();
 
     // The side panel chat input should contain the 'attach' button.
@@ -62,7 +63,8 @@ test.describe('#inputToolbar', () => {
       '.jp-chat-input-container .jp-chat-input-toolbar'
     );
     await expect(inputToolbarSide).toBeVisible();
-    await expect(inputToolbarSide.locator('button')).toHaveCount(2);
+    // send button + send-with-selection opener + attach button
+    await expect(inputToolbarSide.locator('button')).toHaveCount(3);
     expect(inputToolbarSide.locator('.jp-chat-attach-button')).toBeAttached();
   });
 });

--- a/ui-tests/tests/input-toolbar.spec.ts
+++ b/ui-tests/tests/input-toolbar.spec.ts
@@ -53,8 +53,7 @@ test.describe('#inputToolbar', () => {
       '.jp-chat-input-container .jp-chat-input-toolbar'
     );
     await expect(inputToolbar).toBeVisible();
-    // send button + send-with-selection opener
-    await expect(inputToolbar.locator('button')).toHaveCount(2);
+    await expect(inputToolbar.locator('button')).toHaveCount(1);
     expect(inputToolbar.locator('.jp-chat-attach-button')).not.toBeAttached();
 
     // The side panel chat input should contain the 'attach' button.
@@ -63,8 +62,7 @@ test.describe('#inputToolbar', () => {
       '.jp-chat-input-container .jp-chat-input-toolbar'
     );
     await expect(inputToolbarSide).toBeVisible();
-    // send button + send-with-selection opener + attach button
-    await expect(inputToolbarSide.locator('button')).toHaveCount(3);
+    await expect(inputToolbarSide.locator('button')).toHaveCount(2);
     expect(inputToolbarSide.locator('.jp-chat-attach-button')).toBeAttached();
   });
 });

--- a/ui-tests/tests/send-message.spec.ts
+++ b/ui-tests/tests/send-message.spec.ts
@@ -3,7 +3,7 @@
  * Distributed under the terms of the Modified BSD License.
  */
 
-import { expect, test } from '@jupyterlab/galata';
+import { expect, galata, test } from '@jupyterlab/galata';
 
 import {
   openChat,
@@ -95,10 +95,79 @@ test.describe('#sendMessages', () => {
     ).toHaveText(MSG_CONTENT + '\n');
   });
 
+  test('should update settings value sendWithShiftEnter on existing chat', async ({
+    page
+  }) => {
+    const chatPanel = await openChat(page, FILENAME);
+
+    // Modify the settings
+    const settings = await openSettings(page);
+    const sendWithShiftEnter = settings?.getByRole('checkbox', {
+      name: 'sendWithShiftEnter'
+    });
+    await sendWithShiftEnter?.check();
+
+    // wait for the settings to be saved
+    await expect(page.activity.getTabLocator('Settings')).toHaveAttribute(
+      'class',
+      /jp-mod-dirty/
+    );
+    await expect(page.activity.getTabLocator('Settings')).not.toHaveAttribute(
+      'class',
+      /jp-mod-dirty/
+    );
+
+    // Activate the chat panel
+    await page.activity.activateTab(FILENAME);
+
+    // Should not send message with Enter
+    const messages = chatPanel.locator('.jp-chat-messages-container');
+    const input = chatPanel
+      .locator('.jp-chat-input-container')
+      .getByRole('combobox');
+    await input!.pressSequentially(MSG_CONTENT);
+    await input!.press('Enter');
+
+    await expect(messages!.locator('.jp-chat-message')).toHaveCount(0);
+
+    // Should not send message with Shift+Enter
+    await input!.press('Shift+Enter');
+    await expect(messages!.locator('.jp-chat-message')).toHaveCount(1);
+
+    // It seems that the markdown renderer adds a new line, but the '\n' inserted when
+    // pressing Enter above is trimmed.
+    await expect(
+      messages.locator('.jp-chat-message .jp-chat-rendered-message')
+    ).toHaveText(MSG_CONTENT + '\n');
+  });
+});
+
+test.describe('#sendWithSelection', () => {
+  test.use({
+    mockSettings: {
+      ...galata.DEFAULT_SETTINGS,
+      'jupyterlab-chat-extension:factory': {
+        sendWithSelection: true
+      }
+    }
+  });
+
+  test.beforeEach(async ({ page }) => {
+    // Create a chat file
+    await page.filebrowser.contents.uploadContent('{}', 'text', FILENAME);
+  });
+
+  test.afterEach(async ({ page }) => {
+    if (await page.filebrowser.contents.fileExists(FILENAME)) {
+      await page.filebrowser.contents.deleteFile(FILENAME);
+    }
+  });
+
   test('should hide send-with-selection button when setting is disabled', async ({
     page
   }) => {
     const settings = await openSettings(page);
+    await page.pause();
     const sendWithSelection = settings?.getByRole('checkbox', {
       name: 'sendWithSelection'
     });
@@ -283,51 +352,5 @@ test.describe('#sendMessages', () => {
     );
     await expect(rendered).toHaveText(`${MSG_CONTENT}\nprint\n`);
     await expect(rendered.locator('code')).toHaveClass(/language-[i]?python/);
-  });
-
-  test('should update settings value sendWithShiftEnter on existing chat', async ({
-    page
-  }) => {
-    const chatPanel = await openChat(page, FILENAME);
-
-    // Modify the settings
-    const settings = await openSettings(page);
-    const sendWithShiftEnter = settings?.getByRole('checkbox', {
-      name: 'sendWithShiftEnter'
-    });
-    await sendWithShiftEnter?.check();
-
-    // wait for the settings to be saved
-    await expect(page.activity.getTabLocator('Settings')).toHaveAttribute(
-      'class',
-      /jp-mod-dirty/
-    );
-    await expect(page.activity.getTabLocator('Settings')).not.toHaveAttribute(
-      'class',
-      /jp-mod-dirty/
-    );
-
-    // Activate the chat panel
-    await page.activity.activateTab(FILENAME);
-
-    // Should not send message with Enter
-    const messages = chatPanel.locator('.jp-chat-messages-container');
-    const input = chatPanel
-      .locator('.jp-chat-input-container')
-      .getByRole('combobox');
-    await input!.pressSequentially(MSG_CONTENT);
-    await input!.press('Enter');
-
-    await expect(messages!.locator('.jp-chat-message')).toHaveCount(0);
-
-    // Should not send message with Shift+Enter
-    await input!.press('Shift+Enter');
-    await expect(messages!.locator('.jp-chat-message')).toHaveCount(1);
-
-    // It seems that the markdown renderer adds a new line, but the '\n' inserted when
-    // pressing Enter above is trimmed.
-    await expect(
-      messages.locator('.jp-chat-message .jp-chat-rendered-message')
-    ).toHaveText(MSG_CONTENT + '\n');
   });
 });

--- a/ui-tests/tests/send-message.spec.ts
+++ b/ui-tests/tests/send-message.spec.ts
@@ -5,7 +5,12 @@
 
 import { expect, test } from '@jupyterlab/galata';
 
-import { openChat, openSettings, sendMessage } from './test-utils';
+import {
+  openChat,
+  openSettings,
+  sendMessage,
+  splitMainArea
+} from './test-utils';
 
 const FILENAME = 'my-chat.chat';
 const MSG_CONTENT = 'Hello World!';
@@ -88,6 +93,196 @@ test.describe('#sendMessages', () => {
     await expect(
       messages.locator('.jp-chat-message .jp-chat-rendered-message')
     ).toHaveText(MSG_CONTENT + '\n');
+  });
+
+  test('should hide send-with-selection button when setting is disabled', async ({
+    page
+  }) => {
+    const settings = await openSettings(page);
+    const sendWithSelection = settings?.getByRole('checkbox', {
+      name: 'sendWithSelection'
+    });
+    await sendWithSelection?.uncheck();
+
+    await expect(page.activity.getTabLocator('Settings')).toHaveAttribute(
+      'class',
+      /jp-mod-dirty/
+    );
+    await expect(page.activity.getTabLocator('Settings')).not.toHaveAttribute(
+      'class',
+      /jp-mod-dirty/
+    );
+
+    const chatPanel = await openChat(page, FILENAME);
+    const openerButton = chatPanel.locator(
+      '.jp-chat-input-container .jp-chat-send-include-opener'
+    );
+    await expect(openerButton).not.toBeAttached();
+  });
+
+  test('should update send-with-selection button on existing chat', async ({
+    page
+  }) => {
+    const chatPanel = await openChat(page, FILENAME);
+
+    const settings = await openSettings(page);
+    const sendWithSelection = settings?.getByRole('checkbox', {
+      name: 'sendWithSelection'
+    });
+    await sendWithSelection?.uncheck();
+
+    await expect(page.activity.getTabLocator('Settings')).toHaveAttribute(
+      'class',
+      /jp-mod-dirty/
+    );
+    await expect(page.activity.getTabLocator('Settings')).not.toHaveAttribute(
+      'class',
+      /jp-mod-dirty/
+    );
+
+    await page.activity.activateTab(FILENAME);
+    const openerButton = chatPanel.locator(
+      '.jp-chat-input-container .jp-chat-send-include-opener'
+    );
+    await expect(openerButton).not.toBeAttached();
+  });
+
+  test('should disable send with selection when there is no notebook', async ({
+    page
+  }) => {
+    const chatPanel = await openChat(page, FILENAME);
+    const input = chatPanel
+      .locator('.jp-chat-input-container')
+      .getByRole('combobox');
+    const openerButton = chatPanel.locator(
+      '.jp-chat-input-container .jp-chat-send-include-opener'
+    );
+    const sendWithSelectionItem = page.locator('.jp-chat-send-include');
+
+    await input.pressSequentially(MSG_CONTENT);
+    await openerButton.click();
+    await expect(sendWithSelectionItem).toBeVisible();
+    await expect(sendWithSelectionItem).toBeDisabled();
+    await expect(sendWithSelectionItem).toContainText(
+      'No selection or active cell'
+    );
+  });
+
+  test('should send with code cell content', async ({ page }) => {
+    const cellContent = 'a = 1\nprint(f"a={a}")';
+    const chatPanel = await openChat(page, FILENAME);
+    const messages = chatPanel.locator('.jp-chat-messages-container');
+    const input = chatPanel
+      .locator('.jp-chat-input-container')
+      .getByRole('combobox');
+    const openerButton = chatPanel.locator(
+      '.jp-chat-input-container .jp-chat-send-include-opener'
+    );
+    const sendWithSelectionItem = page.locator('.jp-chat-send-include');
+
+    const notebook = await page.notebook.createNew();
+    const cell = (await page.notebook.getCellLocator(0))!;
+    await cell.getByRole('textbox').pressSequentially(cellContent);
+
+    await splitMainArea(page, notebook!);
+
+    await input.pressSequentially(MSG_CONTENT);
+    await openerButton.click();
+    await expect(sendWithSelectionItem).toBeVisible();
+    await expect(sendWithSelectionItem).toBeEnabled();
+    await expect(sendWithSelectionItem).toContainText(
+      'Code from 1 active cell'
+    );
+    await sendWithSelectionItem.click();
+    await expect(messages!.locator('.jp-chat-message')).toHaveCount(1);
+
+    const rendered = messages.locator(
+      '.jp-chat-message .jp-chat-rendered-message'
+    );
+    await expect(rendered).toHaveText(`${MSG_CONTENT}\n${cellContent}\n`);
+    await expect(rendered.locator('code')).toHaveClass('language-python');
+  });
+
+  test('should send with markdown cell content', async ({ page }) => {
+    const cellContent = 'markdown content';
+    const chatPanel = await openChat(page, FILENAME);
+    const messages = chatPanel.locator('.jp-chat-messages-container');
+    const input = chatPanel
+      .locator('.jp-chat-input-container')
+      .getByRole('combobox');
+    const openerButton = chatPanel.locator(
+      '.jp-chat-input-container .jp-chat-send-include-opener'
+    );
+    const sendWithSelectionItem = page.locator('.jp-chat-send-include');
+
+    const notebook = await page.notebook.createNew();
+    const cell = (await page.notebook.getCellLocator(0))!;
+    await page.notebook.setCellType(0, 'markdown');
+    await cell.getByRole('textbox').pressSequentially(cellContent);
+
+    await splitMainArea(page, notebook!);
+
+    await input.pressSequentially(MSG_CONTENT);
+    await openerButton.click();
+    await expect(sendWithSelectionItem).toBeVisible();
+    await expect(sendWithSelectionItem).toBeEnabled();
+    await expect(sendWithSelectionItem).toContainText(
+      'Code from 1 active cell'
+    );
+    await sendWithSelectionItem.click();
+    await expect(messages!.locator('.jp-chat-message')).toHaveCount(1);
+
+    const rendered = messages.locator(
+      '.jp-chat-message .jp-chat-rendered-message'
+    );
+    await expect(rendered).toHaveText(`${MSG_CONTENT}\n${cellContent}\n`);
+    await expect(rendered.locator('code')).toHaveClass('');
+  });
+
+  test('should send with text selection', async ({ page }) => {
+    const cellContent = 'a = 1\nprint(f"a={a}")';
+    const chatPanel = await openChat(page, FILENAME);
+    const messages = chatPanel.locator('.jp-chat-messages-container');
+    const input = chatPanel
+      .locator('.jp-chat-input-container')
+      .getByRole('combobox');
+    const openerButton = chatPanel.locator(
+      '.jp-chat-input-container .jp-chat-send-include-opener'
+    );
+    const sendWithSelectionItem = page.locator('.jp-chat-send-include');
+
+    const notebook = await page.notebook.createNew();
+    await splitMainArea(page, notebook!);
+
+    const cell = (await page.notebook.getCellLocator(0))!;
+    await cell.getByRole('textbox').pressSequentially(cellContent);
+
+    await expect(cell.locator('.cm-line')).toHaveCount(2);
+    await expect(
+      cell.locator('.cm-line').nth(1).locator('.cm-builtin')
+    ).toBeAttached();
+
+    const selection = cell
+      ?.locator('.cm-line')
+      .nth(1)
+      .locator('.cm-builtin')
+      .first();
+    await selection.dblclick({ position: { x: 10, y: 10 } });
+
+    await input.pressSequentially(MSG_CONTENT);
+    await openerButton.click();
+    await expect(sendWithSelectionItem).toBeVisible();
+    await expect(sendWithSelectionItem).toBeEnabled();
+    await expect(sendWithSelectionItem).toContainText('1 line(s) selected');
+    await sendWithSelectionItem.click();
+
+    await expect(messages!.locator('.jp-chat-message')).toHaveCount(1);
+
+    const rendered = messages.locator(
+      '.jp-chat-message .jp-chat-rendered-message'
+    );
+    await expect(rendered).toHaveText(`${MSG_CONTENT}\nprint\n`);
+    await expect(rendered.locator('code')).toHaveClass(/language-[i]?python/);
   });
 
   test('should update settings value sendWithShiftEnter on existing chat', async ({


### PR DESCRIPTION
This PR restores the 'send with selection' feature in `@jupyter/chat`.
It allows to include text selection (from a notebook or editor widget) or active cell content.

There is also a setting in `jupyterlab-chat` to hide it if not expected.

- fixes #303 
- related to https://github.com/jupyterlab/jupyter-ai/issues/1536

### Discussion

Should we include the selection as an attachment instead ?
Currently is is added as `code` in the message.

[output.webm](https://github.com/user-attachments/assets/7fc84763-65b3-435f-a262-76ce496854e3)
