### PR TITLE
Add message metadata to the input model

### DIFF
--- a/packages/jupyter-chat/jest.setup.js
+++ b/packages/jupyter-chat/jest.setup.js
@@ -14,3 +14,12 @@ global.IntersectionObserver = class IntersectionObserver {
   observe() {}
   unobserve() {}
 };
+
+/*
+ * `structuredClone` is a standard global in the browser (and Node), but the
+ * jsdom test environment doesn't expose it. Provide it so code that relies on
+ * it (e.g. input-model metadata, message cloning) can be unit-tested.
+ */
+if (typeof global.structuredClone !== 'function') {
+  global.structuredClone = value => JSON.parse(JSON.stringify(value));
+}

--- a/packages/jupyter-chat/src/__tests__/input-model.spec.ts
+++ b/packages/jupyter-chat/src/__tests__/input-model.spec.ts
@@ -38,6 +38,23 @@ describe('test input model', () => {
       expect(model.getMetadata()).toEqual({ persona: 'jupyternaut' });
     });
 
+    it('should shallow-merge: a top-level key replaces the whole value', () => {
+      const model = new InputModel({ onSend: jest.fn() });
+      model.updateMetadata({ model: { id: 'a' } });
+      // Passing `model` again replaces it wholesale (no recursive merge).
+      model.updateMetadata({ model: { id: 'b' } });
+      expect(model.getMetadata()).toEqual({ model: { id: 'b' } });
+    });
+
+    it('should not be mutated by later changes to a patch', () => {
+      const model = new InputModel({ onSend: jest.fn() });
+      const patch = { model: { id: 'a' } };
+      model.updateMetadata(patch);
+      // Mutating the patch after the fact must not reach into stored metadata.
+      patch.model.id = 'tampered';
+      expect(model.getMetadata()).toEqual({ model: { id: 'a' } });
+    });
+
     it('should clear metadata', () => {
       const model = new InputModel({ onSend: jest.fn() });
       model.updateMetadata({ persona: 'kiro' });
@@ -100,7 +117,10 @@ describe('test input model', () => {
   });
 });
 
