### PR TITLE
Skip bot users in mention suggestions

### DIFF
--- a/packages/jupyterlab-chat-extension/src/chat-commands/providers/user-mention.tsx
+++ b/packages/jupyterlab-chat-extension/src/chat-commands/providers/user-mention.tsx
@@ -139,6 +139,13 @@ class MentionCommandProvider implements IChatCommandProvider {
         return;
       }
 
+      // Skip bots (e.g. AI personas): they are not mentionable. This map also
+      // resolves mentions on submit, so a hand-typed bot mention stays plain
+      // text.
+      if (user.bot) {
+        return;
+      }
+
       if (!user.mention_name) {
         console.error(
           `No 'mention_name' property for user '${user.username}'. ` +

--- a/ui-tests/tests/user-mention.spec.ts
+++ b/ui-tests/tests/user-mention.spec.ts
@@ -117,3 +117,104 @@ test.describe('#user-mention', () => {
     expect(await chatCommandName.nth(0).textContent()).toBe('@jovyan_2');
   });
 });
+
+test.describe('#bot-mention', () => {
+  const BOT_FILENAME = 'bot-mention.chat';
+  // A chat whose user list already contains a human and a bot (the shape AI
+  // personas write): only the human should be mentionable. Each has sent a
+  // message, so both are populated as chat users.
+  const CONTENT = JSON.stringify({
+    messages: [
+      {
+        id: '4dd34eee-9e9f-4b0a-9c44-9962c8de4f95',
+        type: 'msg',
+        body: 'hi from human',
+        sender: 'human_user',
+        time: 1700000000,
+        raw_time: false
+      },
+      {
+        id: '9a4b7c88-2f6e-4d15-a30f-4a5bc1af1d21',
+        type: 'msg',
+        body: 'hi from bot',
+        sender: 'bot_user',
+        time: 1700000001,
+        raw_time: false
+      }
+    ],
+    users: {
+      human_user: {
+        username: 'human_user',
+        name: 'human_user',
+        display_name: 'human_user'
+      },
+      bot_user: {
+        username: 'bot_user',
+        name: 'Bot Agent',
+        display_name: 'Bot-Agent',
+        bot: true
+      }
+    },
+    attachments: {},
+    metadata: {}
+  });
+
+  test.use({
+    mockUser: USER
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await page.filebrowser.contents.uploadContent(
+      CONTENT,
+      'text',
+      BOT_FILENAME
+    );
+  });
+
+  test.afterEach(async ({ page }) => {
+    if (await page.filebrowser.contents.fileExists(BOT_FILENAME)) {
+      await page.filebrowser.contents.deleteFile(BOT_FILENAME);
+    }
+  });
+
+  test('should not suggest bot users', async ({ page }) => {
+    const chatPanel = await openChat(page, BOT_FILENAME);
+
+    // Wait for the seeded messages to render, so the user list is loaded
+    // before querying completions.
+    await expect(chatPanel.locator('.jp-chat-message')).toHaveCount(2);
+
+    const input = chatPanel
+      .locator('.jp-chat-input-container')
+      .getByRole('combobox');
+    const chatCommandName = page.locator('.jp-chat-command-name');
+
+    await input.fill('');
+    await input.press('@');
+    await expect(chatCommandName).toHaveCount(1);
+    expect(await chatCommandName.nth(0).textContent()).toBe('@human_user');
+  });
+
+  test('should not attach a mention for a typed bot name', async ({ page }) => {
+    const chatPanel = await openChat(page, BOT_FILENAME);
+
+    // Wait for the seeded messages to render, so the user list is loaded
+    // before submitting (mentions resolve on submit).
+    await expect(chatPanel.locator('.jp-chat-message')).toHaveCount(2);
+
+    const input = chatPanel
+      .locator('.jp-chat-input-container')
+      .getByRole('combobox');
+    const sendButton = chatPanel.locator(
+      '.jp-chat-input-container .jp-chat-send-button'
+    );
+
+    await input.fill('');
+    await input.pressSequentially('hi @Bot-Agent');
+    await sendButton.click();
+
+    const message = chatPanel.locator('.jp-chat-message').last();
+    await expect(message).toContainText('hi @Bot-Agent');
+    await expect(message.locator('.jp-chat-mention')).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
### Description

Bot users currently appear in the `@` mention autocomplete, and a hand-typed `@<bot-mention-name>` attaches a real mention on submit. For AI personas (which register as users with `bot: true`) mentions are no longer a meaningful gesture: jupyter-ai routes messages to personas via message metadata, not mentions. The chat UI already adapts to the `bot` flag elsewhere (the stop button enables only for bot writers, bot senders get different delete permissions), so mentionability follows the same line.

This skips users with `bot: true` in `MentionCommandProvider._getUsers()`. That map drives both the suggestion list and submit-time mention resolution, so bots stop being suggested and a hand-typed bot name stays plain text. Human users are unaffected.

### Tests

Two E2E tests in `user-mention.spec.ts` using a chat file seeded with one human and one bot user (each with a seeded message, matching how chat users populate): typing `@` suggests exactly the human, and sending `hi @Bot-Agent` attaches no mention. The three existing mention tests pass unchanged. Also verified live against a chat whose user list contains real AI personas: typing `@` offers none of them.

### Reviewer instructions

- Open chat, type "@", check that no personas are auto-suggested
