### PR TITLE
Show a "New chat" label next to the "+" button in the chat panel

### DIFF
--- a/packages/jupyter-chat/src/widgets/multichat-panel.tsx
+++ b/packages/jupyter-chat/src/widgets/multichat-panel.tsx
@@ -102,6 +102,7 @@ export class MultiChatPanel extends PanelWithToolbar {
           this.open(addChatArgs);
         },
         icon: addIcon,
+        label: this._trans.__('New chat'),
         tooltip: this._trans.__('Create a new chat')
       });
       addChat.addClass(ADD_BUTTON_CLASS);


### PR DESCRIPTION
Fixes #449

### Description

Adds `label: this._trans.__('New chat')` to the existing new-chat `ToolbarButton` in `MultiChatPanel`, keeping the icon, tooltip, and click handler. Reuses the same translation string as the empty-state placeholder button so the two entry points stay in sync.

### Reviewer instructions

- Open the Jupyter Chat side panel, the toolbar should "+ New chat" next to the chat selector, not just "+"
