### PR TITLE
Expose awareness on IChatModel and IChatContext

### DIFF
--- a/packages/jupyter-chat/package.json
+++ b/packages/jupyter-chat/package.json
@@ -46,6 +46,7 @@
     "@emotion/react": "^11.10.5",
     "@emotion/styled": "^11.10.5",
     "@jupyter/react-components": "^0.15.2",
+    "@jupyter/ydoc": "^3.0.0 || ^4.0.0",
     "@jupyterlab/application": "^4.6.0",
     "@jupyterlab/apputils": "^4.7.0",
     "@jupyterlab/codeeditor": "^4.6.0",

--- a/packages/jupyter-chat/src/__tests__/model.spec.ts
+++ b/packages/jupyter-chat/src/__tests__/model.spec.ts
@@ -7,6 +7,8 @@
  * Example of [Jest](https://jestjs.io/docs/getting-started) unit tests
  */
 
+import type { IAwareness } from '@jupyter/ydoc';
+
 import { AbstractChatModel, IChatContext, IChatModel } from '../model';
 import { IMessage, IMessageContent, INewMessage } from '../types';
 import { MockChatModel, MockChatContext } from './mocks';
@@ -147,6 +149,22 @@ describe('test chat model', () => {
     it('should allow config', () => {
       const model = new MockChatModel({ config: { sendWithShiftEnter: true } });
       expect(model.config.sendWithShiftEnter).toBeTruthy();
+    });
+  });
+
+  describe('awareness', () => {
+    it('should surface the model awareness on the context', () => {
+      class AwareChatModel extends MockChatModel {
+        readonly awareness = {} as IAwareness;
+      }
+      const model = new AwareChatModel();
+      const context = new MockChatContext({ model });
+      expect(context.awareness).toBe(model.awareness);
+    });
+
+    it('should be undefined when the model has no awareness', () => {
+      const context = new MockChatContext({ model: new MockChatModel() });
+      expect(context.awareness).toBeUndefined();
     });
   });
 });

--- a/packages/jupyter-chat/src/model.ts
+++ b/packages/jupyter-chat/src/model.ts
@@ -9,6 +9,7 @@ import {
   nullTranslator,
   TranslationBundle
 } from '@jupyterlab/translation';
+import type { IAwareness } from '@jupyter/ydoc';
 import { ArrayExt } from '@lumino/algorithm';
 import { CommandRegistry } from '@lumino/commands';
 import { PromiseDelegate } from '@lumino/coreutils';
@@ -52,6 +53,14 @@ export interface IChatModel extends IDisposable {
    * The promise resolving when the model is ready.
    */
   readonly ready: Promise<void>;
+
+  /**
+   * The awareness channel of the underlying shared document, when the chat is
+   * backed by one. Lets extensions read collaborative state attached to the
+   * chat (e.g. session information published by AI personas) through a
+   * supported API instead of reaching into a concrete implementation.
+   */
+  readonly awareness?: IAwareness;
 
   /**
    * The indexes list of the messages currently in the viewport.
@@ -894,6 +903,11 @@ export interface IChatContext {
    * Current user connected with the chat panel
    */
   readonly user: IUser | undefined;
+  /**
+   * The awareness channel of the underlying shared document, when the chat is
+   * backed by one.
+   */
+  readonly awareness?: IAwareness;
 }
 
 /**
@@ -915,6 +929,10 @@ export abstract class AbstractChatContext implements IChatContext {
 
   get user(): IUser | undefined {
     return this._model?.user;
+  }
+
+  get awareness(): IAwareness | undefined {
+    return this._model.awareness;
   }
 
   /**

--- a/packages/jupyterlab-chat/src/model.ts
+++ b/packages/jupyterlab-chat/src/model.ts
@@ -14,6 +14,7 @@ import {
   INewMessage,
   IUser
 } from '@jupyter/chat';
+import type { IAwareness } from '@jupyter/ydoc';
 import { IChangedArgs } from '@jupyterlab/coreutils';
 import { DocumentRegistry } from '@jupyterlab/docregistry';
 import { User } from '@jupyterlab/services';
@@ -130,6 +131,13 @@ export class LabChatModel
 
   get sharedModel(): YChat {
     return this._sharedModel;
+  }
+
+  /**
+   * The awareness channel of the shared model.
+   */
+  get awareness(): IAwareness {
+    return this._sharedModel.awareness;
   }
 
   get contentChanged(): ISignal<this, void> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2360,6 +2360,7 @@ __metadata:
     "@emotion/react": ^11.10.5
     "@emotion/styled": ^11.10.5
     "@jupyter/react-components": ^0.15.2
+    "@jupyter/ydoc": ^3.0.0 || ^4.0.0
     "@jupyterlab/application": ^4.6.0
     "@jupyterlab/apputils": ^4.7.0
     "@jupyterlab/codeeditor": ^4.6.0


### PR DESCRIPTION
### Description

Extensions increasingly need the chat's Yjs awareness channel: jupyter-ai personas now publish their session state (models, settings, usage, commands) over it, and the chat input toolbar reads it. There is no public path to it today, so downstream code reaches through internals, e.g. jupyter-ai-acp-client reads `(chatContext as { _model?: unknown })._model.sharedModel.awareness` (https://github.com/jupyter-ai-contrib/jupyter-ai-acp-client/blob/73bd7aa/src/index.ts). Because the cast hides the access from the compiler, a rename of that internal breaks the consumer silently. Verified by renaming `_model` in a local build: everything still compiles and the consumer's slash-command E2E fails with completions never appearing.

This adds an optional readonly `awareness` to `IChatModel` and `IChatContext`. `AbstractChatContext` returns `this._model.awareness`, and `LabChatModel` implements it as `sharedModel.awareness`. Purely additive, no behavior change; `@jupyter/ydoc` is added to `@jupyter/chat` for the type (`^3.0.0 || ^4.0.0`, matching `jupyterlab-chat`).

Known consumers once released: jupyter-ai-acp-client replaces the reach-in, and the planned shared persona toolbar in jupyter-ai-persona-manager reads awareness through it from the start.

### Tests

Two unit tests in the core `model.spec.ts`: the context surfaces the model's awareness object, and it is undefined for models that don't provide one.