### PR TITLE
fix: match @mentions with non-ASCII characters

### DIFF
--- a/packages/jupyter-chat/src/__tests__/mention.spec.ts
+++ b/packages/jupyter-chat/src/__tests__/mention.spec.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+import { MENTION_REGEX } from '../utils';
+
+function mentionNames(text: string): string[] {
+  const names: string[] = [];
+  // exec() with a 'g' regex advances lastIndex, so build a fresh regex each
+  // call instead of reusing the shared one.
+  const regex = new RegExp(MENTION_REGEX.source, MENTION_REGEX.flags);
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(text)) !== null) {
+    names.push(match[1]);
+  }
+  return names;
+}
+
+describe('MENTION_REGEX', () => {
+  it('should match a plain ASCII mention', () => {
+    expect(mentionNames('@jovyan')).toEqual(['jovyan']);
+  });
+
+  it('should match a mention with an underscore', () => {
+    expect(mentionNames('@jovyan_2')).toEqual(['jovyan_2']);
+  });
+
+  it('should match a mention with a hyphen', () => {
+    expect(mentionNames('@test-user')).toEqual(['test-user']);
+  });
+
+  it('should match a mention with non-ASCII letters', () => {
+    expect(mentionNames('@Pérez')).toEqual(['Pérez']);
+    expect(mentionNames('@María-Pérez')).toEqual(['María-Pérez']);
+    expect(mentionNames('@José')).toEqual(['José']);
+  });
+
+  it('should match a mention starting with a non-ASCII letter', () => {
+    expect(mentionNames('@Élodie')).toEqual(['Élodie']);
+  });
+
+  it('should match non-Latin script mentions', () => {
+    expect(mentionNames('@张三')).toEqual(['张三']);
+    expect(mentionNames('@Иван')).toEqual(['Иван']);
+  });
+
+  it('should match several mentions in one message', () => {
+    expect(mentionNames('hello @Pérez and @jovyan')).toEqual([
+      'Pérez',
+      'jovyan'
+    ]);
+  });
+
+  it('should match an @ without a name', () => {
+    expect(mentionNames('just an @ sign')).toEqual(['']);
+  });
+
+  it('should stop the mention at trailing punctuation', () => {
+    expect(mentionNames('@Pérez, next')).toEqual(['Pérez']);
+    expect(mentionNames('Hi @Pérez.')).toEqual(['Pérez']);
+  });
+
+  it('should not match text without an @', () => {
+    expect(mentionNames('plain text')).toEqual([]);
+  });
+});

