### PR TITLE
fix: keep message navigation working when deleted messages are hidden

### DIFF
--- a/packages/jupyter-chat/src/__tests__/model.spec.ts
+++ b/packages/jupyter-chat/src/__tests__/model.spec.ts
@@ -151,6 +151,33 @@ describe('test chat model', () => {
     });
   });
 
+  describe('unread messages', () => {
+    const msg = (id: string, time: number): IMessageContent => ({
+      type: 'msg',
+      id,
+      time,
+      body: `message ${id}`,
+      sender: { username: 'user' }
+    });
+
+    it('should not mark deleted messages as unread', () => {
+      const model = new MockChatModel();
+      model.messageAdded({ ...msg('message1', 1000), deleted: true });
+      model.messageAdded(msg('message2', 2000));
+      expect(model.unreadMessages).toEqual([1]);
+    });
+
+    it('should remove a message from the unread list when it is deleted', () => {
+      const model = new MockChatModel();
+      model.messageAdded(msg('message1', 1000));
+      model.messageAdded(msg('message2', 2000));
+      expect(model.unreadMessages).toEqual([0, 1]);
+
+      model.messages[0].update({ deleted: true });
+      expect(model.unreadMessages).toEqual([1]);
+    });
+  });
+
   describe('awareness', () => {
     it('should surface the model awareness on the context', () => {
       class AwareChatModel extends MockChatModel {

--- a/packages/jupyter-chat/src/components/messages/messages.tsx
+++ b/packages/jupyter-chat/src/components/messages/messages.tsx
@@ -210,6 +210,19 @@ export function ChatMessages(): JSX.Element {
     };
   }, [messages, showDeleted, allRendered]);
 
+  // The list of messages to display, once deleted messages are filtered out.
+  const visibleMessages = showDeleted
+    ? messages
+    : messages.filter(message => !message.deleted);
+
+  // Map each message to its index in 'model.messages'. The viewport and the
+  // unread messages are tracked against the full model list (deleted messages
+  // are kept in the model, even when they are not rendered), so 'data-index'
+  // has to reference the model index for the intersection observer and the
+  // navigation to stay consistent.
+  const modelIndex = new Map<string, number>();
+  model.messages.forEach((message, index) => modelIndex.set(message.id, index));
+
   const horizontalPadding = area === 'main' ? 8 : 4;
   return (
     <>
@@ -230,10 +243,7 @@ export function ChatMessages(): JSX.Element {
           className={clsx(MESSAGES_BOX_CLASS)}
         >
           {/* Filter the deleted message if user don't expect to see it. */}
-          {(showDeleted
-            ? messages
-            : messages.filter(message => !message.deleted)
-          ).map((message, i) => {
+          {visibleMessages.map((message, i) => {
             const isCurrentUser =
               model.user !== undefined &&
               model.user.username === message.sender.username;
@@ -262,7 +272,10 @@ export function ChatMessages(): JSX.Element {
                 {messagePreambleRegistry && (
                   <MessagePreambleComponent message={message} />
                 )}
-                <ChatMessage message={message} index={i} />
+                <ChatMessage
+                  message={message}
+                  index={modelIndex.get(message.id) ?? i}
+                />
                 {messageFooterRegistry && (
                   <MessageFooterComponent message={message} />
                 )}

--- a/packages/jupyter-chat/src/components/messages/navigation.tsx
+++ b/packages/jupyter-chat/src/components/messages/navigation.tsx
@@ -20,6 +20,27 @@ const NAVIGATION_TOP_CLASS = 'jp-chat-navigation-top';
 const NAVIGATION_BOTTOM_CLASS = 'jp-chat-navigation-bottom';
 
 /**
+ * The index of the last message expected to be rendered, or -1 when no message
+ * is rendered at all. Deleted messages are skipped when the 'showDeleted'
+ * setting is disabled, so the navigation should consider the last visible
+ * message instead of the last one in the model.
+ *
+ * @param model - the chat model.
+ * @returns the index of the last rendered message.
+ */
+function lastRenderedMessageIndex(model: IChatModel): number {
+  if (model.config.showDeleted) {
+    return model.messages.length - 1;
+  }
+  for (let i = model.messages.length - 1; i >= 0; i--) {
+    if (!model.messages[i].deleted) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+/**
  * The navigation component props.
  */
 type NavigationProps = {
@@ -44,7 +65,16 @@ export function Navigation(props: NavigationProps): JSX.Element {
   const [unreadAfter, setUnreadAfter] = useState<number | null>(null);
 
   const gotoMessage = (msgIdx: number, alignToTop: boolean = true) => {
-    props.refMsgBox.current?.children.item(msgIdx)?.scrollIntoView(alignToTop);
+    const msgEl = props.refMsgBox.current?.querySelector(
+      `[data-index="${msgIdx}"]`
+    );
+    if (msgEl) {
+      msgEl.scrollIntoView(alignToTop);
+    } else {
+      // The message is not rendered (deleted and hidden), so scroll to the
+      // last visible message instead.
+      props.refMsgBox.current?.scrollIntoView(false);
+    }
   };
 
   // Listen for change in unread messages, and find the first unread message before or
@@ -101,7 +131,7 @@ export function Navigation(props: NavigationProps): JSX.Element {
     unreadChanged(model, model.unreadMessages);
 
     // Move to the last the message after all the messages have been first rendered.
-    gotoMessage(model.messages.length - 1, false);
+    gotoMessage(lastRenderedMessageIndex(model), false);
 
     return () => {
       model.unreadChanged?.disconnect(unreadChanged);
@@ -114,7 +144,7 @@ export function Navigation(props: NavigationProps): JSX.Element {
     const viewportChanged = (model: IChatModel, viewport: number[]) => {
       setLastInViewport(
         model.messages.length === 0 ||
-          viewport.includes(model.messages.length - 1)
+          viewport.includes(lastRenderedMessageIndex(model))
       );
     };
 
@@ -147,7 +177,7 @@ export function Navigation(props: NavigationProps): JSX.Element {
           className={`${NAVIGATION_BUTTON_CLASS} ${unreadAfter !== null ? NAVIGATION_UNREAD_CLASS : ''} ${NAVIGATION_BOTTOM_CLASS}`}
           onClick={
             unreadAfter === null
-              ? () => gotoMessage(model.messages.length - 1, false)
+              ? () => gotoMessage(lastRenderedMessageIndex(model), false)
               : () => gotoMessage(unreadAfter)
           }
           title={

--- a/packages/jupyter-chat/src/model.ts
+++ b/packages/jupyter-chat/src/model.ts
@@ -623,7 +623,10 @@ export abstract class AbstractChatModel implements IChatModel {
       const msg = new Message(formattedMessage);
       msg.changed.connect(this._onMessageChanged, this);
       formattedMessages.push(msg);
-      if (message.time > this.lastRead) {
+      // A deleted message is never rendered (or only as an empty placeholder),
+      // so it can never be marked as read by being scrolled into view: it
+      // should not be counted as unread.
+      if (message.time > this.lastRead && !message.deleted) {
         unreadIndexes.push(index + idx);
       }
     });
@@ -773,6 +776,17 @@ export abstract class AbstractChatModel implements IChatModel {
   }
 
   private _onMessageChanged(msg: IMessage): void {
+    // A deleted message is never rendered (or only as an empty placeholder),
+    // so it can never be marked as read by being scrolled into view: remove
+    // it from the unread messages as soon as it is deleted.
+    if (msg.deleted) {
+      const index = this._messages.indexOf(msg);
+      if (index !== -1 && this._unreadMessages.includes(index)) {
+        this.unreadMessages = this._unreadMessages.filter(
+          unreadIndex => unreadIndex !== index
+        );
+      }
+    }
     this._messageChanged.emit(msg);
   }
 

--- a/ui-tests/tests/unread.spec.ts
+++ b/ui-tests/tests/unread.spec.ts
@@ -74,6 +74,120 @@ test.describe('#messagesNavigation', () => {
     });
   });
 
+  test.describe('navigation with deleted messages hidden', () => {
+    const deletedMessagesCount = 50;
+
+    // Build a chat long enough that the messages overflow the viewport, so the
+    // navigation buttons have a reason to show up.
+    const deletedMessagesList = (): any[] => {
+      const list: any[] = [];
+      for (let i = 0; i < deletedMessagesCount; i++) {
+        list.push({
+          type: 'msg',
+          id: UUID.uuid4(),
+          sender: USERNAME,
+          body: `Message ${i}`,
+          time: baseTime + i * 60
+        });
+      }
+      return list;
+    };
+
+    // Upload a chat with a deleted message (hidden by default) and open it.
+    const openChatWithDeletedMessage = async (
+      page: IJupyterLabPageFixture,
+      deleteIndex: number
+    ) => {
+      const chatMessages = deletedMessagesList();
+      chatMessages[deleteIndex].deleted = true;
+      const deletedChatContent = {
+        messages: chatMessages,
+        users: {}
+      };
+      deletedChatContent.users[USERNAME] = USER.identity;
+
+      await page.filebrowser.contents.uploadContent(
+        JSON.stringify(deletedChatContent),
+        'text',
+        FILENAME
+      );
+
+      const chatPanel = await openChat(page, FILENAME);
+      const messages = chatPanel.locator('.jp-chat-message');
+      // The deleted message is not rendered.
+      await expect(messages).toHaveCount(deletedMessagesCount - 1);
+      return chatPanel;
+    };
+
+    test('should navigate to the last message when a message is deleted', async ({
+      page
+    }) => {
+      const chatPanel = await openChatWithDeletedMessage(page, 10);
+      const messages = chatPanel.locator('.jp-chat-message');
+      const lastMessageButton = chatPanel.getByTitle('Go to last message');
+
+      // Mark the chat as read so the bottom button targets the last message
+      // instead of the next unread one.
+      await chatPanel.getByTitle('Mark chat as read').click();
+
+      // Move to the first message.
+      await messages.first().scrollIntoViewIfNeeded();
+
+      await expect(lastMessageButton).toBeAttached();
+      await lastMessageButton.click();
+      await expect(messages.last()).toBeInViewport();
+      await expect(lastMessageButton).not.toBeAttached();
+    });
+
+    test('should navigate when the last message is deleted', async ({
+      page
+    }) => {
+      const chatPanel = await openChatWithDeletedMessage(
+        page,
+        deletedMessagesCount - 1
+      );
+      const messages = chatPanel.locator('.jp-chat-message');
+      const lastMessageButton = chatPanel.getByTitle('Go to last message');
+
+      // Mark the chat as read so the bottom button targets the last message.
+      await chatPanel.getByTitle('Mark chat as read').click();
+
+      // Move to the first message.
+      await messages.first().scrollIntoViewIfNeeded();
+
+      await expect(lastMessageButton).toBeAttached();
+      await lastMessageButton.click();
+      await expect(messages.last()).toBeInViewport();
+      await expect(lastMessageButton).not.toBeAttached();
+    });
+
+    test('should navigate to the next unread message when a message is deleted', async ({
+      page
+    }) => {
+      const chatPanel = await openChatWithDeletedMessage(page, 10);
+      const messages = chatPanel.locator('.jp-chat-message');
+      const navigationBottom = chatPanel.locator('.jp-chat-navigation-bottom');
+      const scrollContainer = chatPanel.locator(
+        '[id^="jupyter-chat-scroll-container"]'
+      );
+
+      // Move to a message just above the deleted one.
+      await messages.nth(9).scrollIntoViewIfNeeded();
+
+      await expect(navigationBottom).toBeAttached();
+      expect(navigationBottom).toHaveClass(/jp-chat-navigation-unread/);
+
+      // Clicking jumps to the next unread message, past the hidden deleted one.
+      const scrollTopBefore = await scrollContainer.evaluate(
+        el => el.scrollTop
+      );
+      await navigationBottom.click();
+      await expect
+        .poll(() => scrollContainer.evaluate(el => el.scrollTop))
+        .toBeGreaterThan(scrollTopBefore);
+    });
+  });
+
   test.describe('navigation with previous unread message', () => {
     let newChatContent = {};
     test.beforeEach(async ({ page }) => {


### PR DESCRIPTION
Fixes #404

## What this does

The navigation buttons and the unread-message tracking work on indexes into the full model message list, but each rendered message was tagged with `data-index` equal to its position in the *filtered* list (deleted messages stay in the model, they just aren't rendered when `showDeleted` is off). As soon as one message is deleted, those two index spaces stop lining up:

- unread messages never appear in the viewport, so they never get marked as read and the navigation buttons stick around
- "go to last message" targets a DOM child that doesn't exist anymore, so the button silently does nothing

## How I fixed it

- `messages.tsx`: tag each rendered message with its index in `model.messages` instead of its position in the rendered list, so `data-index`, the viewport and the unread messages all live in the same index space.
- `navigation.tsx`: resolve navigation targets by `data-index` instead of `children.item(...)`, and use the last *rendered* message as the bottom target, so it still works when the last message in the model is deleted and hidden.
- `model.ts`: a deleted message is never rendered (or only as an empty placeholder) so it can never be marked as read by scrolling. Deleted messages are now excluded from the unread list when inserted, and dropped from it when a message is deleted, so a chat with a hidden deleted message doesn't stay permanently unread.

## Tests

- Two unit tests in `model.spec.ts` covering the unread behaviour for deleted messages.
- Three UI tests in `unread.spec.ts`: navigation to the last message works when a message in the middle is deleted and hidden, when the last message itself is deleted and hidden, and unread navigation still jumps past the hidden deleted message.

Verified locally: `tsc` build, the jest suite (54 tests), prettier and eslint all pass.