### PR TITLE
Support server-side writers without YDoc awareness

### DIFF
--- a/packages/jupyter-chat/src/__tests__/writers.spec.ts
+++ b/packages/jupyter-chat/src/__tests__/writers.spec.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+import { IChatModel } from '../model';
+import { IUser } from '../types';
+import { MockChatModel } from './mocks';
+
+const userA: IUser = { username: 'a', name: 'Alice', display_name: 'Alice' };
+const userB: IUser = { username: 'b', name: 'Bob', display_name: 'Bob' };
+
+describe('writers state', () => {
+  let model: MockChatModel;
+  let changes: IChatModel.IWriter[][];
+
+  beforeEach(() => {
+    model = new MockChatModel();
+    changes = [];
+    model.writersChanged?.connect((_, writers) => changes.push(writers));
+  });
+
+  afterEach(() => {
+    model.dispose();
+  });
+
+  it('adds and removes a writer per user', () => {
+    model.setWritingStatus(userA);
+    expect(model.writers.map(w => w.user.username)).toEqual(['a']);
+
+    model.setWritingStatus(userB);
+    expect(model.writers.map(w => w.user.username).sort()).toEqual(['a', 'b']);
+
+    model.clearWritingStatus(userA);
+    expect(model.writers.map(w => w.user.username)).toEqual(['b']);
+  });
+
+  it('carries a custom typingIndicator', () => {
+    model.setWritingStatus(userA, { typingIndicator: 'is running ripgrep' });
+    expect(model.writers[0].typingIndicator).toBe('is running ripgrep');
+  });
+
+  it('does not re-emit when the status is unchanged', () => {
+    model.setWritingStatus(userA, { typingIndicator: 'x' });
+    const count = changes.length;
+    model.setWritingStatus(userA, { typingIndicator: 'x' });
+    expect(changes.length).toBe(count);
+  });
+
+  it('auto-clears a writer after the timeout unless refreshed', () => {
+    jest.useFakeTimers();
+    try {
+      model.setWritingStatus(userA, undefined, 2000);
+      expect(model.writers).toHaveLength(1);
+
+      // Refresh before expiry keeps it alive.
+      jest.advanceTimersByTime(1500);
+      model.setWritingStatus(userA, undefined, 2000);
+      jest.advanceTimersByTime(1500);
+      expect(model.writers).toHaveLength(1);
+
+      // No refresh -> auto-cleared after the timeout (the WS anti-stuck path).
+      jest.advanceTimersByTime(2000);
+      expect(model.writers).toHaveLength(0);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('updateWriters replaces the whole list', () => {
+    model.setWritingStatus(userA);
+    model.updateWriters([{ user: userB }]);
+    expect(model.writers.map(w => w.user.username)).toEqual(['b']);
+  });
+});

--- a/packages/jupyter-chat/src/components/writing-indicator.tsx
+++ b/packages/jupyter-chat/src/components/writing-indicator.tsx
@@ -41,13 +41,29 @@ function formatWritersText(
     return '';
   }
 
-  const names = writers.map(
-    w =>
-      w.user.display_name ??
-      w.user.name ??
-      w.user.username ??
-      trans.__('Unknown')
-  );
+  const nameOf = (w: IChatModel.IWriter) =>
+    w.user.display_name ??
+    w.user.name ??
+    w.user.username ??
+    trans.__('Unknown');
+
+  // When any writer supplies a custom typing indicator, render per-writer
+  // phrases ("<name> <indicator>"), so e.g. "Jupyternaut is running `ripgrep`".
+  if (writers.some(w => w.typingIndicator)) {
+    const phrases = writers.map(
+      w => `${nameOf(w)} ${w.typingIndicator ?? trans.__('is typing...')}`
+    );
+    if (phrases.length === 1) {
+      return phrases[0];
+    } else if (phrases.length === 2) {
+      return trans.__('%1 and %2', phrases[0], phrases[1]);
+    } else {
+      const allButLast = phrases.slice(0, -1).join(', ');
+      return trans.__('%1, and %2', allButLast, phrases[phrases.length - 1]);
+    }
+  }
+
+  const names = writers.map(nameOf);
 
   if (names.length === 1) {
     return trans.__('%1 is typing...', names[0]);

--- a/packages/jupyter-chat/src/model.ts
+++ b/packages/jupyter-chat/src/model.ts
@@ -10,7 +10,6 @@ import {
   TranslationBundle
 } from '@jupyterlab/translation';
 import type { IAwareness } from '@jupyter/ydoc';
-import { ArrayExt } from '@lumino/algorithm';
 import { CommandRegistry } from '@lumino/commands';
 import { PromiseDelegate } from '@lumino/coreutils';
 import { IDisposable } from '@lumino/disposable';
@@ -218,6 +217,34 @@ export interface IChatModel extends IDisposable {
   updateWriters(writers: IChatModel.IWriter[]): void;
 
   /**
+   * Mark a user as currently writing (add or update their writer entry).
+   *
+   * @param user - the writing user.
+   * @param status - optional writing status (messageID, custom typingIndicator).
+   * @param timeout - optional auto-clear delay in ms. When set, the user is
+   *   automatically cleared after `timeout` unless refreshed by another call.
+   *   Used by transports without their own liveness signal (e.g. WebSocket) to
+   *   avoid a stuck "is typing" if a clear message is never received.
+   */
+  setWritingStatus(
+    user: IUser,
+    status?: IChatModel.IWritingStatus,
+    timeout?: number
+  ): void;
+
+  /**
+   * Remove a user from the writers list.
+   */
+  clearWritingStatus(user: IUser): void;
+
+  /**
+   * Broadcast the *current user's* writing status to other clients, or clear it
+   * with `null`. Implemented per transport (RTC sets awareness; WebSocket sends
+   * a periodic writing frame). Default implementation is a no-op.
+   */
+  broadcastWritingStatus(status: IChatModel.IWritingStatus | null): void;
+
+  /**
    * Create the chat context that will be passed to the input model.
    */
   createChatContext(): IChatContext;
@@ -345,7 +372,7 @@ export abstract class AbstractChatModel implements IChatModel {
    * The current writer list.
    */
   get writers(): IChatModel.IWriter[] {
-    return this._writers;
+    return [...this._writers.values()];
   }
 
   /**
@@ -666,17 +693,82 @@ export abstract class AbstractChatModel implements IChatModel {
    * This implementation only propagate the list via a signal.
    */
   updateWriters(writers: IChatModel.IWriter[]): void {
-    const compareWriters = (a: IChatModel.IWriter, b: IChatModel.IWriter) => {
-      return (
-        a.user.username === b.user.username &&
-        a.user.display_name === b.user.display_name &&
-        a.messageID === b.messageID
-      );
-    };
-    if (!ArrayExt.shallowEqual(this._writers, writers, compareWriters)) {
-      this._writers = writers;
-      this._writersChanged.emit(writers);
+    // Reconcile the writers map with the provided snapshot (used by
+    // snapshot-style transports such as RTC awareness). Any auto-clear timers
+    // are dropped, since the snapshot is authoritative.
+    this._clearAllWriterTimers();
+    const next = new Map<string, IChatModel.IWriter>();
+    for (const writer of writers) {
+      next.set(writer.user.username, writer);
     }
+    if (!Private.writersEqual(this._writers, next)) {
+      this._writers = next;
+      this._writersChanged.emit(this.writers);
+    }
+  }
+
+  /**
+   * Mark a user as currently writing. See IChatModel.setWritingStatus.
+   */
+  setWritingStatus(
+    user: IUser,
+    status?: IChatModel.IWritingStatus,
+    timeout?: number
+  ): void {
+    const writer: IChatModel.IWriter = {
+      user,
+      messageID: status?.messageID,
+      typingIndicator: status?.typingIndicator
+    };
+    this._clearWriterTimer(user.username);
+    if (timeout !== undefined) {
+      this._writerTimers.set(
+        user.username,
+        window.setTimeout(() => this._removeWriter(user.username), timeout)
+      );
+    }
+    const previous = this._writers.get(user.username);
+    this._writers.set(user.username, writer);
+    if (!previous || !Private.writerEqual(previous, writer)) {
+      this._writersChanged.emit(this.writers);
+    }
+  }
+
+  /**
+   * Remove a user from the writers list. See IChatModel.clearWritingStatus.
+   */
+  clearWritingStatus(user: IUser): void {
+    this._removeWriter(user.username);
+  }
+
+  /**
+   * Broadcast the current user's writing status. Default no-op; transports
+   * override this (RTC awareness, WebSocket frame).
+   */
+  broadcastWritingStatus(_status: IChatModel.IWritingStatus | null): void {
+    // no-op by default
+  }
+
+  private _removeWriter(username: string): void {
+    this._clearWriterTimer(username);
+    if (this._writers.delete(username)) {
+      this._writersChanged.emit(this.writers);
+    }
+  }
+
+  private _clearWriterTimer(username: string): void {
+    const timer = this._writerTimers.get(username);
+    if (timer !== undefined) {
+      window.clearTimeout(timer);
+      this._writerTimers.delete(username);
+    }
+  }
+
+  private _clearAllWriterTimers(): void {
+    for (const timer of this._writerTimers.values()) {
+      window.clearTimeout(timer);
+    }
+    this._writerTimers.clear();
   }
 
   /**
@@ -793,7 +885,8 @@ export abstract class AbstractChatModel implements IChatModel {
   private _selectionWatcher: ISelectionWatcher | null;
   private _documentManager: IDocumentManager | null;
   private _notificationId: string | null = null;
-  private _writers: IChatModel.IWriter[] = [];
+  private _writers = new Map<string, IChatModel.IWriter>();
+  private _writerTimers = new Map<string, number>();
   private _messageEditions = new Map<string, IInputModel>();
   private _messagesUpdated = new Signal<IChatModel, void>(this);
   private _messageChanged = new Signal<IChatModel, IMessage>(this);
@@ -877,6 +970,25 @@ export namespace IChatModel {
      * The message ID (optional)
      */
     messageID?: string;
+    /**
+     * Custom status text to display instead of the default "is typing…",
+     * e.g. "is running `ripgrep …`". Falls back to the default when unset.
+     */
+    typingIndicator?: string;
+  }
+
+  /**
+   * The writing status broadcast by (or on behalf of) a user.
+   */
+  export interface IWritingStatus {
+    /**
+     * The ID of the message being edited, if any.
+     */
+    messageID?: string;
+    /**
+     * Optional custom typing-indicator text (see IWriter.typingIndicator).
+     */
+    typingIndicator?: string;
   }
 }
 
@@ -941,4 +1053,43 @@ export abstract class AbstractChatContext implements IChatContext {
   abstract get users(): IUser[];
 
   protected _model: IChatModel;
+}
+
+/**
+ * A namespace for private functionality.
+ */
+namespace Private {
+  /**
+   * Whether two writers are equivalent for change-detection purposes.
+   */
+  export function writerEqual(
+    a: IChatModel.IWriter,
+    b: IChatModel.IWriter
+  ): boolean {
+    return (
+      a.user.username === b.user.username &&
+      a.user.display_name === b.user.display_name &&
+      a.messageID === b.messageID &&
+      a.typingIndicator === b.typingIndicator
+    );
+  }
+
+  /**
+   * Whether two writer maps are equivalent.
+   */
+  export function writersEqual(
+    a: Map<string, IChatModel.IWriter>,
+    b: Map<string, IChatModel.IWriter>
+  ): boolean {
+    if (a.size !== b.size) {
+      return false;
+    }
+    for (const [username, writer] of a) {
+      const other = b.get(username);
+      if (!other || !writerEqual(writer, other)) {
+        return false;
+      }
+    }
+    return true;
+  }
 }

--- a/packages/jupyterlab-chat/src/model.ts
+++ b/packages/jupyterlab-chat/src/model.ts
@@ -29,6 +29,15 @@ import { IChatChanges, IYmessage, YChat } from './ychat';
 const WRITING_DELAY = 1000;
 
 /**
+ * How long a server-pushed (e.g. AI persona) writing status stays visible
+ * without a refresh. The sender is expected to re-broadcast while still
+ * writing and to send an explicit stop when done; this is only a safety net so
+ * a crashed or forgetful sender cannot leave a "is writing" indicator stuck
+ * forever. An explicit stop clears it immediately, regardless of this value.
+ */
+const WS_WRITING_TIMEOUT = 3000;
+
+/**
  * Chat model namespace.
  */
 export namespace LabChatModel {
@@ -431,10 +440,14 @@ export class LabChatModel
       return;
     }
     if (writing.state) {
-      this.setWritingStatus(writing.user, {
-        messageID: writing.messageID,
-        typingIndicator: writing.typingIndicator
-      });
+      this.setWritingStatus(
+        writing.user,
+        {
+          messageID: writing.messageID,
+          typingIndicator: writing.typingIndicator
+        },
+        WS_WRITING_TIMEOUT
+      );
     } else {
       this.clearWritingStatus(writing.user);
     }

--- a/packages/jupyterlab-chat/src/model.ts
+++ b/packages/jupyterlab-chat/src/model.ts
@@ -130,6 +130,7 @@ export class LabChatModel
       });
       this._wsHandler.messageReceived.connect(this._onWsMessage, this);
       this._wsHandler.usersChanged.connect(this._onWsUsersChanged, this);
+      this._wsHandler.writingChanged.connect(this._onWsWriting, this);
     }
   }
 
@@ -261,9 +262,10 @@ export class LabChatModel
     if (!message.body && !message.mime_model && !message.attachments?.length) {
       return null;
     }
-    this._resetWritingStatus();
+    this.broadcastWritingStatus(null);
     if (this._timeoutWriting !== null) {
       window.clearTimeout(this._timeoutWriting);
+      this._timeoutWriting = null;
     }
 
     if (this._wsHandler) {
@@ -331,16 +333,22 @@ export class LabChatModel
    * @param messageID - The ID of the message being edited, if any.
    */
   onInputChanged = (value: string, messageID?: string): void => {
-    if (!value || !this.config.sendTypingNotification) {
+    if (!this.config.sendTypingNotification) {
       return;
     }
-    const awareness = this.sharedModel.awareness;
     if (this._timeoutWriting !== null) {
       window.clearTimeout(this._timeoutWriting);
+      this._timeoutWriting = null;
     }
-    awareness.setLocalStateField('isWriting', messageID ?? true);
+    // Empty input (including right after sending) means the user stopped.
+    if (!value) {
+      this.broadcastWritingStatus(null);
+      return;
+    }
+    this.broadcastWritingStatus({ messageID });
     this._timeoutWriting = window.setTimeout(() => {
-      this._resetWritingStatus();
+      this._timeoutWriting = null;
+      this.broadcastWritingStatus(null);
     }, WRITING_DELAY);
   };
 
@@ -375,7 +383,8 @@ export class LabChatModel
       if (state.isWriting !== undefined && state.isWriting !== false) {
         const writer: IChatModel.IWriter = {
           user: state.user,
-          messageID: state.isWriting === true ? undefined : state.isWriting
+          messageID: state.isWriting === true ? undefined : state.isWriting,
+          typingIndicator: state.typingIndicator ?? undefined
         };
         writers.push(writer);
       }
@@ -383,13 +392,53 @@ export class LabChatModel
     this.updateWriters(writers);
   };
 
-  private _resetWritingStatus() {
+  /**
+   * Broadcast the current user's writing status.
+   *
+   * Collaborative (RTC) mode advertises it over the awareness channel so peers
+   * see it. RTC-free (WebSocket) mode is effectively single-user, so the client
+   * does not advertise its own typing at all -- writers only ever come from the
+   * server (e.g. AI agents). Hence this is a no-op without RTC.
+   */
+  broadcastWritingStatus(status: IChatModel.IWritingStatus | null): void {
+    if (!this.collaborative) {
+      return;
+    }
     const awareness = this.sharedModel.awareness;
-    const states = awareness.getLocalState();
-    delete states?.isWriting;
-    awareness.setLocalState(states);
-    this._timeoutWriting = null;
+    if (status === null) {
+      const local = awareness.getLocalState() ?? {};
+      delete local.isWriting;
+      delete local.typingIndicator;
+      awareness.setLocalState(local);
+    } else {
+      awareness.setLocalStateField('isWriting', status.messageID ?? true);
+      awareness.setLocalStateField(
+        'typingIndicator',
+        status.typingIndicator ?? null
+      );
+    }
   }
+
+  /**
+   * Handle a writing status pushed by the server (e.g. an AI agent) over the
+   * WebSocket. The sender controls its own lifecycle via explicit start/stop.
+   */
+  private _onWsWriting = (
+    _: WebSocketHandler,
+    writing: WebSocketHandler.IWriting
+  ): void => {
+    if (writing.user.username === this.user.username) {
+      return;
+    }
+    if (writing.state) {
+      this.setWritingStatus(writing.user, {
+        messageID: writing.messageID,
+        typingIndicator: writing.typingIndicator
+      });
+    } else {
+      this.clearWritingStatus(writing.user);
+    }
+  };
 
   private _enforceAutosaveEnabled = () => {
     enforceAutosaveEnabled(this.sharedModel.awareness);

--- a/packages/jupyterlab-chat/src/websocket-handler.ts
+++ b/packages/jupyterlab-chat/src/websocket-handler.ts
@@ -23,6 +23,22 @@ export namespace WebSocketHandler {
      */
     user?: IUser;
   }
+
+  /**
+   * A writing status pushed by the server (e.g. an AI agent). In RTC-free mode
+   * clients never advertise their own typing, so writers only originate
+   * server-side.
+   */
+  export interface IWriting {
+    /** The user the status is about. */
+    user: IUser;
+    /** True if the user is writing, false if they stopped. */
+    state: boolean;
+    /** The message being edited, if any. */
+    messageID?: string;
+    /** Optional custom typing-indicator text. */
+    typingIndicator?: string;
+  }
 }
 
 /**
@@ -69,6 +85,13 @@ export class WebSocketHandler {
    */
   get usersChanged(): ISignal<this, Record<string, IUser>> {
     return this._usersChanged;
+  }
+
+  /**
+   * Emitted whenever a writing status is pushed by the server (e.g. an AI agent).
+   */
+  get writingChanged(): ISignal<this, WebSocketHandler.IWriting> {
+    return this._writingChanged;
   }
 
   /**
@@ -155,6 +178,18 @@ export class WebSocketHandler {
       this._usersChanged.emit(incoming);
     } else if (data.type === 'msg' && data.message) {
       this._messageReceived.emit(this._toMessageContent(data.message));
+    } else if (data.type === 'writing') {
+      const user: IUser = data.user ?? {
+        username: data.sender,
+        name: data.sender,
+        display_name: data.sender
+      };
+      this._writingChanged.emit({
+        user,
+        state: !!data.state,
+        messageID: data.messageID,
+        typingIndicator: data.typingIndicator
+      });
     }
   }
 
@@ -242,4 +277,5 @@ export class WebSocketHandler {
   private _ready = new PromiseDelegate<void>();
   private _messageReceived = new Signal<this, IMessageContent>(this);
   private _usersChanged = new Signal<this, Record<string, IUser>>(this);
+  private _writingChanged = new Signal<this, WebSocketHandler.IWriting>(this);
 }

--- a/python/jupyterlab-chat/jupyterlab_chat/models.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/models.py
@@ -283,3 +283,21 @@ class BaseChatModel(ABC):
     @abstractmethod
     def set_metadata(self, name: str, metadata: Any) -> None:
         ...
+
+    def broadcast_writing_status(
+        self,
+        user: Union["User", dict],
+        status: Optional[dict] = None,
+    ) -> None:
+        """Broadcast an ephemeral "user is writing" status on behalf of ``user``.
+
+        ``user`` is a :class:`User` (or a mapping with at least ``username``),
+        allowing server-side senders such as AI agents -- which each have their
+        own user identity -- to advertise a typing indicator. ``status`` is
+        ``None`` when the user stopped, or a mapping with optional ``messageID``
+        and ``typingIndicator`` keys.
+
+        The default implementation is a no-op; transports that support live
+        presence (e.g. the WebSocket model) override it.
+        """
+        # no-op by default

--- a/python/jupyterlab-chat/jupyterlab_chat/tests/test_writing.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/tests/test_writing.py
@@ -1,0 +1,73 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+"""Tests for the WebSocket writing-status relay (RTC-free typing indicator)."""
+
+import json
+
+from jupyterlab_chat.models import User
+from jupyterlab_chat.websocket_model import WsChatModel
+
+
+class _FakeHandler:
+    """Captures messages written to a connected client."""
+
+    def __init__(self):
+        self.messages = []
+
+    def write_message(self, message):
+        self.messages.append(message)
+
+
+def _model_with_client(tmp_path):
+    model = WsChatModel(path="chat.chat", root_dir=tmp_path)
+    handler = _FakeHandler()
+    model.handlers["client-1"] = handler
+    return model, handler
+
+
+def test_broadcast_writing_status_frame(tmp_path):
+    model, handler = _model_with_client(tmp_path)
+    user = User(username="bot", name="Bot", display_name="Bot-Agent")
+
+    model.broadcast_writing_status(user, {"typingIndicator": "is running ripgrep"})
+
+    assert len(handler.messages) == 1
+    frame = json.loads(handler.messages[0])
+    assert frame["type"] == "writing"
+    assert frame["state"] is True
+    assert frame["typingIndicator"] == "is running ripgrep"
+    assert frame["user"]["username"] == "bot"
+    assert frame["user"]["display_name"] == "Bot-Agent"
+
+
+def test_broadcast_writing_status_accepts_user_dict(tmp_path):
+    model, handler = _model_with_client(tmp_path)
+
+    model.broadcast_writing_status(
+        {"username": "alice", "display_name": "Alice"}, {"messageID": "m1"}
+    )
+
+    frame = json.loads(handler.messages[0])
+    assert frame["user"] == {"username": "alice", "display_name": "Alice"}
+    assert frame["state"] is True
+    assert frame["messageID"] == "m1"
+
+
+def test_broadcast_writing_status_stop(tmp_path):
+    model, handler = _model_with_client(tmp_path)
+
+    model.broadcast_writing_status({"username": "bot"}, None)
+
+    frame = json.loads(handler.messages[0])
+    assert frame["state"] is False
+    assert frame["user"]["username"] == "bot"
+    assert "typingIndicator" not in frame
+
+
+def test_writing_is_not_persisted(tmp_path):
+    model, _ = _model_with_client(tmp_path)
+
+    model.broadcast_writing_status({"username": "bot"}, {"typingIndicator": "x"})
+
+    # Ephemeral: broadcasting a writing status must not create/modify the file.
+    assert not (tmp_path / "chat.chat").exists()

--- a/python/jupyterlab-chat/jupyterlab_chat/tests/test_writing.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/tests/test_writing.py
@@ -21,7 +21,8 @@ class _FakeHandler:
 def _model_with_client(tmp_path):
     model = WsChatModel(path="chat.chat", root_dir=tmp_path)
     handler = _FakeHandler()
-    model.handlers["client-1"] = handler
+    # _FakeHandler duck-types the WebSocketHandler surface used here (write_message).
+    model.handlers["client-1"] = handler  # type: ignore[assignment]
     return model, handler
 
 

--- a/python/jupyterlab-chat/jupyterlab_chat/websocket_model.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/websocket_model.py
@@ -76,6 +76,38 @@ class WsChatModel(BaseChatModel):
             except websocket.WebSocketClosedError:
                 pass
 
+    def broadcast_writing_status(self, user, status=None) -> None:
+        """Broadcast an ephemeral writing status for ``user`` to all clients.
+
+        Not persisted to the ``.chat`` file. ``user`` may be a ``User`` or a
+        mapping (with at least ``username``); ``status`` is ``None`` (stopped) or
+        a mapping with optional ``messageID``/``typingIndicator``. The full user
+        object is included so recipients can display the writer without having
+        seen a message from them.
+        """
+        if isinstance(user, dict):
+            user_dict = user
+        else:
+            user_dict = {
+                "username": user.username,
+                "name": getattr(user, "name", None),
+                "display_name": getattr(user, "display_name", None),
+                "initials": getattr(user, "initials", None),
+                "color": getattr(user, "color", None),
+                "avatar_url": getattr(user, "avatar_url", None),
+            }
+        payload: dict = {
+            "type": "writing",
+            "user": user_dict,
+            "state": status is not None,
+        }
+        if status:
+            for key in ("messageID", "typingIndicator"):
+                value = status.get(key)
+                if value is not None:
+                    payload[key] = value
+        self.broadcast(json.dumps(payload))
+
     def resolve_message(self, message: dict) -> dict:
         """Return a copy of a message with attachment IDs replaced by full objects."""
         atts = message.get("attachments")


### PR DESCRIPTION
## Motivation

In RTC-free (WebSocket) mode there is no awareness channel, so chat cannot show an "X is typing…" indicator the way it does under real-time collaboration. This matters most for AI personas: while a persona works, it should be able to signal that it is busy, ideally with its own text (e.g. "Jupyternaut is running ripgrep…") rather than a generic "is typing".

Jupyter Chat needs a transport-agnostic way for a server-side sender to advertise a writing status, so personas behave the same with or without RTC.

## Summary

This adds a writing-status API that lets the server show a typing indicator in RTC-free chat. Because that mode is effectively single-user, the client no longer advertises its own typing; instead the server (e.g. an AI persona) pushes writers to the client, which displays them. RTC mode is unchanged and still rides awareness.

The indicator text is customizable, so a sender can show what it is doing instead of a fixed "is typing" (addresses #263, part 1).

A sender starts and stops the indicator explicitly, and a stop takes effect immediately. As a safety net, a pushed indicator also auto-clears a few seconds after its last update, so a crashed or forgetful sender cannot leave it stuck.

## Technical details

- The shared chat model keeps writers in a per-user map and exposes a `broadcastWritingStatus` hook that each transport implements: RTC sets awareness; the WebSocket backend pushes an ephemeral writing frame that is never persisted.

- The backend `broadcast_writing_status(user, status)` takes the sender's own user, so agents with their own identity can advertise on their own behalf. Passing `status=None` stops.

## Testing

Unit tests for the writers state and indicator rendering on the frontend, and for the WebSocket writing relay on the backend.