--- a/packages/jupyter-chat/src/utils.ts
+++ b/packages/jupyter-chat/src/utils.ts
@@ -19,6 +19,19 @@ import { IUser } from './types';
 const MENTION_CLASS = 'jp-chat-mention';
 
 /**
+ * Regular expression matching the `@mention` tokens in a chat message.
+ *
+ * The first capturing group holds the mention name. Mention names are built
+ * from display names (see {@link IUser.mention_name}), which routinely contain
+ * non-ASCII letters (e.g. "Pérez"), so the character class is Unicode-aware
+ * instead of relying on `\w`, which is ASCII-only in JavaScript.
+ *
+ * The `g` flag must be kept: callers use `matchAll()` over the full input
+ * to collect every `@`-mention.
+ */
+export const MENTION_REGEX = /@([\p{L}\p{N}_-]*)/gu;
+
+/**
  * Gets the editor instance used by a document widget. Returns `null` if unable.
  */
 export function getEditor(

--- a/packages/jupyterlab-chat-extension/src/chat-commands/providers/user-mention.tsx
+++ b/packages/jupyterlab-chat-extension/src/chat-commands/providers/user-mention.tsx
@@ -10,7 +10,8 @@ import {
   ChatCommand,
   IInputModel,
   Avatar,
-  IUser
+  IUser,
+  MENTION_REGEX
 } from '@jupyter/chat';
 import { JupyterFrontEndPlugin } from '@jupyterlab/application';
 
@@ -34,7 +35,7 @@ class MentionCommandProvider implements IChatCommandProvider {
    * IMPORTANT: the 'g' flag must be set to return multiple `@`-mentions when
    * parsing the entire input `inputModel.value`.
    */
-  private _regex: RegExp = /@([\w-]*)/g;
+  private _regex: RegExp = MENTION_REGEX;
 
   /**
    * Lists all valid user mentions that complete the current word.

--- a/ui-tests/tests/user-mention.spec.ts
+++ b/ui-tests/tests/user-mention.spec.ts
@@ -218,3 +218,108 @@ test.describe('#bot-mention', () => {
     await expect(message.locator('.jp-chat-mention')).toHaveCount(0);
   });
 });
+
+test.describe('#non-ascii-mention', () => {
+  const NON_ASCII_FILENAME = 'non-ascii-mention.chat';
+  // A chat whose user list contains someone with an accented display name
+  // (the mention name keeps the accent, see IUser.mention_name). Both users
+  // have sent a message, so they are both populated as chat users.
+  const CONTENT = JSON.stringify({
+    messages: [
+      {
+        id: 'a5b14f7e-0d29-4e4a-9a8f-1f1b9f6d3d21',
+        type: 'msg',
+        body: 'hi from main',
+        sender: 'human_user',
+        time: 1700000000,
+        raw_time: false
+      },
+      {
+        id: 'e0f6c8aa-2a4b-4f5e-b7a2-3c6d9f0e1b33',
+        type: 'msg',
+        body: 'hola desde guest',
+        sender: 'guest_user',
+        time: 1700000001,
+        raw_time: false
+      }
+    ],
+    users: {
+      human_user: {
+        username: 'human_user',
+        name: 'human_user',
+        display_name: 'human_user'
+      },
+      guest_user: {
+        username: 'guest_user',
+        name: 'guest_user',
+        display_name: 'Élodie'
+      }
+    },
+    attachments: {},
+    metadata: {}
+  });
+
+  test.use({
+    mockUser: USER
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await page.filebrowser.contents.uploadContent(
+      CONTENT,
+      'text',
+      NON_ASCII_FILENAME
+    );
+  });
+
+  test.afterEach(async ({ page }) => {
+    if (await page.filebrowser.contents.fileExists(NON_ASCII_FILENAME)) {
+      await page.filebrowser.contents.deleteFile(NON_ASCII_FILENAME);
+    }
+  });
+
+  test('should suggest a user with an accented display name', async ({
+    page
+  }) => {
+    const chatPanel = await openChat(page, NON_ASCII_FILENAME);
+
+    // Wait for the seeded messages to render, so the user list is loaded
+    // before querying completions.
+    await expect(chatPanel.locator('.jp-chat-message')).toHaveCount(2);
+
+    const input = chatPanel
+      .locator('.jp-chat-input-container')
+      .getByRole('combobox');
+    const chatCommandName = page.locator('.jp-chat-command-name');
+
+    await input.fill('');
+    await input.pressSequentially('@Él');
+    await expect(chatCommandName).toHaveCount(1);
+    expect(await chatCommandName.nth(0).textContent()).toBe('@Élodie');
+  });
+
+  test('should attach a mention for an accented display name on submit', async ({
+    page
+  }) => {
+    const chatPanel = await openChat(page, NON_ASCII_FILENAME);
+
+    // Wait for the seeded messages to render, so the user list is loaded
+    // before submitting (mentions resolve on submit).
+    await expect(chatPanel.locator('.jp-chat-message')).toHaveCount(2);
+
+    const input = chatPanel
+      .locator('.jp-chat-input-container')
+      .getByRole('combobox');
+    const sendButton = chatPanel.locator(
+      '.jp-chat-input-container .jp-chat-send-button'
+    );
+
+    await input.fill('');
+    await input.pressSequentially('hi @Élodie');
+    await sendButton.click();
+
+    const message = chatPanel.locator('.jp-chat-message').last();
+    await expect(message).toContainText('hi @Élodie');
+    await expect(message.locator('.jp-chat-mention')).toHaveCount(1);
+    await expect(message.locator('.jp-chat-mention')).toContainText('@Élodie');
+  });
+});


### PR DESCRIPTION
## Description

The mention provider in `jupyterlab-chat-extension` parsed `@`-mentions with `/@([\w-]*)/g`, and `\w` is ASCII-only in JavaScript. Mention names keep the user's display name (see `IUser.mention_name`), so anyone with a non-ASCII name — `Pérez`, `Élodie`, `张三`, etc. — could not be completed or resolved: typing `@Pé` produced a truncated match, and on submit the mention was dropped entirely. The server-side `find_mentions` in `jupyterlab_chat/utils.py` uses Python's `\w`, which is Unicode-aware, so the client and server disagreed about what a mention name could be. This is the same issue reported for the Jupyter AI chat (jupyterlab/jupyter-ai#1393), which embeds this provider.

The fix moves the mention regex into `@jupyter/chat` as a shared `MENTION_REGEX` using a Unicode-aware character class (`\p{L}\p{N}_-`), and the provider now uses it. This matches what the server already accepts.

## Changes

- `packages/jupyter-chat/src/utils.ts`: export `MENTION_REGEX` (Unicode-aware, `g` flag preserved for `matchAll`).
- `packages/jupyterlab-chat-extension/src/chat-commands/providers/user-mention.tsx`: use `MENTION_REGEX` instead of the local ASCII regex.
- `packages/jupyter-chat/src/__tests__/mention.spec.ts`: unit tests covering ASCII, accented, hyphenated, non-Latin, multi-mention and punctuation cases (the accented cases fail against the old regex).
- `ui-tests/tests/user-mention.spec.ts`: UI regression tests for an accented display name (completion and mention attachment on submit).

## How to test

1. `cd packages/jupyter-chat && npx jest src/__tests__/mention.spec.ts` — 10 tests pass; the accented and non-Latin cases fail if the regex is reverted to `[\w-]`.
2. Full `@jupyter/chat` suite: 62 tests pass.
3. UI tests: `user-mention.spec.ts` includes `#non-ascii-mention` cases.

Refs jupyterlab/jupyter-ai#1393
