### PR TITLE
[Bug] Pass defaultDirectory when opening chats via openChat command

### DIFF
--- a/packages/jupyterlab-chat-extension/src/index.ts
+++ b/packages/jupyterlab-chat-extension/src/index.ts
@@ -825,7 +825,12 @@ const chatCommands: JupyterFrontEndPlugin<void> = {
                 return true;
               }
 
-              const openChatArgs = await createChatModel(app, drive, filepath);
+              const openChatArgs = await createChatModel(
+                app,
+                drive,
+                filepath,
+                widgetConfig.config.defaultDirectory
+              );
 
               // Add a chat widget to the side panel.
               chatPanel.open(openChatArgs);


### PR DESCRIPTION
The `openChat` command hardcodes `undefined` for the `defaultDirectory` parameter in `createChatModel`. This causes `getDisplayName` to show the full path (e.g. `.jupyter/chats/untitled`) instead of the short name (`untitled`) when a chat is restored on page refresh.

The `chatPanel`'s own `createModel` callback already passes the correct value from `widgetConfig` — this just makes the `openChat` command consistent.

I'm building a custom Lumino application that reuses the chat panel plugin and noticed the display name was wrong after page refresh. Traced it to this one-liner.