### PR TITLE
add space around mentions in span

### DIFF
--- a/packages/jupyter-chat/src/utils.ts
+++ b/packages/jupyter-chat/src/utils.ts
@@ -62,7 +62,7 @@ export function replaceMentionToSpan(content: string, user: IUser): string {
   }
   const mention = '@' + user.mention_name;
   const regex = new RegExp(mention, 'g');
-  const mentionEl = `<span class="${MENTION_CLASS}">${mention}</span>`;
+  const mentionEl = `<span class="${MENTION_CLASS}"> ${mention} </span>`;
   return content.replace(regex, mentionEl);
 }
 
@@ -77,7 +77,7 @@ export function replaceSpanToMention(content: string, user: IUser): string {
     return content;
   }
   const mention = '@' + user.mention_name;
-  const mentionEl = `<span class="${MENTION_CLASS}">${mention}</span>`;
+  const mentionEl = `<span class="${MENTION_CLASS}"> ${mention} </span>`;
   const regex = new RegExp(mentionEl, 'g');
   return content.replace(regex, mention);
 }


### PR DESCRIPTION
some markdown processors (e.g. myst) need space between html tags and markdown text, otherwise they get handled in funky ways

I _think_ this particular one is likely a bug in myst itself, but the spaces here aren't wrong in HTML, so should be fine anyway. I'll also open a bug in mystmd, I think.

closes #440 