### PR TITLE
Allow bot users to send empty messages in the frontend

### DIFF
--- a/packages/jupyterlab-chat/src/model.ts
+++ b/packages/jupyterlab-chat/src/model.ts
@@ -234,7 +234,13 @@ export class LabChatModel
   }
 
   sendMessage(message: INewMessage): string | null {
-    if (!message.body && !message.mime_model && !message.attachments?.length) {
+    // Allow empty message for bot only, as it may be streamed later.
+    if (
+      !message.body &&
+      !message.mime_model &&
+      !message.attachments?.length &&
+      !message.sender?.bot
+    ) {
       return null;
     }
     this._resetWritingStatus();


### PR DESCRIPTION
This PR allows bot users in the frontend to send empty messages.

Frontend bots, start streaming by sending an empty message, and then updates it with chunk, like back end bots.
This was not possible before this PR, because empty messages are not allowed in the frontend, to prevent regular users to send empty messages (and pollute the UI).