### PR TITLE
Fix flaky tests by avoiding duplicate file names

### DIFF
--- a/ui-tests/tests/chat-file.spec.ts
+++ b/ui-tests/tests/chat-file.spec.ts
@@ -15,8 +15,8 @@ import { ReadonlyJSONObject, UUID } from '@lumino/coreutils';
 import { createChat, openChat, openSettings, USER } from './test-utils';
 import { PathExt } from '@jupyterlab/coreutils';
 
-const CHAT_NAME = 'my-chat';
-const FILENAME = 'my-chat.chat';
+const CHAT_NAME = 'chat-file';
+const FILENAME = `${CHAT_NAME}.chat`;
 const MSG_CONTENT = 'Hello World!';
 const USERNAME = USER.identity.username;
 

--- a/ui-tests/tests/code-toolbar.spec.ts
+++ b/ui-tests/tests/code-toolbar.spec.ts
@@ -17,7 +17,7 @@ test.use({
   }
 });
 
-const FILENAME = 'toolbar.chat';
+const FILENAME = 'code-toolbar.chat';
 const CONTENT = 'print("This is a code cell")';
 const MESSAGE = `\`\`\`\n${CONTENT}\n\`\`\``;
 

--- a/ui-tests/tests/commands.spec.ts
+++ b/ui-tests/tests/commands.spec.ts
@@ -6,7 +6,7 @@
 import { expect, IJupyterLabPageFixture, test } from '@jupyterlab/galata';
 import { openChat, openChatToSide } from './test-utils';
 
