### PR TITLE
Fix circular import when importing jupyterlab_chat.ychat first

### DIFF
--- a/python/jupyterlab-chat/jupyterlab_chat/__init__.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/__init__.py
@@ -1,6 +1,18 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+# Import `jupyter_ydoc` before anything imports `jupyterlab_chat.ychat`.
+#
+# `jupyter_ydoc`'s package init eagerly loads every registered `jupyter_ydoc`
+# entry point, one of which is `chat = jupyterlab_chat.ychat:YChat`. If
+# `jupyterlab_chat.ychat` is the first module to touch `jupyter_ydoc` (via its
+# top-level `from jupyter_ydoc.ybasedoc import YBaseDoc`), that eager load
+# re-enters the still-initializing `ychat` module before `YChat` is defined and
+# raises a circular-import AttributeError. Importing `jupyter_ydoc` here forces
+# its entry-point registry to finish first, since this package `__init__` always
+# runs before the `ychat` submodule.
+import jupyter_ydoc  # noqa: F401
+
 try:
     from ._version import __version__
 except ImportError:

--- a/python/jupyterlab-chat/jupyterlab_chat/tests/test_imports.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/tests/test_imports.py
@@ -1,0 +1,25 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+import subprocess
+import sys
+
+
+def test_import_ychat_standalone():
+    """`jupyterlab_chat.ychat` must be importable on its own.
+
+    `ychat.py` imports from `jupyter_ydoc`, whose package init eagerly loads all
+    `jupyter_ydoc` entry points -- one of which is `chat = jupyterlab_chat.ychat:YChat`.
+    If `jupyterlab_chat.ychat` is the first module to touch `jupyter_ydoc`, that
+    eager load re-enters the still-initializing `ychat` module and fails with a
+    circular import. This is run in a fresh subprocess so no earlier import in
+    the test session masks the problem.
+    """
+    result = subprocess.run(
+        [sys.executable, "-c", "import jupyterlab_chat.ychat"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        "Importing jupyterlab_chat.ychat failed:\n" + result.stderr
+    )

--- a/python/jupyterlab-chat/jupyterlab_chat/tests/test_ychat.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/tests/test_ychat.py
@@ -1,9 +1,6 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-# import jupyter_ydoc before YChat to avoid circular error
-import jupyter_ydoc
-
 from dataclasses import asdict
 import pytest
 from uuid import uuid4


### PR DESCRIPTION

## Summary

Importing `jupyterlab_chat.ychat` as the first module to touch `jupyter_ydoc`
fails:

```python
import jupyterlab_chat.ychat
```

```
AttributeError: partially initialized module 'jupyterlab_chat.ychat'
has no attribute 'YChat' (most likely due to a circular import)
```

`jupyter_ydoc`'s package init eagerly loads every registered `jupyter_ydoc`
entry point, one of which is `chat = jupyterlab_chat.ychat:YChat`. When
`ychat.py`'s top-level `from jupyter_ydoc.ybasedoc import YBaseDoc` is the first
thing to import `jupyter_ydoc`, that eager load re-enters the still-initializing
`ychat` module before `YChat` is defined.

## Fix

Import `jupyter_ydoc` at the top of `jupyterlab_chat/__init__.py`, which always
runs before the `ychat` submodule, so `jupyter_ydoc`'s entry-point registry
finishes initializing first. (The test suite already carried an ad-hoc
`import jupyter_ydoc` workaround in `test_ychat.py`; this makes the fix part of
the package itself, and the workaround is removed.)

The proper long-term fix is arguably upstream in `jupyter_ydoc` (it shouldn't
eagerly load all entry points on import), but this resolves it for
`jupyterlab_chat` today.

## Changes

- `jupyterlab_chat/__init__.py`: import `jupyter_ydoc` first, with an explanatory comment.
- `tests/test_imports.py`: new subprocess-based regression test (fails without the fix).
- `tests/test_ychat.py`: drop the now-redundant workaround import.

Fixes #456