### PR TITLE
Add configurable welcome message visibility (auto-hide and always-hide)

### DIFF
--- a/packages/jupyter-chat/src/__tests__/model.spec.ts
+++ b/packages/jupyter-chat/src/__tests__/model.spec.ts
@@ -142,6 +142,8 @@ describe('test chat model', () => {
     it('should have empty config', () => {
       const model = new MockChatModel();
       expect(model.config.sendWithShiftEnter).toBeUndefined();
+      expect(model.config.autoHideWelcomeMessage).toBeTruthy();
+      expect(model.config.hideWelcomeMessage).toBeFalsy();
     });
 
     it('should allow config', () => {

--- a/packages/jupyter-chat/src/__tests__/welcome-message.spec.ts
+++ b/packages/jupyter-chat/src/__tests__/welcome-message.spec.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+import { shouldDisplayWelcomeMessage } from '../components/messages/messages';
+import { IConfig } from '../types';
+
+describe('welcome message visibility', () => {
+  const welcomeMessage = 'Welcome!';
+
+  it('should hide if no welcome message is provided', () => {
+    expect(
+      shouldDisplayWelcomeMessage({
+        config: {},
+        messageCount: 0
+      })
+    ).toBeFalsy();
+  });
+
+  it('should display for empty chats by default', () => {
+    expect(
+      shouldDisplayWelcomeMessage({
+        welcomeMessage,
+        config: {},
+        messageCount: 0
+      })
+    ).toBeTruthy();
+  });
+
+  it('should auto-hide after the first message by default', () => {
+    expect(
+      shouldDisplayWelcomeMessage({
+        welcomeMessage,
+        config: {},
+        messageCount: 1
+      })
+    ).toBeFalsy();
+  });
+
+  it('should keep showing after messages if auto-hide is disabled', () => {
+    const config: IConfig = { autoHideWelcomeMessage: false };
+    expect(
+      shouldDisplayWelcomeMessage({
+        welcomeMessage,
+        config,
+        messageCount: 1
+      })
+    ).toBeTruthy();
+  });
+
+  it('should always hide when configured', () => {
+    const config: IConfig = {
+      autoHideWelcomeMessage: false,
+      hideWelcomeMessage: true
+    };
+    expect(
+      shouldDisplayWelcomeMessage({
+        welcomeMessage,
+        config,
+        messageCount: 0
+      })
+    ).toBeFalsy();
+  });
+
+  it('should display after first message when auto-hide is disabled and always-hide is disabled', () => {
+    const config: IConfig = {
+      autoHideWelcomeMessage: false,
+      hideWelcomeMessage: false
+    };
+    expect(
+      shouldDisplayWelcomeMessage({
+        welcomeMessage,
+        config,
+        messageCount: 1
+      })
+    ).toBeTruthy();
+  });
+});

--- a/packages/jupyter-chat/src/components/messages/messages.tsx
+++ b/packages/jupyter-chat/src/components/messages/messages.tsx
@@ -26,6 +26,24 @@ const MESSAGES_BOX_CLASS = 'jp-chat-messages-container';
 const MESSAGE_STACKED_CLASS = 'jp-chat-message-stacked';
 
 /**
+ * Whether the welcome message should be displayed.
+ */
+export function shouldDisplayWelcomeMessage(options: {
+  welcomeMessage?: string;
+  config: IConfig;
+  messageCount: number;
+}): boolean {
+  const { welcomeMessage, config, messageCount } = options;
+  if (!welcomeMessage || (config.hideWelcomeMessage ?? false)) {
+    return false;
+  }
+  if ((config.autoHideWelcomeMessage ?? true) && messageCount > 0) {
+    return false;
+  }
+  return true;
+}
+
+/**
  * The messages list component.
  */
 export function ChatMessages(): JSX.Element {
@@ -40,9 +58,7 @@ export function ChatMessages(): JSX.Element {
   const [messages, setMessages] = useState<IMessage[]>(model.messages);
   const refMsgBox = useRef<HTMLDivElement>(null);
   const [allRendered, setAllRendered] = useState<boolean>(false);
-  const [showDeleted, setShowDeleted] = useState<boolean>(
-    model.config.showDeleted ?? false
-  );
+  const [config, setConfig] = useState<IConfig>(model.config);
 
   // The list of message DOM and their rendered promises.
   const listRef = useRef<(HTMLDivElement | null)[]>([]);
@@ -143,16 +159,14 @@ export function ChatMessages(): JSX.Element {
    */
   useEffect(() => {
     function handleConfigChange(_: IChatModel, config: IConfig) {
-      if (config.showDeleted !== showDeleted) {
-        setShowDeleted(config.showDeleted ?? false);
-      }
+      setConfig(config);
     }
     model.configChanged.connect(handleConfigChange);
 
     return () => {
       model.configChanged.disconnect(handleConfigChange);
     };
-  }, [model, showDeleted]);
+  }, [model]);
 
   /**
    * Observe the messages to update the current viewport and the unread messages.
@@ -217,10 +231,18 @@ export function ChatMessages(): JSX.Element {
   }, [messages, allRendered]);
 
   const horizontalPadding = area === 'main' ? 8 : 4;
+  const showWelcomeMessage = shouldDisplayWelcomeMessage({
+    welcomeMessage,
+    config,
+    messageCount: messages.length
+  });
+
   return (
     <>
       <ScrollContainer ref={scrollContainerRef} sx={{ flexGrow: 1 }}>
-        {welcomeMessage && <WelcomeMessage content={welcomeMessage} />}
+        {showWelcomeMessage && welcomeMessage && (
+          <WelcomeMessage content={welcomeMessage} />
+        )}
         {messages.length === 0 && <ChatBodyPlaceholder />}
         <Box
           sx={{
@@ -236,7 +258,7 @@ export function ChatMessages(): JSX.Element {
           className={clsx(MESSAGES_BOX_CLASS)}
         >
           {/* Filter the deleted message if user don't expect to see it. */}
-          {(showDeleted
+          {(config.showDeleted
             ? messages
             : messages.filter(message => !message.deleted)
           ).map((message, i) => {

--- a/packages/jupyter-chat/src/model.ts
+++ b/packages/jupyter-chat/src/model.ts
@@ -245,6 +245,8 @@ export abstract class AbstractChatModel implements IChatModel {
     this._config = {
       stackMessages: true,
       sendTypingNotification: true,
+      autoHideWelcomeMessage: true,
+      hideWelcomeMessage: false,
       ...config
     };
 

--- a/packages/jupyter-chat/src/types.ts
+++ b/packages/jupyter-chat/src/types.ts
@@ -63,6 +63,14 @@ export interface IConfig {
    * Whether to display the 'send with selection' button.
    */
   sendWithSelection?: boolean;
+  /**
+   * Whether to auto-hide the welcome message after the first message.
+   */
+  autoHideWelcomeMessage?: boolean;
+  /**
+   * Whether to always hide the welcome message.
+   */
+  hideWelcomeMessage?: boolean;
 }
 
 /**

--- a/packages/jupyterlab-chat-extension/schema/factory.json
+++ b/packages/jupyterlab-chat-extension/schema/factory.json
@@ -49,6 +49,18 @@
       "default": false,
       "readOnly": false
     },
+    "autoHideWelcomeMessage": {
+      "description": "Whether to auto-hide the welcome message after the first message is sent.",
+      "type": "boolean",
+      "default": true,
+      "readOnly": false
+    },
+    "hideWelcomeMessage": {
+      "description": "Whether to always hide the welcome message.",
+      "type": "boolean",
+      "default": false,
+      "readOnly": false
+    },
     "defaultDirectory": {
       "description": "Default directory where to create and look for chat, the jupyter root directory if empty.",
       "type": "string",

--- a/packages/jupyterlab-chat-extension/src/index.ts
+++ b/packages/jupyterlab-chat-extension/src/index.ts
@@ -255,6 +255,10 @@ const chatConfig: JupyterFrontEndPlugin<IWidgetConfig> = {
           showDeleted: setting.get('showDeleted').composite as boolean,
           sendWithSelection: setting.get('sendWithSelection')
             .composite as boolean,
+          autoHideWelcomeMessage: setting.get('autoHideWelcomeMessage')
+            .composite as boolean,
+          hideWelcomeMessage: setting.get('hideWelcomeMessage')
+            .composite as boolean,
           defaultDirectory: currentDirectory
         };
       });

--- a/ui-tests/tests/ui-config.spec.ts
+++ b/ui-tests/tests/ui-config.spec.ts
@@ -62,12 +62,14 @@ test.describe('#settings', () => {
     expect(showDeleted).not.toBeChecked();
 
     const autoHideWelcomeMessage = settings.getByRole('checkbox', {
-      name: 'autoHideWelcomeMessage'
+      name: 'autoHideWelcomeMessage',
+      exact: true
     });
     expect(autoHideWelcomeMessage).toBeChecked();
 
     const hideWelcomeMessage = settings.getByRole('checkbox', {
-      name: 'hideWelcomeMessage'
+      name: 'hideWelcomeMessage',
+      exact: true
     });
     expect(hideWelcomeMessage).not.toBeChecked();
   });

--- a/ui-tests/tests/ui-config.spec.ts
+++ b/ui-tests/tests/ui-config.spec.ts
@@ -60,6 +60,16 @@ test.describe('#settings', () => {
       name: 'showDeleted'
     });
     expect(showDeleted).not.toBeChecked();
+
+    const autoHideWelcomeMessage = settings.getByRole('checkbox', {
+      name: 'autoHideWelcomeMessage'
+    });
+    expect(autoHideWelcomeMessage).toBeChecked();
+
+    const hideWelcomeMessage = settings.getByRole('checkbox', {
+      name: 'hideWelcomeMessage'
+    });
+    expect(hideWelcomeMessage).not.toBeChecked();
   });
 });
 


### PR DESCRIPTION
Closes #224 

This PR adds support for customizing welcome message visibility with two settings: `autoHideWelcomeMessage` (default true) to hide the welcome message after the first message, and `hideWelcomeMessage` (default false) to always hide it. The behavior is wired through core chat config and JupyterLab extension settings schema/loading.

