### PR TITLE
[Feature] Set file browser path as chat cwd metadata

### DIFF
--- a/packages/jupyterlab-chat-extension/src/index.ts
+++ b/packages/jupyterlab-chat-extension/src/index.ts
@@ -104,7 +104,8 @@ async function createChatModel(
   app: JupyterFrontEnd,
   contentProvider: ICollaborativeContentProvider,
   path?: string,
-  defaultDirectory?: string
+  defaultDirectory?: string,
+  filebrowser?: IDefaultFileBrowser | null
 ): Promise<MultiChatPanel.IOpenChatArgs> {
   const modelFactory = app.docRegistry.getModelFactory(
     'Chat'
@@ -131,6 +132,15 @@ async function createChatModel(
 
   const chatModel = modelFactory.createNew({
     sharedModel
+  });
+
+  // Set the file browser's current path as the chat's working directory
+  // after the Y.js document has synced, so the update isn't overwritten.
+  chatModel.ready.then(() => {
+    const browserPath = filebrowser?.model.path ?? '';
+    if (browserPath) {
+      sharedModel.ydoc.getMap('metadata').set('cwd', browserPath);
+    }
   });
 
   // Set the name of the model.
@@ -825,7 +835,13 @@ const chatCommands: JupyterFrontEndPlugin<void> = {
                 return true;
               }
 
-              const openChatArgs = await createChatModel(app, drive, filepath);
+              const openChatArgs = await createChatModel(
+                app,
+                drive,
+                filepath,
+                undefined,
+                filebrowser
+              );
 
               // Add a chat widget to the side panel.
               chatPanel.open(openChatArgs);
@@ -1054,6 +1070,7 @@ const chatPanel: JupyterFrontEndPlugin<MultiChatPanel> = {
   optional: [
     IAttachmentOpenerRegistry,
     IChatCommandRegistry,
+    IDefaultFileBrowser,
     IInputToolbarRegistryFactory,
     ILayoutRestorer,
     IMessageFooterRegistry,
@@ -1070,6 +1087,7 @@ const chatPanel: JupyterFrontEndPlugin<MultiChatPanel> = {
     rmRegistry: IRenderMimeRegistry,
     attachmentOpenerRegistry: IAttachmentOpenerRegistry,
     chatCommandRegistry: IChatCommandRegistry,
+    filebrowser: IDefaultFileBrowser | null,
     inputToolbarFactory: IInputToolbarRegistryFactory,
     restorer: ILayoutRestorer | null,
     messageFooterRegistry: IMessageFooterRegistry,
@@ -1110,7 +1128,8 @@ const chatPanel: JupyterFrontEndPlugin<MultiChatPanel> = {
           app,
           drive,
           path,
-          widgetConfig.config.defaultDirectory
+          widgetConfig.config.defaultDirectory,
+          filebrowser
         );
       },
       openInMain: path => {

--- a/packages/jupyterlab-chat/src/__tests__/ychat-cwd-metadata.spec.ts
+++ b/packages/jupyterlab-chat/src/__tests__/ychat-cwd-metadata.spec.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+import { YChat } from '../ychat';
+
+describe('YChat metadata', () => {
+  it('should store and retrieve cwd metadata', () => {
+    const ychat = new YChat();
+    ychat.ydoc.getMap('metadata').set('cwd', 'projects/my-repo');
+
+    const source = ychat.getSource();
+    expect((source.metadata as Record<string, unknown>)['cwd']).toBe(
+      'projects/my-repo'
+    );
+  });
+
+  it('should not include cwd when not set', () => {
+    const ychat = new YChat();
+
+    const source = ychat.getSource();
+    expect((source.metadata as Record<string, unknown>)['cwd']).toBeUndefined();
+  });
+
+  it('should overwrite cwd metadata', () => {
+    const ychat = new YChat();
+    const metadataMap = ychat.ydoc.getMap('metadata');
+
+    metadataMap.set('cwd', 'old-dir');
+    metadataMap.set('cwd', 'new-dir');
+
+    const source = ychat.getSource();
+    expect((source.metadata as Record<string, unknown>)['cwd']).toBe('new-dir');
+  });
+
+  it('should preserve other metadata when cwd is set', () => {
+    const ychat = new YChat();
+    const metadataMap = ychat.ydoc.getMap('metadata');
+
+    metadataMap.set('id', 'chat-123');
+    metadataMap.set('cwd', 'projects/my-repo');
+
+    const source = ychat.getSource();
+    const metadata = source.metadata as Record<string, unknown>;
+    expect(metadata['id']).toBe('chat-123');
+    expect(metadata['cwd']).toBe('projects/my-repo');
+  });
+});


### PR DESCRIPTION
I like to tuck my chats away in a single folder (like .jupyter/chats) so they don't clutter my file tree. Problem is, when a server-side extension wants to know where I was actually working when I opened the chat, the only directory info it can find is where the chat file lives.

This writes the file browser's current path as a `cwd` key in the YChat metadata when a chat model is created. The write happens after the Y.js document finishes its initial sync so the server's state doesn't overwrite it.

From the server side, any extension with access to the YChat can read `ychat.get_metadata().get("cwd")` to find out where the user was browsing. Handy for AI agents, code assistants, or anything that benefits from knowing the user's working context.