### PR TITLE
[Bug] Launcher ignores configured defaultDirectory when creating chats

### DIFF
--- a/packages/jupyterlab-chat-extension/src/index.ts
+++ b/packages/jupyterlab-chat-extension/src/index.ts
@@ -576,12 +576,8 @@ const chatCommands: JupyterFrontEndPlugin<void> = {
         const inSidePanel: boolean = (args.inSidePanel as boolean) ?? false;
         let targetDirectory: string | undefined = args.path as string;
 
-        // Create new chat file in default dir if created from filebrowser
-        // as "Open a chat" dropdown only discovers chat files in default
-        // dir. Create new chat in file browser cwd if created from main
-        // area (launcher, menu, palette).
         if (targetDirectory === undefined) {
-          if (inSidePanel) {
+          if (inSidePanel || widgetConfig.config.defaultDirectory) {
             targetDirectory = widgetConfig.config.defaultDirectory ?? '';
           } else {
             targetDirectory = filebrowser?.model.path ?? '';

--- a/ui-tests/tests/commands.spec.ts
+++ b/ui-tests/tests/commands.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import { expect, IJupyterLabPageFixture, test } from '@jupyterlab/galata';
-import { openChat, openChatToSide } from './test-utils';
+import { openChat, openChatToSide, openSettings } from './test-utils';
 
 const FILENAME = 'my-chat.chat';
 
@@ -165,5 +165,57 @@ test.describe('#focusInput', () => {
     // expect the chat to be visible and the input to be focussed
     await expect(chatPanel).toBeVisible();
     await expect(input).toBeFocused();
+  });
+});
+
+test.describe('#launcher with defaultDirectory', () => {
+  const CHAT_DIR = 'launcher_chats';
+
+  test.afterEach(async ({ page }) => {
+    if (await page.filebrowser.contents.directoryExists(CHAT_DIR)) {
+      await page.filebrowser.contents.deleteDirectory(CHAT_DIR);
+    }
+  });
+
+  // Regression test: the launcher was ignoring the configured defaultDirectory
+  // and creating chats in the file browser's current directory instead.
+  test('should create a chat in configured default directory', async ({
+    page,
+    tmpPath
+  }) => {
+    // Step 1: Configure a custom default directory for chats via settings.
+    const settings = await openSettings(page);
+    const defaultDirectory = settings.locator(
+      'input[label="defaultDirectory"]'
+    );
+    await defaultDirectory.pressSequentially(CHAT_DIR);
+    // Wait for settings to persist (dirty flag appears then clears).
+    await expect(page.activity.getTabLocator('Settings')).toHaveAttribute(
+      'class',
+      /jp-mod-dirty/
+    );
+    await expect(page.activity.getTabLocator('Settings')).not.toHaveAttribute(
+      'class',
+      /jp-mod-dirty/
+    );
+
+    // Step 2: Create a chat from the launcher (not the side panel).
+    // The file browser is at tmpPath, so without the fix this would
+    // create the chat in tmpPath instead of CHAT_DIR.
+    await page.activity.activateTab('Launcher');
+    await page.locator('.jp-LauncherCard').getByTitle('Create a chat').click();
+
+    // Step 3: Verify the chat was created in the configured directory.
+    await page.waitForCondition(
+      async () =>
+        await page.filebrowser.contents.fileExists(
+          `${CHAT_DIR}/untitled.chat`
+        )
+    );
+
+    // And NOT in the file browser's current directory.
+    expect(
+      await page.filebrowser.contents.fileExists(`${tmpPath}/untitled.chat`)
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
When a `defaultDirectory` is configured (via settings or server config), chats created from the side panel correctly land in that directory. But chats created from the launcher, menu, or command palette ignore it and use the file browser's current directory instead.

The `createChat` command was only checking `inSidePanel` to decide whether to use the configured directory. Now it also checks whether a `defaultDirectory` is configured -- if one exists, it's used regardless of where the chat was created from. The file browser fallback only kicks in when no default is configured.

Includes a UI test that configures a default directory, creates a chat from the launcher, and verifies it lands in the right place.