### PR TITLE
Add UI test for persona /command autocomplete

### DIFF
--- a/ui-tests/tests/persona-commands.spec.ts
+++ b/ui-tests/tests/persona-commands.spec.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+import { expect, test } from '@jupyterlab/galata';
+import { openChat, USER } from './test-utils';
+
+const FILENAME = 'persona-commands.chat';
+
+test.use({
+  mockUser: USER
+});
+
+/**
+ * Verifies the @-mention /command platform: the chat-commands extension's
+ * `PersonaCommandProvider` fetches per-persona commands from
+ * `/api/ai/persona-commands` and surfaces them in the autocomplete dropdown
+ * when the user types `/` at the leading command position.
+ *
+ * The endpoint is mocked here so the test does not depend on a persona
+ * actually being registered with `@persona_command` in the running env.
+ */
+test.describe('#persona-commands', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.filebrowser.contents.uploadContent('{}', 'text', FILENAME);
+    await page.route(/api\/ai\/persona-commands/, async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          commands: [
+            { name: '/clear', description: 'Clear the conversation' },
+            { name: '/help', description: 'Show available commands' },
+            { name: '/login', description: 'Authenticate with the agent' }
+          ]
+        })
+      });
+    });
+  });
+
+  test.afterEach(async ({ page }) => {
+    if (await page.filebrowser.contents.fileExists(FILENAME)) {
+      await page.filebrowser.contents.deleteFile(FILENAME);
+    }
+  });
+
+  test('should list persona /commands when user types /', async ({ page }) => {
+    const chatPanel = await openChat(page, FILENAME);
+    const input = chatPanel
+      .locator('.jp-chat-input-container')
+      .getByRole('combobox');
+    const chatCommandName = page.locator('.jp-chat-command-name');
+
+    await input.pressSequentially('/');
+
+    // The dropdown surfaces our 3 mocked commands (other slash-providers may
+    // contribute additional entries — assert by content, not exact count).
+    await expect(chatCommandName.filter({ hasText: '/clear' })).toHaveCount(1);
+    await expect(chatCommandName.filter({ hasText: '/help' })).toHaveCount(1);
+    await expect(chatCommandName.filter({ hasText: '/login' })).toHaveCount(1);
+  });
+
+  test('should filter persona /commands by prefix', async ({ page }) => {
+    const chatPanel = await openChat(page, FILENAME);
+    const input = chatPanel
+      .locator('.jp-chat-input-container')
+      .getByRole('combobox');
+    const chatCommandName = page.locator('.jp-chat-command-name');
+
+    await input.pressSequentially('/he');
+
+    // `/clear` and `/login` no longer match; only `/help` should remain among
+    // the persona commands. Other providers may still surface unrelated
+    // entries (e.g. emoji), so assert by inclusion.
+    await expect(chatCommandName.filter({ hasText: '/help' })).toHaveCount(1);
+    await expect(chatCommandName.filter({ hasText: '/clear' })).toHaveCount(0);
+    await expect(chatCommandName.filter({ hasText: '/login' })).toHaveCount(0);
+  });
+
+  test('should not list persona /commands mid-message', async ({ page }) => {
+    const chatPanel = await openChat(page, FILENAME);
+    const input = chatPanel
+      .locator('.jp-chat-input-container')
+      .getByRole('combobox');
+    const chatCommandName = page.locator('.jp-chat-command-name');
+
+    // A `/` that is not the leading token must NOT trigger persona-command
+    // autocomplete — those commands only make sense at the start of input.
+    await input.pressSequentially('hello /he');
+    await expect(chatCommandName.filter({ hasText: '/help' })).toHaveCount(0);
+    await expect(chatCommandName.filter({ hasText: '/clear' })).toHaveCount(0);
+    await expect(chatCommandName.filter({ hasText: '/login' })).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a Playwright spec under `ui-tests/` that exercises the new persona-scoped `/command` autocomplete being added to `jupyter-ai-contrib/jupyter-ai-chat-commands` (companion PR linked below). The test mocks the new `/api/ai/persona-commands` server endpoint via `page.route()` so it doesn't depend on a real persona being installed in the test env.

Three cases covered:

1. **Full dropdown** — typing `/` shows all three mocked commands (`/clear`, `/help`, `/login`).
2. **Prefix filtering** — typing `/he` narrows down to `/help`.
3. **Mid-message guard** — typing `hello /he` does NOT trigger persona-command autocomplete (those commands only make sense at the leading position).

Assertions are content-based (`filter({ hasText: ... })`) rather than strict counts, so other registered providers (`/refresh-personas`, emoji, mentions) don't make the test brittle.

## Test plan

- [x] `playwright test tests/persona-commands.spec.ts` — 3/3 passing locally against the latest `origin/main`s of all related extensions
- [x] Test isolated via `page.route()` — does not require persona-manager to ship the new endpoint at the time CI runs

## Companion changes

- Backend: `jupyter-ai-contrib/jupyter-ai-persona-manager` — adds `@persona_command` decorator + dispatcher + endpoint.
- Frontend: `jupyter-ai-contrib/jupyter-ai-chat-commands` — adds the `PersonaCommandProvider` that this test exercises.

🤖 Generated with [Claude Code](https://claude.com/claude-code)