### PR TITLE
test: avoid SQLite YStore locks in parallel UI tests

### DIFF
--- a/ui-tests/jupyter_server_test_config.py
+++ b/ui-tests/jupyter_server_test_config.py
@@ -13,5 +13,10 @@ configure_jupyter_server(c)
 
 c.FileContentsManager.delete_to_trash = False
 
+# Each UI test runs in its own temporary directory, but all documents handled by
+# the server otherwise share the same SQLite YStore. Use one temporary file per
+# document so parallel tests do not contend for a database lock.
+c.YDocExtension.ystore_class = "jupyter_server_ydoc.stores.TempFileYStore"
+
 # Uncomment to set server log level to debug level
 # c.ServerApp.log_level = "DEBUG"

--- a/ui-tests/jupyter_server_test_config_notebook.py
+++ b/ui-tests/jupyter_server_test_config_notebook.py
@@ -23,5 +23,10 @@ c.LabServerApp.extra_labextensions_path = str(Path(jupyterlab.__file__).parent /
 
 c.FileContentsManager.delete_to_trash = False
 
+# Each UI test runs in its own temporary directory, but all documents handled by
+# the server otherwise share the same SQLite YStore. Use one temporary file per
+# document so parallel tests do not contend for a database lock.
+c.YDocExtension.ystore_class = "jupyter_server_ydoc.stores.TempFileYStore"
+
 # Uncomment to set server log level to debug level
 # c.ServerApp.log_level = "DEBUG"


### PR DESCRIPTION
Fixes #479

Parallel UI tests use separate Galata temporary directories, but the Jupyter server still persists all Y documents through the same SQLite YStore. When tests create and clean up chats, files, and notebooks at the same time, SQLite can fail with `sqlite3.OperationalError: database is locked`.

The UI test server configs now use `TempFileYStore`, which keeps each document's update log in a temporary file and avoids cross-test SQLite contention. This only changes the test server configuration; the default SQLite store remains unchanged for normal use.

Validation:
- `pytest -q python/jupyterlab-chat/jupyterlab_chat/tests` (22 passed)
- `jlpm build:prod`
- `playwright test tests/drag-drop-attachments.spec.ts tests/attachments.spec.ts --workers=2 --retries=0` (12 passed)
- repeated the notebook drag-and-drop case three times (6 passed)