-const FILENAME = 'my-chat.chat';
+const FILENAME = 'commands.chat';
 
 const fillModal = async (
   page: IJupyterLabPageFixture,

--- a/ui-tests/tests/input-toolbar.spec.ts
+++ b/ui-tests/tests/input-toolbar.spec.ts
@@ -13,7 +13,7 @@ import {
   openChatToSide
 } from './test-utils';
 
-const CHAT = 'test.chat';
+const CHAT = 'input-toolbar.chat';
 
 test.describe('#inputToolbar', () => {
   test('Should hide toolbar item for main area chat only', async ({

--- a/ui-tests/tests/message-toolbar.spec.ts
+++ b/ui-tests/tests/message-toolbar.spec.ts
@@ -8,7 +8,7 @@ import { UUID } from '@lumino/coreutils';
 
 import { openChat, USER, hoverFirstMessage } from './test-utils';
 
-const FILENAME = 'my-chat.chat';
+const FILENAME = 'message-toolbar.chat';
 const MSG_CONTENT = 'Hello World!';
 const USERNAME = USER.identity.username;
 

--- a/ui-tests/tests/mime-renderer.spec.ts
+++ b/ui-tests/tests/mime-renderer.spec.ts
@@ -8,7 +8,7 @@ import { UUID } from '@lumino/coreutils';
 
 import { openChat, USER } from './test-utils';
 
-const FILENAME = 'my-chat.chat';
+const FILENAME = 'mime-renderer.chat';
 const USERNAME = USER.identity.username;
 const BUNDLES = [
   {

--- a/ui-tests/tests/notebook-application.spec.ts
+++ b/ui-tests/tests/notebook-application.spec.ts
@@ -20,7 +20,7 @@ test.use({
   viewport: { width: 1024, height: 900 }
 });
 
-const NAME = 'my_chat';
+const NAME = 'notebook';
 const FILENAME = `${NAME}.chat`;
 
 test.describe('#NotebookApp', () => {

--- a/ui-tests/tests/notifications.spec.ts
+++ b/ui-tests/tests/notifications.spec.ts
@@ -15,7 +15,7 @@ import { UUID } from '@lumino/coreutils';
 
 import { openChat, openSettings, sendMessage, USER } from './test-utils';
 
-const FILENAME = 'my-chat.chat';
+const FILENAME = 'notifications.chat';
 const MSG_CONTENT = 'Hello World!';
 const USERNAME = USER.identity.username;
 
@@ -101,7 +101,7 @@ test.skip('#notifications', () => {
     // TODO: fix it, the notification should be info but is 'default'
     // expect(notifications[0].type).toBe('info');
     expect(notifications[0].message).toBe(
-      '1 incoming message(s) in my-chat.chat'
+      `1 incoming message(s) in ${FILENAME}`
     );
   });
 
@@ -142,13 +142,13 @@ test.skip('#notifications', () => {
     expect(notifications).toHaveLength(1);
 
     expect(notifications[0].message).toBe(
-      '1 incoming message(s) in my-chat.chat'
+      `1 incoming message(s) in ${FILENAME}`
     );
 
     await sendMessage(guestPage, FILENAME, MSG_CONTENT);
     notifications = await page.notifications;
     expect(notifications[0].message).toBe(
-      '2 incoming message(s) in my-chat.chat'
+      `2 incoming message(s) in ${FILENAME}`
     );
   });
 

--- a/ui-tests/tests/placeholder.spec.ts
+++ b/ui-tests/tests/placeholder.spec.ts
@@ -7,7 +7,7 @@ import { expect, test } from '@jupyterlab/galata';
 
 import { openSidePanel } from './test-utils';
 
-const CHAT_NAME = 'my-chat';
+const CHAT_NAME = 'placeholder';
 const FILENAME = `${CHAT_NAME}.chat`;
 
 test.describe('#placeholder', () => {

--- a/ui-tests/tests/send-message.spec.ts
+++ b/ui-tests/tests/send-message.spec.ts
@@ -12,7 +12,7 @@ import {
   splitMainArea
 } from './test-utils';
 
-const FILENAME = 'my-chat.chat';
+const FILENAME = 'send-message.chat';
 const MSG_CONTENT = 'Hello World!';
 
 test.describe('#sendMessages', () => {

--- a/ui-tests/tests/side-panel.spec.ts
+++ b/ui-tests/tests/side-panel.spec.ts
@@ -13,7 +13,7 @@ import {
   openSidePanel
 } from './test-utils';
 
-const FILENAME = 'my-chat.chat';
+const FILENAME = 'sidepanel.chat';
 
 test.describe('#sidepanel', () => {
   test.describe('#initialization', () => {

--- a/ui-tests/tests/ui-config.spec.ts
+++ b/ui-tests/tests/ui-config.spec.ts
@@ -14,7 +14,7 @@ import { UUID } from '@lumino/coreutils';
 
 import { openChat, openSettings, USER } from './test-utils';
 
-const FILENAME = 'my-chat.chat';
+const FILENAME = 'ui-config.chat';
 const MSG_CONTENT = 'Hello World!';
 const USERNAME = USER.identity.username;
 

--- a/ui-tests/tests/unread.spec.ts
+++ b/ui-tests/tests/unread.spec.ts
@@ -14,7 +14,7 @@ import { UUID } from '@lumino/coreutils';
 
 import { openChat, openChatToSide, sendMessage, USER } from './test-utils';
 
-const FILENAME = 'my-chat.chat';
+const FILENAME = 'unread.chat';
 const MSG_CONTENT = 'Hello World!';
 const USERNAME = USER.identity.username;
 

--- a/ui-tests/tests/user-mention.spec.ts
+++ b/ui-tests/tests/user-mention.spec.ts
@@ -12,7 +12,7 @@ import {
 import { User } from '@jupyterlab/services';
 import { openChat, sendMessage, USER } from './test-utils';
 
-const FILENAME = 'my-chat.chat';
+const FILENAME = 'user-mention.chat';
 
 test.use({
   mockUser: USER


### PR DESCRIPTION
Sometime the tests are not passing, because the file names are the same across tests running in parallel.

This PR fix it by using a different name for the chat file of each UI test.