### PR TITLE
Server-side ChatManager and message observer

### DIFF
--- a/python/jupyterlab-chat/jupyterlab_chat/__init__.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/__init__.py
@@ -61,11 +61,17 @@ def _load_jupyter_server_extension(server_app):
     # decision to the frontend via PageConfig. See jupyterlab_chat.rtc_lib.
     rtc_info = publish_rtc_info(server_app)
 
+    # Create the transport-agnostic chat manager (event bus + model registry +
+    # memory management). Under RTC it forwards jupyter_collaboration room events;
+    # under WebSocket it backs the WS handler (owns ``ws_chat_models``).
+    from .events import ChatManager
+
+    chat_manager = ChatManager(server_app, rtc_enabled=rtc_info.enabled)
+    server_app.web_app.settings["chat_manager"] = chat_manager
+
     # When RTC is off, chat runs over the plain WebSocket handler. When an RTC
     # provider is active, the collaborative (YChat) backend serves chat instead.
     if not rtc_info.enabled:
-        server_app.web_app.settings["ws_chat_models"] = {}
-
         base_url = server_app.web_app.settings.get("base_url", "/")
         server_app.web_app.add_handlers(".*$", [
             (url_path_join(base_url, "api/jupyter-chat/ws"), WSChatHandler),

--- a/python/jupyterlab-chat/jupyterlab_chat/events.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/events.py
@@ -265,9 +265,26 @@ class ChatManager(LoggingConfigurable):
         self._last_active[path] = time.time()
 
     def ws_client_gone(self, path: str) -> None:
-        # Do not free immediately; the inactivity poller reclaims it after the
-        # grace period unless a client reconnects.
+        # The last client for this chat has disconnected. Free the model now
+        # unless a server-side writer (e.g. an AI persona still producing a
+        # reply) is keeping it alive, in which case the poller reclaims it once
+        # the writer stops. Freeing here -- rather than reloading from disk on the
+        # next open -- is what keeps a reopened chat consistent without having to
+        # handle out-of-band file changes.
         self._last_active[path] = time.time()
+        if not self._has_active_writers(path):
+            self._free(path, ChatEventAction.CLOSED)
+
+    def _has_active_writers(self, path: str) -> bool:
+        """Whether a server-side writer is keeping this chat alive.
+
+        A "writer" is an AI persona (or other server-side producer) that is still
+        working on a reply and would be orphaned if the model were freed. The
+        server-side writing API is not on this branch yet (see
+        jupyterlab/jupyter-chat#497); until it lands there are no server-side
+        writers, so a chat is freed as soon as its last client disconnects.
+        """
+        return False
 
     def _get_or_create_ws(self, path: str) -> "WsChatModel":
         model = self._models.get(path)
@@ -277,6 +294,10 @@ class ChatManager(LoggingConfigurable):
             self._models[path] = model
             self._last_active[path] = time.time()
             self._emit_event(ChatEvent(path=path, action=ChatEventAction.OPENED))
+        # A cached model is the live in-memory session: reuse it verbatim. We do
+        # not reload from disk (out-of-band file changes are unsupported) so that
+        # any attached server-side state, such as AI personas, is preserved when a
+        # client reconnects.
         return model  # type: ignore[return-value]
 
     # ------------------------------------------------------------------

--- a/python/jupyterlab-chat/jupyterlab_chat/events.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/events.py
@@ -1,0 +1,342 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+"""
+Transport-agnostic chat lifecycle: event bus, model access, and memory management.
+
+``ChatManager`` gives server-side consumers (e.g. jupyter-ai-router, personas) a
+single way to (1) observe chat lifecycle events, (2) retrieve a chat model by path
+(or room id under RTC), and (3) rely on chat models being freed once inactive,
+regardless of whether the backend is collaborative (``YChat``) or WebSocket-only
+(``WsChatModel``).
+
+The lifecycle event bus is delivered via Jupyter Events. Under RTC, jupyter
+collaboration's room events are forwarded/parsed into the generic schema below;
+under WebSocket, the handler notifies the manager directly.
+
+Out of scope for now (see tmp/chat-manager-design.md non-goals): message-level
+events, ``reset``/``overwrite`` (hand-edited files), and a dedicated deletion
+signal (deletion is detected by the inactivity poller checking the backing file).
+"""
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import TYPE_CHECKING, Callable, Optional
+
+from tornado.ioloop import PeriodicCallback
+from traitlets import Float
+from traitlets.config import LoggingConfigurable
+
+from .websocket_model import WsChatModel
+
+if TYPE_CHECKING:
+    from jupyter_server.serverapp import ServerApp
+
+    from .models import BaseChatModel
+
+#: Jupyter Events schema id for the generic (transport-agnostic) chat lifecycle bus.
+CHAT_ROOM_EVENT_SCHEMA_ID = "https://schema.jupyter.org/jupyterlab_chat/room/v1"
+
+#: jupyter_collaboration / JSD room event schema we forward from under RTC.
+JUPYTER_COLLABORATION_EVENTS_URI = (
+    "https://schema.jupyter.org/jupyter_collaboration/session/v1"
+)
+
+#: Inline schema (registered with the EventLogger at startup). Kept as a dict so
+#: the package does not need to ship/locate a yaml resource.
+CHAT_ROOM_EVENT_SCHEMA = {
+    "$id": CHAT_ROOM_EVENT_SCHEMA_ID,
+    "version": "1",
+    "title": "Chat room lifecycle events",
+    "personal-data": True,
+    "description": "Transport-agnostic chat room lifecycle events emitted by jupyterlab_chat.",
+    "type": "object",
+    "required": ["path", "action"],
+    "properties": {
+        "path": {
+            "type": "string",
+            "description": "Server-root-relative path of the .chat file (canonical id).",
+        },
+        "action": {
+            "enum": ["opened", "closed", "deleted"],
+            "description": "Chat room lifecycle action.",
+        },
+        "room_id": {
+            "type": "string",
+            "description": "RTC room id ({format}:{type}:{file_id}); absent in WebSocket mode.",
+        },
+    },
+    "additionalProperties": False,
+}
+
+
+class ChatEventAction(str, Enum):
+    """Lifecycle actions on the generic chat event bus."""
+
+    OPENED = "opened"
+    CLOSED = "closed"
+    DELETED = "deleted"
+
+
+@dataclass(frozen=True)
+class ChatEvent:
+    """A lifecycle event. Emitted as JSON via Jupyter Events; this is the
+    canonical shape (the registered schema mirrors it)."""
+
+    path: str
+    action: ChatEventAction
+    room_id: Optional[str] = None
+
+    def to_data(self) -> dict:
+        data: dict = {"path": self.path, "action": self.action.value}
+        if self.room_id is not None:
+            data["room_id"] = self.room_id
+        return data
+
+
+class ChatManager(LoggingConfigurable):
+    """
+    Owns the set of live chat models and emits lifecycle events for them.
+
+    Responsibilities:
+      1. Event bus  -- ``observe_chats`` / emits ``opened|closed|deleted`` via Jupyter Events.
+      2. Model access -- ``get`` (sync) / ``create`` (async get-or-create).
+      3. Memory management -- frees a model after ``inactivity_timeout_s`` with no
+         connected clients, or when its backing file is gone.
+    """
+
+    inactivity_timeout_s = Float(
+        300.0, config=True, help="Free a chat model after this many seconds with no connected clients."
+    )
+    poll_interval_s = Float(
+        60.0, config=True, help="How often to poll for inactive/deleted chats."
+    )
+
+    def __init__(self, serverapp: "ServerApp", rtc_enabled: bool = False, start_poller: bool = True, **kwargs):
+        super().__init__(**kwargs)
+        self._serverapp = serverapp
+        self._settings = serverapp.web_app.settings
+        self._event_logger = self._settings.get("event_logger")
+        self._rtc_enabled = rtc_enabled
+
+        self._models: dict[str, "BaseChatModel"] = {}
+        self._room_to_path: dict[str, str] = {}
+        self._last_active: dict[str, float] = {}
+
+        # Single source of truth for the WS handler (supersedes the ad-hoc
+        # ``ws_chat_models`` dict; kept under the same key for compatibility).
+        self._settings["ws_chat_models"] = self._models
+
+        self._register_schema()
+        if rtc_enabled:
+            self._wire_rtc_forwarding()
+
+        self._poller = PeriodicCallback(self._poll, self.poll_interval_s * 1000)
+        if start_poller:
+            self._poller.start()
+
+    @property
+    def _root_dir(self) -> Path:
+        return Path(self._settings.get("server_root_dir", ".")).expanduser().resolve()
+
+    # ------------------------------------------------------------------
+    # Responsibility 1 -- event bus
+    # ------------------------------------------------------------------
+    def _register_schema(self) -> None:
+        if self._event_logger is None:
+            self.log.warning("No event_logger in settings; chat events disabled.")
+            return
+        try:
+            self._event_logger.register_event_schema(CHAT_ROOM_EVENT_SCHEMA)
+        except Exception as e:  # pragma: no cover - defensive
+            self.log.warning("Failed to register chat room event schema: %s", e)
+
+    def observe_chats(self, callback: Callable) -> None:
+        """Subscribe to chat lifecycle events (wraps ``EventLogger.add_listener``).
+
+        ``callback`` is ``async def (logger, schema_id, data)`` where ``data``
+        matches :class:`ChatEvent`.
+        """
+        if self._event_logger is None:
+            return
+        self._event_logger.add_listener(
+            schema_id=CHAT_ROOM_EVENT_SCHEMA_ID, listener=callback
+        )
+
+    def _emit_event(self, event: ChatEvent) -> None:
+        if self._event_logger is None:
+            return
+        try:
+            self._event_logger.emit(
+                schema_id=CHAT_ROOM_EVENT_SCHEMA_ID, data=event.to_data()
+            )
+        except Exception as e:  # pragma: no cover - defensive
+            self.log.warning("Failed to emit chat event %s: %s", event, e)
+
+    # ------------------------------------------------------------------
+    # Responsibility 2 -- model access
+    # ------------------------------------------------------------------
+    def get(self, query: str) -> Optional["BaseChatModel"]:
+        """Return the live model for a path (or a room id, when RTC is available).
+
+        Synchronous: an open chat is always already cached (we cache before
+        emitting ``opened``). Returns ``None`` if the chat is not currently live.
+        """
+        path = self._resolve_path(query)
+        if path is None:
+            return None
+        return self._models.get(path)
+
+    async def create(self, path: str) -> Optional["BaseChatModel"]:
+        """Async get-or-create. Resolves+caches if already open, otherwise
+        instantiates the model (WS: ``WsChatModel`` + ``load_from_file``; RTC:
+        resolve the ``YChat``). Creating an empty chat when the file is missing
+        is expected behavior for WS.
+        """
+        model = self._models.get(path)
+        if model is not None:
+            return model
+        if self._rtc_enabled:
+            return await self._resolve_ychat_by_path(path)
+        return self._get_or_create_ws(path)
+
+    def _resolve_path(self, query: str) -> Optional[str]:
+        if query in self._models:
+            return query
+        if query in self._room_to_path:
+            return self._room_to_path[query]
+        # A room id ("{fmt}:{type}:{id}") is only meaningful under RTC, and only
+        # resolvable if we have seen its ``opened`` event. We do not depend on a
+        # fileIdManager here; an unknown room id resolves to None.
+        if _looks_like_room_id(query):
+            return None
+        return query  # treat as a path
+
+    # ------------------------------------------------------------------
+    # Responsibility 3 -- memory management
+    # ------------------------------------------------------------------
+    def _poll(self) -> None:
+        now = time.time()
+        for path in list(self._models.keys()):
+            model = self._models.get(path)
+            if model is None:
+                continue
+            # Deletion: the backing file is gone (via ContentsManager/filesystem).
+            if not (self._root_dir / path).exists():
+                self._free(path, ChatEventAction.DELETED)
+                continue
+            # Inactivity: only applies to WS models we own the memory for. A
+            # connected client keeps the chat alive.
+            if isinstance(model, WsChatModel):
+                if model.handlers:
+                    self._last_active[path] = now
+                elif now - self._last_active.get(path, now) > self.inactivity_timeout_s:
+                    self._free(path, ChatEventAction.CLOSED)
+
+    def _free(self, path: str, action: ChatEventAction) -> Optional["BaseChatModel"]:
+        model = self._models.pop(path, None)
+        self._last_active.pop(path, None)
+        room_id = None
+        for rid, p in list(self._room_to_path.items()):
+            if p == path:
+                room_id = rid
+                del self._room_to_path[rid]
+        if model is not None:
+            self._emit_event(ChatEvent(path=path, action=action, room_id=room_id))
+        return model
+
+    def stop(self) -> None:
+        if getattr(self, "_poller", None) is not None:
+            self._poller.stop()
+
+    # ------------------------------------------------------------------
+    # WebSocket transport hooks (called by WSChatHandler)
+    # ------------------------------------------------------------------
+    def ws_open(self, path: str) -> "WsChatModel":
+        """First/any client connecting to ``path``: get-or-create the model and
+        (on first creation) emit ``opened``."""
+        model = self._get_or_create_ws(path)
+        self._last_active[path] = time.time()
+        return model
+
+    def ws_activity(self, path: str) -> None:
+        self._last_active[path] = time.time()
+
+    def ws_client_gone(self, path: str) -> None:
+        # Do not free immediately; the inactivity poller reclaims it after the
+        # grace period unless a client reconnects.
+        self._last_active[path] = time.time()
+
+    def _get_or_create_ws(self, path: str) -> "WsChatModel":
+        model = self._models.get(path)
+        if model is None:
+            model = WsChatModel(path=path, root_dir=self._root_dir)
+            model.load_from_file()
+            self._models[path] = model
+            self._last_active[path] = time.time()
+            self._emit_event(ChatEvent(path=path, action=ChatEventAction.OPENED))
+        return model  # type: ignore[return-value]
+
+    # ------------------------------------------------------------------
+    # RTC forwarding (best-effort; not exercised without jupyter_collaboration)
+    # ------------------------------------------------------------------
+    def _wire_rtc_forwarding(self) -> None:
+        if self._event_logger is None:
+            return
+        try:
+            self._event_logger.add_listener(
+                schema_id=JUPYTER_COLLABORATION_EVENTS_URI,
+                listener=self._on_rtc_room_event,
+            )
+        except Exception as e:  # pragma: no cover - depends on RTC install
+            self.log.warning("Could not attach RTC room-event forwarder: %s", e)
+
+    async def _on_rtc_room_event(self, logger, schema_id: str, data: dict) -> None:
+        room = data.get("room", "") or ""
+        path = data.get("path")
+        action = data.get("action")
+        parts = room.split(":")
+        # Chat rooms only: {file_format}:{file_type}:{file_id} with file_type == "chat".
+        if len(parts) < 2 or parts[1] != "chat" or not path:
+            return
+        if action == "initialize":
+            self._room_to_path[room] = path
+            self._last_active[path] = time.time()
+            model = await self._resolve_ychat(room)
+            if model is not None:
+                self._models[path] = model
+            self._emit_event(
+                ChatEvent(path=path, action=ChatEventAction.OPENED, room_id=room)
+            )
+        elif action == "clean":
+            self._free(path, ChatEventAction.CLOSED)
+
+    async def _resolve_ychat(self, room_id: str):
+        """Resolve the ``YChat`` for a room via jupyter_collaboration. Mirrors
+        jupyter-ai-router's approach; guarded because the APIs only exist when an
+        RTC provider is installed."""
+        try:
+            collaboration = self._settings["jupyter_server_ydoc"]
+            return await collaboration.get_document(room_id=room_id, copy=False)
+        except Exception as e:  # pragma: no cover - depends on RTC install
+            self.log.warning("Could not resolve YChat for room %s: %s", room_id, e)
+            return None
+
+    async def _resolve_ychat_by_path(self, path: str):
+        room_id = next(
+            (rid for rid, p in self._room_to_path.items() if p == path), None
+        )
+        if room_id is None:
+            return None
+        model = await self._resolve_ychat(room_id)
+        if model is not None:
+            self._models[path] = model
+        return model
+
+
+def _looks_like_room_id(query: str) -> bool:
+    """Heuristic: RTC room ids have the form ``{file_format}:{file_type}:{file_id}``.
+    A ``.chat`` path never contains ':' on the platforms we support."""
+    return query.count(":") >= 2

--- a/python/jupyterlab-chat/jupyterlab_chat/models.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/models.py
@@ -3,6 +3,7 @@
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
+from enum import Enum
 from typing import Any, Callable, Literal, Optional, Tuple, Union
 from jupyter_server.auth import User as JupyterUser
 
@@ -222,6 +223,49 @@ class NotebookAttachment:
     """
 
 
+class ChatMessageAction(str, Enum):
+    """The kind of message change surfaced to ``observe_messages`` callbacks."""
+
+    CLIENT_MSG_RECEIVED = "client_msg_received"
+    """A new message was received from a client (human user)."""
+
+    CLIENT_MSG_EDITED = "client_msg_edited"
+    """An existing message was edited by a client (human user)."""
+
+    SERVER_MSG_SENT = "server_msg_sent"
+    """A new message was sent from the server (e.g. an AI persona)."""
+
+    SERVER_MSG_UPDATED = "server_msg_updated"
+    """An existing server message was updated (e.g. a streaming response)."""
+
+
+@dataclass
+class ChatMessageEvent:
+    """A single message change delivered to ``observe_messages`` callbacks."""
+
+    action: ChatMessageAction
+    """What happened to the message."""
+
+    message: Message
+    """The affected message (its current state)."""
+
+
+MessageObserverCallback = Callable[["ChatMessageEvent"], None]
+""" A callback invoked with a :class:`ChatMessageEvent` for each message change. """
+
+
+@dataclass
+class MessageObserver:
+    """Opaque handle returned by :meth:`BaseChatModel.observe_messages`.
+
+    The consumer MUST pass it back to :meth:`BaseChatModel.unobserve_messages`
+    when it no longer wants updates; otherwise the underlying subscription (and
+    the callback it references) leaks for the lifetime of the model.
+    """
+
+    _handle: Any = field(repr=False, compare=False)
+
+
 class BaseChatModel(ABC):
     """
     Common interface implemented by both YChat (collaborative) and WsChatRoom
@@ -282,4 +326,23 @@ class BaseChatModel(ABC):
 
     @abstractmethod
     def set_metadata(self, name: str, metadata: Any) -> None:
+        ...
+
+    @abstractmethod
+    def observe_messages(
+        self, callback: MessageObserverCallback
+    ) -> MessageObserver:
+        """Register ``callback`` to be invoked with a :class:`ChatMessageEvent`
+        for each message change.
+
+        Returns a :class:`MessageObserver` handle; pass it to
+        :meth:`unobserve_messages` to stop receiving updates and release the
+        underlying subscription.
+        """
+        ...
+
+    @abstractmethod
+    def unobserve_messages(self, observer: MessageObserver) -> None:
+        """Stop a message observer previously registered via
+        :meth:`observe_messages`."""
         ...

--- a/python/jupyterlab-chat/jupyterlab_chat/tests/test_events.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/tests/test_events.py
@@ -1,0 +1,132 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+"""Unit tests for jupyterlab_chat.events.ChatManager (WebSocket path)."""
+import asyncio
+import time
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, cast
+
+from jupyter_events import EventLogger
+
+from jupyterlab_chat.events import ChatManager
+from jupyterlab_chat.websocket_model import WsChatModel
+
+if TYPE_CHECKING:
+    from jupyter_server.serverapp import ServerApp
+
+
+def _make_manager(tmp_path, capture):
+    logger = EventLogger()
+    settings = {"event_logger": logger, "server_root_dir": str(tmp_path)}
+    serverapp = cast(
+        "ServerApp", SimpleNamespace(web_app=SimpleNamespace(settings=settings))
+    )
+    mgr = ChatManager(serverapp, rtc_enabled=False, start_poller=False)
+
+    async def listener(logger, schema_id, data):
+        capture.append(data)
+
+    mgr.observe_chats(listener)
+    return mgr
+
+
+async def _drain():
+    # Let jupyter_events dispatch queued listener coroutines.
+    await asyncio.sleep(0.1)
+
+
+def test_ws_open_emits_opened_once_and_get(tmp_path):
+    async def run():
+        capture: list = []
+        mgr = _make_manager(tmp_path, capture)
+        (tmp_path / "a.chat").write_text("{}")
+
+        model = mgr.ws_open("a.chat")
+        assert isinstance(model, WsChatModel)
+        await _drain()
+        assert {"path": "a.chat", "action": "opened"} in capture
+
+        # model access
+        assert mgr.get("a.chat") is model
+        assert mgr.get("missing.chat") is None
+        assert mgr.get("text:chat:xyz") is None  # room id resolves to None w/o RTC
+
+        # second connection to same path: no duplicate `opened`
+        capture.clear()
+        mgr.ws_open("a.chat")
+        await _drain()
+        assert capture == []
+
+        mgr.stop()
+
+    asyncio.run(run())
+
+
+def test_create_get_or_create(tmp_path):
+    async def run():
+        mgr = _make_manager(tmp_path, [])
+        (tmp_path / "b.chat").write_text("{}")
+        m = await mgr.create("b.chat")
+        assert isinstance(m, WsChatModel)
+        assert await mgr.create("b.chat") is m  # get-or-create returns same
+        # create on a missing file is allowed (get-or-create)
+        m2 = await mgr.create("new.chat")
+        assert isinstance(m2, WsChatModel)
+        mgr.stop()
+
+    asyncio.run(run())
+
+
+def test_inactivity_frees_model(tmp_path):
+    async def run():
+        capture: list = []
+        mgr = _make_manager(tmp_path, capture)
+        (tmp_path / "c.chat").write_text("{}")
+        model = mgr.ws_open("c.chat")
+        assert not model.handlers  # no connected clients
+
+        mgr._last_active["c.chat"] = time.time() - 10_000  # stale
+        capture.clear()
+        mgr._poll()
+        await _drain()
+
+        assert mgr.get("c.chat") is None  # garbage-collected
+        assert {"path": "c.chat", "action": "closed"} in capture
+        mgr.stop()
+
+    asyncio.run(run())
+
+
+def test_connected_client_keeps_model_alive(tmp_path):
+    async def run():
+        mgr = _make_manager(tmp_path, [])
+        (tmp_path / "d.chat").write_text("{}")
+        model = mgr.ws_open("d.chat")
+        model.handlers["client-1"] = object()  # simulate a connected client
+        mgr._last_active["d.chat"] = time.time() - 10_000
+
+        mgr._poll()
+        assert mgr.get("d.chat") is model  # kept because a client is connected
+        mgr.stop()
+
+    asyncio.run(run())
+
+
+def test_deletion_frees_model(tmp_path):
+    async def run():
+        capture: list = []
+        mgr = _make_manager(tmp_path, capture)
+        chat = tmp_path / "e.chat"
+        chat.write_text("{}")
+        mgr.ws_open("e.chat")
+
+        chat.unlink()  # deleted via filesystem/ContentsManager
+        capture.clear()
+        mgr._poll()
+        await _drain()
+
+        assert mgr.get("e.chat") is None
+        assert {"path": "e.chat", "action": "deleted"} in capture
+        mgr.stop()
+
+    asyncio.run(run())

--- a/python/jupyterlab-chat/jupyterlab_chat/tests/test_events.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/tests/test_events.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, cast
 from jupyter_events import EventLogger
 
 from jupyterlab_chat.events import ChatManager
+from jupyterlab_chat.models import NewMessage
 from jupyterlab_chat.websocket_model import WsChatModel
 
 if TYPE_CHECKING:
@@ -127,6 +128,59 @@ def test_deletion_frees_model(tmp_path):
 
         assert mgr.get("e.chat") is None
         assert {"path": "e.chat", "action": "deleted"} in capture
+        mgr.stop()
+
+    asyncio.run(run())
+
+
+def test_last_client_gone_frees_model(tmp_path):
+    """When the last client disconnects and no server-side writer is active, the
+    model is freed, so the next open builds a fresh model instead of reusing a
+    stale in-memory instance that would accumulate messages across reopens."""
+
+    async def run():
+        capture: list = []
+        mgr = _make_manager(tmp_path, capture)
+        chat = tmp_path / "r.chat"
+        chat.write_text("{}")
+
+        m1 = mgr.ws_open("r.chat")
+        m1.handlers["client-1"] = SimpleNamespace(write_message=lambda *a, **k: None)
+        m1.add_message(NewMessage(body="first message", sender="u"))
+
+        # Last client disconnects with no active writer -> model is freed.
+        m1.handlers.clear()
+        capture.clear()
+        mgr.ws_client_gone("r.chat")
+        await _drain()
+        assert mgr.get("r.chat") is None
+        assert {"path": "r.chat", "action": "closed"} in capture
+
+        # Reopening builds a fresh model, not the stale in-memory instance.
+        m2 = mgr.ws_open("r.chat")
+        assert m2 is not m1
+        mgr.stop()
+
+    asyncio.run(run())
+
+
+def test_reopen_while_live_reuses_in_memory_model(tmp_path):
+    """A reopen while the chat is still live (a client is connected) reuses the
+    same in-memory model without reloading, so attached server-side state is
+    preserved on reconnect."""
+
+    async def run():
+        mgr = _make_manager(tmp_path, [])
+        (tmp_path / "r.chat").write_text("{}")
+
+        m1 = mgr.ws_open("r.chat")
+        m1.handlers["client-1"] = SimpleNamespace(write_message=lambda *a, **k: None)
+        m1.add_message(NewMessage(body="first message", sender="u"))
+
+        # A second client connects while the first is still present.
+        m2 = mgr.ws_open("r.chat")
+        assert m2 is m1  # same live model
+        assert len(m2._messages) == 1  # nothing reloaded or reset
         mgr.stop()
 
     asyncio.run(run())

--- a/python/jupyterlab-chat/jupyterlab_chat/tests/test_message_observer.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/tests/test_message_observer.py
@@ -1,0 +1,152 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+"""Unit tests for the transport-agnostic message observer API.
+
+Covers ``observe_messages``/``unobserve_messages`` on both the WebSocket model
+(RTC-free) and the collaborative ``YChat``.
+"""
+from pathlib import Path
+from typing import List
+
+import pytest
+from pycrdt import Map
+
+from jupyterlab_chat.models import (
+    ChatMessageAction,
+    ChatMessageEvent,
+    NewMessage,
+    User,
+)
+from jupyterlab_chat.websocket_model import WsChatModel
+from jupyterlab_chat.ychat import YChat
+
+
+def _ws_model(tmp_path: Path) -> WsChatModel:
+    (tmp_path / "chat.chat").write_text("{}")
+    model = WsChatModel(path="chat.chat", root_dir=tmp_path)
+    model.load_from_file()
+    return model
+
+
+# --------------------------------------------------------------------------
+# WebSocket model (RTC-free)
+# --------------------------------------------------------------------------
+def test_ws_server_msg_sent_and_unobserve(tmp_path: Path) -> None:
+    model = _ws_model(tmp_path)
+    events: List[ChatMessageEvent] = []
+    token = model.observe_messages(events.append)
+
+    model.add_message(NewMessage(body="hi", sender="agent"))
+    assert len(events) == 1
+    assert events[0].action == ChatMessageAction.SERVER_MSG_SENT
+    assert events[0].message.body == "hi"
+
+    # After unobserve, no further events are delivered.
+    model.unobserve_messages(token)
+    model.add_message(NewMessage(body="again", sender="agent"))
+    assert len(events) == 1
+
+
+def test_ws_server_msg_updated(tmp_path: Path) -> None:
+    model = _ws_model(tmp_path)
+    msg_id = model.add_message(NewMessage(body="v1", sender="agent"))
+
+    events: List[ChatMessageEvent] = []
+    model.observe_messages(events.append)
+
+    updated = model.get_message(msg_id)
+    assert updated is not None
+    updated.body = "v2"
+    model.update_message(updated)
+
+    assert [e.action for e in events] == [ChatMessageAction.SERVER_MSG_UPDATED]
+    assert events[0].message.body == "v2"
+
+
+def test_ws_client_events(tmp_path: Path) -> None:
+    # CLIENT_* events are emitted by the WS handler; exercise the model's
+    # emission path directly here.
+    model = _ws_model(tmp_path)
+    msg_id = model.add_message(NewMessage(body="hi", sender="jovyan"))
+    message = model.get_message(msg_id)
+    assert message is not None
+
+    events: List[ChatMessageEvent] = []
+    model.observe_messages(events.append)
+    model._emit_message_event(ChatMessageAction.CLIENT_MSG_RECEIVED, message)
+    model._emit_message_event(ChatMessageAction.CLIENT_MSG_EDITED, message)
+
+    assert [e.action for e in events] == [
+        ChatMessageAction.CLIENT_MSG_RECEIVED,
+        ChatMessageAction.CLIENT_MSG_EDITED,
+    ]
+
+
+def test_ws_multiple_observers(tmp_path: Path) -> None:
+    model = _ws_model(tmp_path)
+    a: List[ChatMessageEvent] = []
+    b: List[ChatMessageEvent] = []
+    token_a = model.observe_messages(a.append)
+    model.observe_messages(b.append)
+
+    model.add_message(NewMessage(body="1", sender="agent"))
+    assert len(a) == 1 and len(b) == 1
+
+    model.unobserve_messages(token_a)
+    model.add_message(NewMessage(body="2", sender="agent"))
+    assert len(a) == 1 and len(b) == 2
+
+
+def test_ws_observer_error_is_isolated(tmp_path: Path) -> None:
+    model = _ws_model(tmp_path)
+    good: List[ChatMessageEvent] = []
+
+    def boom(event: ChatMessageEvent) -> None:
+        raise RuntimeError("observer blew up")
+
+    model.observe_messages(boom)
+    model.observe_messages(good.append)
+    # A failing observer must not prevent others from being notified.
+    model.add_message(NewMessage(body="hi", sender="agent"))
+    assert len(good) == 1
+
+
+# --------------------------------------------------------------------------
+# Collaborative model (YChat)
+# --------------------------------------------------------------------------
+def _insert_ymessage(chat: YChat, message: dict) -> None:
+    # raw_time=False avoids the server-timestamp reschedule (which uses an
+    # asyncio task) so the test stays synchronous.
+    message.setdefault("raw_time", False)
+    with chat._ydoc.transaction():
+        chat._ymessages.append(Map(message))
+
+
+def test_ychat_insert_classification_and_unobserve() -> None:
+    chat = YChat()
+    # Give the document an id first so flipping `dirty` does not schedule
+    # `create_id()` (which needs a running event loop).
+    chat.set_id("test-chat")
+    chat.dirty = False  # simulate a fully-loaded document
+    chat.set_user(User(username="human", name="H", display_name="H"))
+    chat.set_user(User(username="bot", name="B", display_name="B", bot=True))
+
+    events: List[ChatMessageEvent] = []
+    token = chat.observe_messages(events.append)
+
+    _insert_ymessage(
+        chat, {"id": "m1", "body": "from human", "time": 1.0, "sender": "human"}
+    )
+    _insert_ymessage(
+        chat, {"id": "m2", "body": "from bot", "time": 2.0, "sender": "bot"}
+    )
+
+    by_body = {e.message.body: e.action for e in events}
+    assert by_body["from human"] == ChatMessageAction.CLIENT_MSG_RECEIVED
+    assert by_body["from bot"] == ChatMessageAction.SERVER_MSG_SENT
+
+    chat.unobserve_messages(token)
+    _insert_ymessage(
+        chat, {"id": "m3", "body": "after", "time": 3.0, "sender": "human"}
+    )
+    assert "after" not in [e.message.body for e in events]

--- a/python/jupyterlab-chat/jupyterlab_chat/websocket_handler.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/websocket_handler.py
@@ -10,7 +10,7 @@ from typing import Dict
 from jupyter_server.base.handlers import JupyterHandler
 from tornado import web, websocket
 
-from .models import User
+from .models import ChatMessageAction, User
 from .websocket_model import WsChatModel
 
 
@@ -45,7 +45,9 @@ class WSChatHandler(JupyterHandler, websocket.WebSocketHandler):
 
     async def get(self, *args, **kwargs):
         self.pre_get()
-        await super().get(*args, **kwargs)
+        result = super().get(*args, **kwargs)
+        if result is not None:
+            await result
 
     def _parse_client_user(self):
         """Parse the optional client-provided identity from the connect query.
@@ -187,6 +189,11 @@ class WSChatHandler(JupyterHandler, websocket.WebSocketHandler):
         model.broadcast(
             json.dumps({"type": "msg", "message": model.resolve_message(message)})
         )
+        received = model.get_message(message["id"])
+        if received is not None:
+            model._emit_message_event(
+                ChatMessageAction.CLIENT_MSG_RECEIVED, received
+            )
 
     def _handle_update_message(self, data: dict, model: WsChatModel) -> None:
         msg_id = data.get("id")
@@ -205,6 +212,11 @@ class WSChatHandler(JupyterHandler, websocket.WebSocketHandler):
         model.broadcast(
             json.dumps({"type": "msg", "message": model.resolve_message(msg)})
         )
+        edited = model.get_message(msg_id)
+        if edited is not None:
+            model._emit_message_event(
+                ChatMessageAction.CLIENT_MSG_EDITED, edited
+            )
 
     def _store_attachments(self, attachments: list[dict], model: WsChatModel) -> list[str]:
         """Store attachment dicts via the model's set_attachment, return their IDs."""

--- a/python/jupyterlab-chat/jupyterlab_chat/websocket_handler.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/websocket_handler.py
@@ -28,6 +28,10 @@ class WSChatHandler(JupyterHandler, websocket.WebSocketHandler):
         return self.settings["ws_chat_models"]
 
     @property
+    def _chat_manager(self):
+        return self.settings["chat_manager"]
+
+    @property
     def _root_dir(self) -> Path:
         return Path(self.settings.get("server_root_dir", ".")).expanduser().resolve()
 
@@ -79,12 +83,9 @@ class WSChatHandler(JupyterHandler, websocket.WebSocketHandler):
         self._path = path
         self._client_id = uuid.uuid4().hex
 
-        if path not in self._chat_models:
-            model = WsChatModel(path=path, root_dir=self._root_dir)
-            model.load_from_file()
-            self._chat_models[path] = model
-
-        model = self._chat_models[path]
+        # The manager owns get-or-create and emits the `opened` lifecycle event
+        # (once, when the model is first created).
+        model = self._chat_manager.ws_open(path)
         model.handlers[self._client_id] = self
 
         # Register the connecting user. Prefer the client-provided identity
@@ -136,6 +137,7 @@ class WSChatHandler(JupyterHandler, websocket.WebSocketHandler):
         model = self._chat_models.get(path)
         if model is None:
             return
+        self._chat_manager.ws_activity(path)
 
         if data.get("is_update"):
             self._handle_update_message(data, model)
@@ -230,5 +232,7 @@ class WSChatHandler(JupyterHandler, websocket.WebSocketHandler):
         if model and client_id:
             model.handlers.pop(client_id, None)
             if not model.handlers:
-                del self._chat_models[path]
+                # Don't free immediately: the manager reclaims the model after a
+                # grace period of inactivity unless a client reconnects.
+                self._chat_manager.ws_client_gone(path)
         self.log.info("WS chat client %s disconnected", client_id)

--- a/python/jupyterlab-chat/jupyterlab_chat/websocket_model.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/websocket_model.py
@@ -2,23 +2,30 @@
 # Distributed under the terms of the Modified BSD License.
 
 import json
+import logging
 import time
 import uuid
 from dataclasses import asdict
 from pathlib import Path
-from typing import Any, Callable, Dict, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Union
 
 from tornado import websocket
 
 from .models import (
     BaseChatModel,
+    ChatMessageAction,
+    ChatMessageEvent,
     FileAttachment,
     Message,
+    MessageObserver,
+    MessageObserverCallback,
     NewMessage,
     NotebookAttachment,
     User,
     message_asdict_factory,
 )
+
+_log = logging.getLogger(__name__)
 
 
 class WsChatModel(BaseChatModel):
@@ -38,6 +45,7 @@ class WsChatModel(BaseChatModel):
         self._users: Dict[str, dict] = {}
         self._attachments: Dict[str, dict] = {}
         self._metadata: Dict[str, object] = {}
+        self._message_observers: List[MessageObserverCallback] = []
 
     # ------------------------------------------------------------------
     # Room-level helpers
@@ -147,6 +155,7 @@ class WsChatModel(BaseChatModel):
         self.broadcast(
             json.dumps({"type": "msg", "message": self.resolve_message(msg_dict)})
         )
+        self._emit_message_event(ChatMessageAction.SERVER_MSG_SENT, message)
         return msg_id
 
     def update_message(
@@ -172,6 +181,11 @@ class WsChatModel(BaseChatModel):
         self.broadcast(
             json.dumps({"type": "msg", "message": self.resolve_message(msg_dict)})
         )
+        updated = self.get_message(update.id)
+        if updated is not None:
+            self._emit_message_event(
+                ChatMessageAction.SERVER_MSG_UPDATED, updated
+            )
 
     def set_attachment(
         self, attachment: Union[FileAttachment, NotebookAttachment]
@@ -194,3 +208,33 @@ class WsChatModel(BaseChatModel):
 
     def set_metadata(self, name: str, metadata: Any) -> None:
         self._metadata[name] = metadata
+
+    # ------------------------------------------------------------------
+    # Message observers
+    # ------------------------------------------------------------------
+
+    def observe_messages(
+        self, callback: MessageObserverCallback
+    ) -> MessageObserver:
+        self._message_observers.append(callback)
+        return MessageObserver(_handle=callback)
+
+    def unobserve_messages(self, observer: MessageObserver) -> None:
+        try:
+            self._message_observers.remove(observer._handle)
+        except ValueError:
+            pass
+
+    def _emit_message_event(
+        self, action: ChatMessageAction, message: Message
+    ) -> None:
+        """Notify all message observers of a change. Observer errors are logged
+        but never interrupt message handling."""
+        if not self._message_observers:
+            return
+        event = ChatMessageEvent(action=action, message=message)
+        for callback in list(self._message_observers):
+            try:
+                callback(event)
+            except Exception:  # pragma: no cover - defensive
+                _log.exception("Message observer failed for %s", action)

--- a/python/jupyterlab-chat/jupyterlab_chat/ychat.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/ychat.py
@@ -13,7 +13,19 @@ from typing import Any, Callable, Optional, Set, Union
 from uuid import uuid4
 from pycrdt import Array, ArrayEvent, Map, MapEvent, Subscription
 
-from .models import BaseChatModel, message_asdict_factory, FileAttachment, NotebookAttachment, Message, NewMessage, User
+from .models import (
+    BaseChatModel,
+    ChatMessageAction,
+    ChatMessageEvent,
+    FileAttachment,
+    Message,
+    MessageObserver,
+    MessageObserverCallback,
+    NewMessage,
+    NotebookAttachment,
+    User,
+    message_asdict_factory,
+)
 from .utils import find_mentions
 
 
@@ -240,6 +252,51 @@ class YChat(YBaseDoc, BaseChatModel):
         """
         with self._ydoc.transaction():
             self._ymetadata.update({name: metadata})
+
+    def observe_messages(
+        self, callback: MessageObserverCallback
+    ) -> MessageObserver:
+        """Observe new messages by subscribing to the shared messages array.
+
+        Only genuine new messages (array inserts) are surfaced; in-place content
+        edits mutate a nested map and do not raise an array event, so
+        ``CLIENT_MSG_EDITED``/``SERVER_MSG_UPDATED`` are not emitted in RTC mode.
+        New messages are classified as server-sent when their sender is a bot
+        user, and client-received otherwise.
+        """
+        subscription: Subscription = self._ymessages.observe(
+            partial(self._dispatch_message_event, callback)
+        )
+        return MessageObserver(_handle=subscription)
+
+    def unobserve_messages(self, observer: MessageObserver) -> None:
+        subscription = observer._handle
+        if subscription is not None:
+            self._ymessages.unobserve(subscription)
+
+    def _dispatch_message_event(
+        self, callback: MessageObserverCallback, event: ArrayEvent
+    ) -> None:
+        # Skip while the document is still loading its pre-existing messages,
+        # and skip events that contain a delete (a message reposition performed
+        # by `_set_timestamp` is a delete+insert of an existing message, not a
+        # new one).
+        if self.dirty:
+            return
+        if any("delete" in value.keys() for value in event.delta):  # type:ignore[attr-defined]
+            return
+        for value in event.delta:  # type:ignore[attr-defined]
+            if "insert" not in value.keys():
+                continue
+            for item in value["insert"]:
+                message = Message(**item.to_py())
+                sender = self.get_user(message.sender)
+                action = (
+                    ChatMessageAction.SERVER_MSG_SENT
+                    if sender is not None and sender.bot
+                    else ChatMessageAction.CLIENT_MSG_RECEIVED
+                )
+                callback(ChatMessageEvent(action=action, message=message))
 
     async def create_id(self) -> str:
         """


### PR DESCRIPTION
## Motivation

Jupyter AI is a key dependent of Jupyter Chat. To power the AI experience it offers,  it needs to know two things about chats from the server: when chats open, close, or are deleted, and when to react to new messages. Both are currently wired to real-time collaboration internals.

- Chat creations are determined from events emitted from Jupyter Collaboration / JSD.

- Chat messages are observed from `ychat.ymessages` directly.

These are implemented in the `jupyter-ai-router` subpackage. To provide a RTC-optional experience, there needs to be generic ways to subscribe to both of these events without requiring RTC.

## Summary

This adds the server-side API the router needs, working the same way with or without RTC.

A `ChatManager` tracks the open chats in a generic registry keyed by path, emits lifecycle events (opened, closed, deleted), and hands out the chat model regardless of transport.

`observe_messages` on the shared chat model lets a consumer follow a chat's messages — received or edited by a client, sent or updated by the server — without reaching into the CRDT.

Together these let the router subscribe to chats and their messages transport-agnostically.

## Technical details

- The ChatManager registers on the web app settings (aliasing the existing `ws_chat_models` key), forwards jupyter-collaboration session events when RTC is present, and reclaims idle WebSocket models with a poller.

- The message observer wraps the shared array observer in RTC mode and emits directly from the WebSocket paths otherwise. In-place edits don't raise an array event in RTC, so only new-message events are surfaced there for now.

- This is the jupyter-chat side; the matching consumer changes live in jupyter-ai-router and are a follow-up.

## Testing

Unit tests for the ChatManager lifecycle and registry, and for the message observer on both transports.