### PR TITLE
[Bug] Fix chat auto-scroll on new messages and streaming content

### DIFF
--- a/packages/jupyter-chat/src/components/messages/messages.tsx
+++ b/packages/jupyter-chat/src/components/messages/messages.tsx
@@ -84,7 +84,8 @@ export function ChatMessages(): JSX.Element {
     function handleChatEvents() {
       const viewport = model.messagesInViewport ?? [];
       const prevLastIdx = model.messages.length - 2;
-      shouldScrollRef.current = prevLastIdx < 0 || viewport.includes(prevLastIdx);
+      shouldScrollRef.current =
+        prevLastIdx < 0 || viewport.includes(prevLastIdx);
       setMessages([...model.messages]);
     }
     model.messagesUpdated.connect(handleChatEvents);
@@ -123,7 +124,11 @@ export function ChatMessages(): JSX.Element {
       shouldScrollRef.current = atBottom;
     };
 
-    observer.observe(el, { childList: true, subtree: true, characterData: true });
+    observer.observe(el, {
+      childList: true,
+      subtree: true,
+      characterData: true
+    });
     el.addEventListener('scroll', handleScroll);
 
     return () => {

--- a/packages/jupyter-chat/src/components/messages/messages.tsx
+++ b/packages/jupyter-chat/src/components/messages/messages.tsx
@@ -68,11 +68,23 @@ export function ChatMessages(): JSX.Element {
     fetchHistory();
   }, [model]);
 
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  // Starts true so the chat scrolls to bottom on first render.
+  const shouldScrollRef = useRef<boolean>(true);
+
   /**
-   * Effect: listen to chat messages.
+   * Effect: listen to chat messages and decide whether to auto-scroll.
+   *
+   * We check `prevLastIdx` (length - 2) because by the time the signal fires,
+   * model.messages already contains the new message. So length - 2 is the
+   * message that WAS last before the new one arrived. If that was visible,
+   * the user was at the bottom and we should follow.
    */
   useEffect(() => {
     function handleChatEvents() {
+      const viewport = model.messagesInViewport ?? [];
+      const prevLastIdx = model.messages.length - 2;
+      shouldScrollRef.current = prevLastIdx < 0 || viewport.includes(prevLastIdx);
       setMessages([...model.messages]);
     }
     model.messagesUpdated.connect(handleChatEvents);
@@ -81,6 +93,44 @@ export function ChatMessages(): JSX.Element {
       model.messagesUpdated.disconnect(handleChatEvents);
     };
   }, [model]);
+
+  /**
+   * Effect: observe DOM mutations in the scroll container to keep the viewport
+   * pinned to the bottom as message content renders asynchronously.
+   *
+   * A single scrollTop assignment on state change isn't enough because message
+   * content (markdown, code blocks, images) renders after the initial DOM
+   * commit. The MutationObserver fires on every subtree change, keeping us
+   * pinned as content streams in or expands.
+   *
+   * The scroll listener lets a user manually scroll to the bottom during
+   * streaming to re-engage auto-scroll, or scroll up to disengage it.
+   */
+  useEffect(() => {
+    const el = scrollContainerRef.current;
+    if (!el) {
+      return;
+    }
+
+    const observer = new MutationObserver(() => {
+      if (shouldScrollRef.current) {
+        el.scrollTop = el.scrollHeight;
+      }
+    });
+
+    const handleScroll = () => {
+      const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 40;
+      shouldScrollRef.current = atBottom;
+    };
+
+    observer.observe(el, { childList: true, subtree: true, characterData: true });
+    el.addEventListener('scroll', handleScroll);
+
+    return () => {
+      observer.disconnect();
+      el.removeEventListener('scroll', handleScroll);
+    };
+  }, []);
 
   /**
    * Effect: Listen to the config change.
@@ -163,7 +213,7 @@ export function ChatMessages(): JSX.Element {
   const horizontalPadding = area === 'main' ? 8 : 4;
   return (
     <>
-      <ScrollContainer sx={{ flexGrow: 1 }}>
+      <ScrollContainer ref={scrollContainerRef} sx={{ flexGrow: 1 }}>
         {welcomeMessage && <WelcomeMessage content={welcomeMessage} />}
         <Box
           sx={{

--- a/packages/jupyter-chat/src/components/scroll-container.tsx
+++ b/packages/jupyter-chat/src/components/scroll-container.tsx
@@ -3,7 +3,7 @@
  * Distributed under the terms of the Modified BSD License.
  */
 
-import React, { useMemo } from 'react';
+import React, { forwardRef, useMemo } from 'react';
 import { Box, SxProps, Theme } from '@mui/material';
 
 type ScrollContainerProps = {
@@ -12,39 +12,32 @@ type ScrollContainerProps = {
 };
 
 /**
- * Component that handles intelligent scrolling.
+ * Scrollable container for chat messages. Scroll position is managed
+ * explicitly by the parent (ChatMessages) via a forwarded ref.
  *
- * - If viewport is at the bottom of the overflow container, appending new
- * children keeps the viewport on the bottom of the overflow container.
- *
- * - If viewport is in the middle of the overflow container, appending new
- * children leaves the viewport unaffected.
- *
- * Currently only works for Chrome and Firefox due to reliance on
- * `overflow-anchor`.
- *
- * **References**
- * - https://css-tricks.com/books/greatest-css-tricks/pin-scrolling-to-bottom/
+ * `overflowAnchor: 'none'` disables the browser's built-in scroll anchoring
+ * which caused partial viewport shifts on new content in Chrome/Firefox
+ * and is unsupported in Safari.
  */
-export function ScrollContainer(props: ScrollContainerProps): JSX.Element {
-  const id = useMemo(
-    () => 'jupyter-chat-scroll-container-' + Date.now().toString(),
-    []
-  );
+export const ScrollContainer = forwardRef<HTMLDivElement, ScrollContainerProps>(
+  function ScrollContainer(props, ref) {
+    const id = useMemo(
+      () => 'jupyter-chat-scroll-container-' + Date.now().toString(),
+      []
+    );
 
-  return (
-    <Box
-      id={id}
-      sx={{
-        overflowY: 'scroll',
-        '& *': {
-          overflowAnchor: 'none'
-        },
-        ...props.sx
-      }}
-    >
-      <Box>{props.children}</Box>
-      <Box sx={{ overflowAnchor: 'auto', height: '1px' }} />
-    </Box>
-  );
-}
+    return (
+      <Box
+        ref={ref}
+        id={id}
+        sx={{
+          overflowY: 'scroll',
+          overflowAnchor: 'none',
+          ...props.sx
+        }}
+      >
+        {props.children}
+      </Box>
+    );
+  }
+);

--- a/ui-tests/tests/autoscroll.spec.ts
+++ b/ui-tests/tests/autoscroll.spec.ts
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+import {
+  IJupyterLabPageFixture,
+  expect,
+  galata,
+  test
+} from '@jupyterlab/galata';
+import { User } from '@jupyterlab/services';
+import { UUID } from '@lumino/coreutils';
+
+import { openChat, sendMessage, USER } from './test-utils';
+
+const FILENAME = 'autoscroll-test.chat';
+const USERNAME = USER.identity.username;
+
+test.describe('#autoscroll', () => {
+  const baseTime = 1714116341;
+  const messagesList: any[] = [];
+  for (let i = 0; i < 20; i++) {
+    messagesList.push({
+      type: 'msg',
+      id: UUID.uuid4(),
+      sender: USERNAME,
+      body: `Message ${i}`,
+      time: baseTime + i * 60
+    });
+  }
+
+  const chatContent = {
+    messages: messagesList,
+    users: {}
+  };
+  chatContent.users[USERNAME] = USER.identity;
+
+  let guestPage: IJupyterLabPageFixture;
+
+  test.beforeEach(
+    async ({ baseURL, browser, page, tmpPath, waitForApplication }) => {
+      await page.filebrowser.contents.uploadContent(
+        JSON.stringify(chatContent),
+        'text',
+        FILENAME
+      );
+
+      const user2: Partial<User.IUser> = {
+        identity: {
+          username: 'jovyan_2',
+          name: 'jovyan_2',
+          display_name: 'jovyan_2',
+          initials: 'JP',
+          color: 'var(--jp-collaborator-color2)'
+        }
+      };
+
+      const { page: newPage } = await galata.newPage({
+        baseURL: baseURL!,
+        browser,
+        mockUser: user2,
+        tmpPath,
+        waitForApplication
+      });
+      await newPage.evaluate(() => {
+        window.galataip.on('dialog', d => {
+          d?.resolve();
+        });
+      });
+      guestPage = newPage;
+    }
+  );
+
+  test.afterEach(async ({ page }) => {
+    await guestPage.close();
+    if (await page.filebrowser.contents.fileExists(FILENAME)) {
+      await page.filebrowser.contents.deleteFile(FILENAME);
+    }
+  });
+
+  test('should start scrolled to the bottom', async ({ page }) => {
+    const chatPanel = await openChat(page, FILENAME, chatContent);
+    const messages = chatPanel.locator('.jp-chat-message');
+
+    await expect(messages.last()).toBeInViewport();
+  });
+
+  test('should auto-scroll when new message arrives and user is at bottom', async ({
+    page
+  }) => {
+    const chatPanel = await openChat(page, FILENAME, chatContent);
+    const messages = chatPanel.locator('.jp-chat-message');
+
+    // Verify we start at the bottom
+    await expect(messages.last()).toBeInViewport();
+
+    // Send a new message from the guest
+    await sendMessage(guestPage, FILENAME, 'New message from guest');
+
+    // Wait for the new message to appear and verify it's in viewport
+    const newMessage = chatPanel.locator('.jp-chat-message').last();
+    await expect(newMessage).toBeInViewport();
+  });
+
+  test('should not scroll when new message arrives and user has scrolled up', async ({
+    page
+  }) => {
+    const chatPanel = await openChat(page, FILENAME, chatContent);
+    const messages = chatPanel.locator('.jp-chat-message');
+
+    // Scroll to the first message (user scrolls up)
+    await messages.first().scrollIntoViewIfNeeded();
+    await expect(messages.last()).not.toBeInViewport();
+
+    // Send a new message from the guest
+    await sendMessage(guestPage, FILENAME, 'New message while scrolled up');
+
+    // Wait for the message to be added
+    await expect(
+      chatPanel.locator('.jp-chat-message').last()
+    ).toContainText('New message while scrolled up');
+
+    // The first message should still be visible (viewport didn't move)
+    await expect(messages.first()).toBeInViewport();
+    // The new last message should not be visible
+    await expect(chatPanel.locator('.jp-chat-message').last()).not.toBeInViewport();
+  });
+
+  test('should re-engage auto-scroll when user scrolls back to bottom', async ({
+    page
+  }) => {
+    const chatPanel = await openChat(page, FILENAME, chatContent);
+    const messages = chatPanel.locator('.jp-chat-message');
+
+    // Scroll up to disengage auto-scroll
+    await messages.first().scrollIntoViewIfNeeded();
+    await expect(messages.last()).not.toBeInViewport();
+
+    // Scroll back to the bottom to re-engage
+    await messages.last().scrollIntoViewIfNeeded();
+    await expect(messages.last()).toBeInViewport();
+
+    // Send a new message — should auto-scroll to show it
+    await sendMessage(guestPage, FILENAME, 'Message after re-engage');
+
+    const newMessage = chatPanel.locator('.jp-chat-message').last();
+    await expect(newMessage).toContainText('Message after re-engage');
+    await expect(newMessage).toBeInViewport();
+  });
+});

--- a/ui-tests/tests/autoscroll.spec.ts
+++ b/ui-tests/tests/autoscroll.spec.ts
@@ -117,14 +117,16 @@ test.describe('#autoscroll', () => {
     await sendMessage(guestPage, FILENAME, 'New message while scrolled up');
 
     // Wait for the message to be added
-    await expect(
-      chatPanel.locator('.jp-chat-message').last()
-    ).toContainText('New message while scrolled up');
+    await expect(chatPanel.locator('.jp-chat-message').last()).toContainText(
+      'New message while scrolled up'
+    );
 
     // The first message should still be visible (viewport didn't move)
     await expect(messages.first()).toBeInViewport();
     // The new last message should not be visible
-    await expect(chatPanel.locator('.jp-chat-message').last()).not.toBeInViewport();
+    await expect(
+      chatPanel.locator('.jp-chat-message').last()
+    ).not.toBeInViewport();
   });
 
   test('should re-engage auto-scroll when user scrolls back to bottom', async ({


### PR DESCRIPTION
The chat wasn't reliably auto-scrolling to the bottom when new messages arrived, and had no way to re-engage scrolling mid-stream.

**Problems:**

1. The old implementation used CSS `overflow-anchor` to pin the scroll position. This doesn't work in Safari, and in Chrome/Firefox it caused a partial viewport shift when new messages arrived while scrolled up — not a full scroll, just an annoying jolt.

2. For streaming messages (where content grows over time), a one-shot scroll jumped to the start of the last message but didn't follow the content as it rendered.

3. If you scrolled up during a streaming message and then scrolled back down, there was no way to re-engage auto-scroll until the next message arrived.

**How it works now:**

- Removed CSS `overflow-anchor` entirely. The `ScrollContainer` is now a plain scrollable box with a forwarded ref — all scroll logic lives in `ChatMessages`.

- A `MutationObserver` watches the scroll container for DOM changes (new messages, streaming text, async markdown/code block rendering, images loading). When `shouldScrollRef` is true, it pins `scrollTop = scrollHeight` on every mutation.

- `shouldScrollRef` is controlled by two mechanisms:
  1. **On new message:** checks `model.messagesInViewport` to see if the previous last message was visible. If the user was at the bottom, pin. (Uses `length - 2` because `model.messages` already contains the new message by the time the signal fires.)
  2. **On scroll event:** if the user scrolls within 40px of the bottom, re-engage pinning. If they scroll up, disengage immediately — no waiting for the next message.

- Starts with `shouldScrollRef = true` so chat scrolls to bottom on first open.

**Tests** (`ui-tests/tests/autoscroll.spec.ts`):
- Chat starts scrolled to bottom on open
- Auto-scrolls to new messages when user is at bottom
- Viewport stays completely fixed when user has scrolled up
- Re-engages auto-scroll when user scrolls back to bottom