-// Extend IMessageMetadata so the tests above can use arbitrary fields.
+// `IMessageMetadata` is intentionally empty in the source; consumers augment it
+// with their own fields via module augmentation. We do the same here purely so
+// the tests can exercise `updateMetadata` with representative fields — this
+// stays in the test file and no consumer-specific fields leak into the source.
 declare module '../types' {
   interface IMessageMetadata {
     persona?: string;

--- a/packages/jupyter-chat/src/__tests__/input-model.spec.ts
+++ b/packages/jupyter-chat/src/__tests__/input-model.spec.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+import { InputModel } from '../input-model';
+import { INewMessage } from '../types';
+
+describe('test input model', () => {
+  describe('metadata', () => {
+    it('should start with empty metadata', () => {
+      const model = new InputModel({ onSend: jest.fn() });
+      expect(model.getMetadata()).toEqual({});
+    });
+
+    it('should seed metadata from options', () => {
+      const model = new InputModel({
+        onSend: jest.fn(),
+        metadata: { persona: 'kiro' }
+      });
+      expect(model.getMetadata()).toEqual({ persona: 'kiro' });
+    });
+
+    it('should merge patches with updateMetadata', () => {
+      const model = new InputModel({ onSend: jest.fn() });
+      model.updateMetadata({ persona: 'kiro' });
+      model.updateMetadata({ model: { id: 'claude-opus-48' } });
+      expect(model.getMetadata()).toEqual({
+        persona: 'kiro',
+        model: { id: 'claude-opus-48' }
+      });
+    });
+
+    it('should overwrite existing keys on update', () => {
+      const model = new InputModel({ onSend: jest.fn() });
+      model.updateMetadata({ persona: 'kiro' });
+      model.updateMetadata({ persona: 'jupyternaut' });
+      expect(model.getMetadata()).toEqual({ persona: 'jupyternaut' });
+    });
+
+    it('should clear metadata', () => {
+      const model = new InputModel({ onSend: jest.fn() });
+      model.updateMetadata({ persona: 'kiro' });
+      model.clearMetadata();
+      expect(model.getMetadata()).toEqual({});
+    });
+
+    it('should emit metadataChanged on update and clear', () => {
+      const model = new InputModel({ onSend: jest.fn() });
+      const emitted: any[] = [];
+      model.metadataChanged?.connect((_, metadata) => {
+        emitted.push({ ...metadata });
+      });
+      model.updateMetadata({ persona: 'kiro' });
+      model.clearMetadata();
+      expect(emitted).toEqual([{ persona: 'kiro' }, {}]);
+    });
+  });
+
+  describe('send', () => {
+    it('should attach metadata to the message when non-empty', () => {
+      const onSend = jest.fn();
+      const model = new InputModel({ onSend });
+      model.updateMetadata({ persona: 'kiro' });
+      model.send('hello');
+
+      const message: INewMessage = onSend.mock.calls[0][0];
+      expect(message.body).toBe('hello');
+      expect(message.metadata).toEqual({ persona: 'kiro' });
+    });
+
+    it('should omit metadata from the message when empty', () => {
+      const onSend = jest.fn();
+      const model = new InputModel({ onSend });
+      model.send('hello');
+
+      const message: INewMessage = onSend.mock.calls[0][0];
+      expect(message.metadata).toBeUndefined();
+    });
+
+    it('should send a copy of the metadata', () => {
+      const onSend = jest.fn();
+      const model = new InputModel({ onSend });
+      model.updateMetadata({ persona: 'kiro' });
+      model.send('hello');
+
+      const message: INewMessage = onSend.mock.calls[0][0];
+      model.updateMetadata({ persona: 'jupyternaut' });
+      expect(message.metadata).toEqual({ persona: 'kiro' });
+    });
+
+    it('should keep metadata after sending (sticky selection)', () => {
+      // Unlike attachments/mentions, metadata carries the picker's
+      // persona/model/settings selection, which is sticky across messages.
+      const model = new InputModel({ onSend: jest.fn() });
+      model.updateMetadata({ persona: 'kiro' });
+      model.send('hello');
+      expect(model.getMetadata()).toEqual({ persona: 'kiro' });
+    });
+  });
+});
+
+// Extend IMessageMetadata so the tests above can use arbitrary fields.
+declare module '../types' {
+  interface IMessageMetadata {
+    persona?: string;
+    model?: { id: string };
+  }
+}

--- a/packages/jupyter-chat/src/input-model.ts
+++ b/packages/jupyter-chat/src/input-model.ts
@@ -165,6 +165,11 @@ export interface IInputModel extends IDisposable {
 
   /**
    * Merge a patch into the metadata to attach to the next message to send.
+   *
+   * This is a *shallow* merge: each key in `patch` replaces the existing value
+   * at that key wholesale, rather than being merged recursively. To change a
+   * nested field, pass the whole new value for its top-level key. The patch is
+   * deep-copied, so mutating it afterwards won't affect the stored metadata.
    */
   updateMetadata(patch: IMessageMetadata): void;
 
@@ -520,9 +525,18 @@ export class InputModel implements IInputModel {
 
   /**
    * Merge a patch into the metadata to attach to the next message to send.
+   *
+   * This is a *shallow* merge: each key in `patch` replaces the existing value
+   * at that key wholesale, rather than being merged recursively. To change a
+   * nested field, pass the whole new value for its top-level key. The patch is
+   * deep-copied, so mutating it afterwards won't affect the stored metadata.
    */
   updateMetadata = (patch: IMessageMetadata): void => {
-    this._metadata = { ...this._metadata, ...patch };
+    // Deep-copy the patch so a caller mutating a nested field afterwards can't
+    // reach into the stored metadata. `this._metadata` only ever holds values
+    // that were themselves deep-copied on the way in, so a shallow spread of it
+    // is safe.
+    this._metadata = { ...this._metadata, ...structuredClone(patch) };
     this._metadataChanged.emit(this._metadata);
   };
 

--- a/packages/jupyter-chat/src/input-model.ts
+++ b/packages/jupyter-chat/src/input-model.ts
@@ -10,7 +10,13 @@ import { ISignal, Signal } from '@lumino/signaling';
 import { IActiveCellManager } from './active-cell-manager';
 import { ISelectionWatcher } from './selection-watcher';
 import { IChatContext } from './model';
-import { IAttachment, INewMessage, INotebookAttachment, IUser } from './types';
+import {
+  IAttachment,
+  IMessageMetadata,
+  INewMessage,
+  INotebookAttachment,
+  IUser
+} from './types';
 
 /**
  * The chat input interface.
@@ -153,6 +159,26 @@ export interface IInputModel extends IDisposable {
   clearMentions(): void;
 
   /**
+   * Get the metadata to attach to the next message to send.
+   */
+  getMetadata(): IMessageMetadata;
+
+  /**
+   * Merge a patch into the metadata to attach to the next message to send.
+   */
+  updateMetadata(patch: IMessageMetadata): void;
+
+  /**
+   * Clear the metadata.
+   */
+  clearMetadata(): void;
+
+  /**
+   * A signal emitting when the metadata has changed.
+   */
+  readonly metadataChanged?: ISignal<IInputModel, IMessageMetadata>;
+
+  /**
    * A signal emitting when disposing of the model.
    */
   readonly onDisposed: ISignal<InputModel, void>;
@@ -169,6 +195,7 @@ export class InputModel implements IInputModel {
     this._value = options.value || '';
     this._attachments = options.attachments || [];
     this._mentions = options.mentions || [];
+    this._metadata = options.metadata || {};
     this.cursorIndex = options.cursorIndex || this.value.length;
     this._activeCellManager = options.activeCellManager ?? null;
     this._selectionWatcher = options.selectionWatcher ?? null;
@@ -206,6 +233,11 @@ export class InputModel implements IInputModel {
     // Add the mentions
     if (this.mentions.length) {
       message.mentions = [...this.mentions];
+    }
+
+    // Add the metadata
+    if (Object.keys(this._metadata).length) {
+      message.metadata = { ...this._metadata };
     }
 
     // Send the message
@@ -480,6 +512,36 @@ export class InputModel implements IInputModel {
   };
 
   /**
+   * Get the metadata to attach to the next message to send.
+   */
+  getMetadata(): IMessageMetadata {
+    return this._metadata;
+  }
+
+  /**
+   * Merge a patch into the metadata to attach to the next message to send.
+   */
+  updateMetadata = (patch: IMessageMetadata): void => {
+    this._metadata = { ...this._metadata, ...patch };
+    this._metadataChanged.emit(this._metadata);
+  };
+
+  /**
+   * Clear the metadata.
+   */
+  clearMetadata = (): void => {
+    this._metadata = {};
+    this._metadataChanged.emit(this._metadata);
+  };
+
+  /**
+   * A signal emitting when the metadata has changed.
+   */
+  get metadataChanged(): ISignal<IInputModel, IMessageMetadata> {
+    return this._metadataChanged;
+  }
+
+  /**
    * Dispose the input model.
    */
   dispose(): void {
@@ -512,6 +574,7 @@ export class InputModel implements IInputModel {
   private _currentWord: string | null = null;
   private _attachments: IAttachment[];
   private _mentions: IUser[];
+  private _metadata: IMessageMetadata;
   private _activeCellManager: IActiveCellManager | null;
   private _selectionWatcher: ISelectionWatcher | null;
   private _documentManager: IDocumentManager | null;
@@ -522,6 +585,7 @@ export class InputModel implements IInputModel {
   private _configChanged = new Signal<IInputModel, InputModel.IConfig>(this);
   private _focusInputSignal = new Signal<InputModel, void>(this);
   private _attachmentsChanged = new Signal<InputModel, IAttachment[]>(this);
+  private _metadataChanged = new Signal<InputModel, IMessageMetadata>(this);
   private _onDisposed = new Signal<InputModel, void>(this);
   private _isDisposed = false;
 }
@@ -559,6 +623,11 @@ export namespace InputModel {
      * The initial mentions.
      */
     mentions?: IUser[];
+
+    /**
+     * The initial metadata.
+     */
+    metadata?: IMessageMetadata;
 
     /**
      * The current cursor index.


### PR DESCRIPTION

`INewMessage` already carries an optional `metadata` field, but the input model has no way to populate it, so it's always empty on send. We want the input toolbar to be able to stamp per-message metadata (for us, the target persona and its model/settings) onto the message it builds, without every consumer wiring its own path down to `send()`.

This adds a small `metadata` store to `IInputModel` alongside `mentions` and `attachments`: `getMetadata()`, `updateMetadata(patch)` (a lazy shallow merge), and `clearMetadata()`, plus a `metadataChanged` signal. `send()` now includes the metadata on the outgoing message when it's non-empty. Unlike attachments and mentions, the metadata is *not* cleared after sending — it holds a sticky selection that should carry to the next message until something changes it.