### PR TITLE
replaces `/` by `PreferredPath + .jupyter/` as the default directory if available

### DIFF
--- a/packages/jupyterlab-chat-extension/src/index.ts
+++ b/packages/jupyterlab-chat-extension/src/index.ts
@@ -43,10 +43,7 @@ import {
   showErrorMessage
 } from '@jupyterlab/apputils';
 import { IEditorLanguageRegistry } from '@jupyterlab/codemirror';
-import {
-  PathExt,
-  PageConfig
-} from '@jupyterlab/coreutils';
+import { PathExt, PageConfig } from '@jupyterlab/coreutils';
 import { DocumentRegistry } from '@jupyterlab/docregistry';
 import { IDefaultFileBrowser } from '@jupyterlab/filebrowser';
 import { ILauncher } from '@jupyterlab/launcher';
@@ -585,13 +582,18 @@ const chatCommands: JupyterFrontEndPlugin<void> = {
         // area (launcher, menu, palette).
         if (targetDirectory === undefined) {
           const hasPreferredPath = PageConfig.getOption('preferredPath');
-          const preferredPath = hasPreferredPath ? hasPreferredPath + '/.jupyter/': '';
+          const preferredPath = hasPreferredPath
+            ? hasPreferredPath + '/.jupyter/'
+            : '';
           if (inSidePanel) {
             const configDir = widgetConfig.config.defaultDirectory;
-            targetDirectory = (configDir && configDir.length > 0) ? configDir : preferredPath;
+            targetDirectory =
+              configDir && configDir.length > 0 ? configDir : preferredPath;
           } else {
-            targetDirectory = (filebrowser?.model.path && filebrowser.model.path.length > 0) 
-                ? filebrowser.model.path : preferredPath;
+            targetDirectory =
+              filebrowser?.model.path && filebrowser.model.path.length > 0
+                ? filebrowser.model.path
+                : preferredPath;
           }
         }
 

--- a/packages/jupyterlab-chat-extension/src/index.ts
+++ b/packages/jupyterlab-chat-extension/src/index.ts
@@ -43,7 +43,10 @@ import {
   showErrorMessage
 } from '@jupyterlab/apputils';
 import { IEditorLanguageRegistry } from '@jupyterlab/codemirror';
-import { PathExt } from '@jupyterlab/coreutils';
+import {
+  PathExt,
+  PageConfig
+ } from '@jupyterlab/coreutils';
 import { DocumentRegistry } from '@jupyterlab/docregistry';
 import { IDefaultFileBrowser } from '@jupyterlab/filebrowser';
 import { ILauncher } from '@jupyterlab/launcher';
@@ -581,10 +584,14 @@ const chatCommands: JupyterFrontEndPlugin<void> = {
         // dir. Create new chat in file browser cwd if created from main
         // area (launcher, menu, palette).
         if (targetDirectory === undefined) {
+          const hasPreferredPath = PageConfig.getOption('preferredPath');
+          const preferredPath = hasPreferredPath ? '' + hasPreferredPath : '';
           if (inSidePanel) {
-            targetDirectory = widgetConfig.config.defaultDirectory ?? '';
+            const configDir = widgetConfig.config.defaultDirectory;
+            targetDirectory = (configDir && configDir.length > 0) ? configDir : preferredPath;
           } else {
-            targetDirectory = filebrowser?.model.path ?? '';
+            targetDirectory = (filebrowser?.model.path && filebrowser.model.path.length > 0) 
+                ? filebrowser.model.path : preferredPath;
           }
         }
 

--- a/packages/jupyterlab-chat-extension/src/index.ts
+++ b/packages/jupyterlab-chat-extension/src/index.ts
@@ -46,7 +46,7 @@ import { IEditorLanguageRegistry } from '@jupyterlab/codemirror';
 import {
   PathExt,
   PageConfig
- } from '@jupyterlab/coreutils';
+} from '@jupyterlab/coreutils';
 import { DocumentRegistry } from '@jupyterlab/docregistry';
 import { IDefaultFileBrowser } from '@jupyterlab/filebrowser';
 import { ILauncher } from '@jupyterlab/launcher';

--- a/packages/jupyterlab-chat-extension/src/index.ts
+++ b/packages/jupyterlab-chat-extension/src/index.ts
@@ -585,7 +585,7 @@ const chatCommands: JupyterFrontEndPlugin<void> = {
         // area (launcher, menu, palette).
         if (targetDirectory === undefined) {
           const hasPreferredPath = PageConfig.getOption('preferredPath');
-          const preferredPath = hasPreferredPath ? '' + hasPreferredPath : '';
+          const preferredPath = hasPreferredPath ? hasPreferredPath + '/.jupyter/': '';
           if (inSidePanel) {
             const configDir = widgetConfig.config.defaultDirectory;
             targetDirectory = (configDir && configDir.length > 0) ? configDir : preferredPath;


### PR DESCRIPTION
This PR replaces `/` by `PreferredPath + .jupyter/` (if available) as the default directory for chat-files if defaultDirectory is not set or empty.  
It is a possible solution for the issue https://github.com/jupyterlab/jupyter-chat/issues/411