### PR TITLE
Bump pycrdt ceiling to <0.15.0

### DIFF
--- a/python/jupyterlab-chat/pyproject.toml
+++ b/python/jupyterlab-chat/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "jupyter_collaboration>=4,<5",
     "jupyter_server>=2.0.1,<3",
     "jupyter_ydoc>=3.0.0,<5.0.0",
-    "pycrdt>=0.12.48,<0.14.0",
+    "pycrdt>=0.12.48,<0.15.0",
 ]
 keywords = ["jupyter", "jupyterlab", "jupyterlab-extension"]
 authors = [


### PR DESCRIPTION
The current `<0.14.0` ceiling on `pycrdt` excludes environments running jupyter_ydoc v4 (e.g. JupyterLab 4.6), which [requires `pycrdt>=0.14.0`](https://github.com/jupyter-server/jupyter_ydoc/blob/d52fdf9024f65903ec38c7f471af3bf223b24abc/pyproject.toml#L16).

Bumps the ceiling to `<0.15.0` (lower bound unchanged).