### PR TITLE
fix: don't send message when Enter confirms an IME candidate

### DIFF
--- a/packages/jupyter-chat/src/__tests__/ime.spec.ts
+++ b/packages/jupyter-chat/src/__tests__/ime.spec.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+import { isImeCompositionEvent } from '../components/input/ime';
+
+describe('isImeCompositionEvent', () => {
+  it('should return true while a composition session is active', () => {
+    expect(isImeCompositionEvent({ isComposing: true, keyCode: 13 })).toBe(
+      true
+    );
+  });
+
+  it('should return true for the legacy keyCode 229 marker', () => {
+    expect(isImeCompositionEvent({ isComposing: false, keyCode: 229 })).toBe(
+      true
+    );
+  });
+
+  it('should return false for a plain Enter key press', () => {
+    expect(isImeCompositionEvent({ isComposing: false, keyCode: 13 })).toBe(
+      false
+    );
+  });
+
+  it('should return false for any other regular key press', () => {
+    expect(isImeCompositionEvent({ isComposing: false, keyCode: 65 })).toBe(
+      false
+    );
+  });
+});

--- a/packages/jupyter-chat/src/components/input/chat-input.tsx
+++ b/packages/jupyter-chat/src/components/input/chat-input.tsx
@@ -14,6 +14,7 @@ import {
 import clsx from 'clsx';
 import React, { useEffect, useRef, useState } from 'react';
 
+import { isImeCompositionEvent } from './ime';
 import { InputToolbarRegistry } from './toolbar-registry';
 import { submitInputMessage } from './submit-message';
 import { useChatCommands } from './use-chat-commands';
@@ -117,6 +118,16 @@ export function ChatInput(props: ChatInput.IProps): JSX.Element {
    * component.
    */
   async function handleKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {
+    /**
+     * During IME composition (e.g. typing with a Chinese, Japanese or Korean
+     * input method) the browser consumes the pressed keys before the page does.
+     * In particular, pressing Enter confirms the selected candidate; handling
+     * it here would send an unfinished message. Let the IME finish first.
+     */
+    if (isImeCompositionEvent(event.nativeEvent)) {
+      return;
+    }
+
     /**
      * IMPORTANT: This statement ensures that arrow keys can be used to navigate
      * the multiline input when the chat commands menu is closed.

--- a/packages/jupyter-chat/src/components/input/ime.ts
+++ b/packages/jupyter-chat/src/components/input/ime.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+/**
+ * Returns true when a key event is part of an ongoing IME composition
+ * (e.g. Chinese Pinyin, Japanese, or Korean input methods).
+ *
+ * Browsers set `isComposing` on key events emitted while a composition
+ * session is active, and some engines report `keyCode === 229` instead.
+ * Pressing Enter during composition confirms the current candidate; it
+ * must not be treated as a regular Enter press (e.g. sending a message).
+ */
+export function isImeCompositionEvent(
+  event: Pick<KeyboardEvent, 'isComposing' | 'keyCode'>
+): boolean {
+  return event.isComposing || event.keyCode === 229;
+}

--- a/packages/jupyter-chat/src/widgets/multichat-panel.tsx
+++ b/packages/jupyter-chat/src/widgets/multichat-panel.tsx
@@ -31,6 +31,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { ChatSelectorPopup } from './chat-selector-popup';
 import { ChatWidget } from './chat-widget';
 import { defaultPlaceholder, Placeholder } from './placeholder';
+import { isImeCompositionEvent } from '../components/input/ime';
 import {
   Chat,
   IInputToolbarRegistry,
@@ -849,6 +850,11 @@ function ChatSearchInput({
   const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
     const popup = getPopup();
     if (!popup || !popup.isVisible) {
+      return;
+    }
+
+    // Ignore key events during IME composition.
+    if (isImeCompositionEvent(event.nativeEvent)) {
       return;
     }
 

--- a/ui-tests/tests/side-panel.spec.ts
+++ b/ui-tests/tests/side-panel.spec.ts
@@ -117,6 +117,40 @@ test.describe('#sidepanel', () => {
       await expect(chatList.locator('li').last()).toHaveText(name);
     });
 
+    test('should not select a chat while confirming an IME candidate', async ({
+      page
+    }) => {
+      panel = await openSidePanel(page);
+      const chatList = page.locator('.jp-chat-selector-popup');
+      const searchInput = panel.locator('.jp-chat-search-input');
+
+      await panel
+        .locator('> .jp-Toolbar .jp-Toolbar-item.jp-chat-open')
+        .click();
+      await chatList.waitFor();
+      await expect(chatList.getByTitle(name)).toBeVisible();
+
+      await searchInput.evaluate(element => {
+        const event = new KeyboardEvent('keydown', {
+          bubbles: true,
+          cancelable: true,
+          key: 'Enter'
+        });
+        Object.defineProperty(event, 'isComposing', { value: true });
+        element.dispatchEvent(event);
+      });
+
+      // Confirming an IME candidate should leave the chat selector open.
+      await expect(chatList).toBeVisible();
+
+      // A regular Enter still selects the highlighted chat.
+      await searchInput.press('Enter');
+      await expect(chatList).not.toBeVisible();
+      await expect(panel.locator('.jp-chat-sidepanel-widget-title')).toHaveText(
+        name
+      );
+    });
+
     test('should attach a spinner while loading the chat', async ({ page }) => {
       panel = await openSidePanel(page);
       const chatList = page.locator('.jp-chat-selector-popup');


### PR DESCRIPTION
Closes #406

## Description

When typing with an Input Method Editor (IME) — Chinese Pinyin, Japanese, Korean — pressing **Enter** to confirm a candidate character was treated as a send: the message got submitted mid-composition with incomplete text. The keydown handler never looked at the composition state.

The fix checks `KeyboardEvent.isComposing` (and the legacy `keyCode === 229` marker some engines still emit) at the top of the input's `handleKeyDown` and bails out while a composition session is active, so Enter only sends a message when it's a real Enter press.

## Changes

- `packages/jupyter-chat/src/components/input/ime.ts`: small `isImeCompositionEvent()` helper with the composition check.
- `packages/jupyter-chat/src/components/input/chat-input.tsx`: `handleKeyDown` now returns early during IME composition.
- `packages/jupyter-chat/src/__tests__/ime.spec.ts`: unit tests covering active composition, the legacy keyCode marker, and plain key presses.

## How to test

- `jlpm workspace @jupyter/chat run test` (or `jest` inside `packages/jupyter-chat`)
- Manual: with a CJK input method active, type in the chat box, pick a candidate with Enter — the message should not send until composition is done.

All 8 suites / 66 tests in `@jupyter/chat` pass, and `prettier --check` + `eslint` are clean on the touched files.
