### PR TITLE
Add a transport-agnostic message observer API to the chat models

### DIFF
--- a/python/jupyterlab-chat/jupyterlab_chat/models.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/models.py
@@ -3,6 +3,7 @@
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
+from enum import Enum
 from typing import Any, Callable, Literal, Optional, Tuple, Union
 from jupyter_server.auth import User as JupyterUser
 
@@ -222,6 +223,49 @@ class NotebookAttachment:
     """
 
 
+class ChatMessageAction(str, Enum):
+    """The kind of message change surfaced to ``observe_messages`` callbacks."""
+
+    CLIENT_MSG_RECEIVED = "client_msg_received"
+    """A new message was received from a client (human user)."""
+
+    CLIENT_MSG_EDITED = "client_msg_edited"
+    """An existing message was edited by a client (human user)."""
+
+    SERVER_MSG_SENT = "server_msg_sent"
+    """A new message was sent from the server (e.g. an AI persona)."""
+
+    SERVER_MSG_UPDATED = "server_msg_updated"
+    """An existing server message was updated (e.g. a streaming response)."""
+
+
+@dataclass
+class ChatMessageEvent:
+    """A single message change delivered to ``observe_messages`` callbacks."""
+
+    action: ChatMessageAction
+    """What happened to the message."""
+
+    message: Message
+    """The affected message (its current state)."""
+
+
+MessageObserverCallback = Callable[["ChatMessageEvent"], None]
+""" A callback invoked with a :class:`ChatMessageEvent` for each message change. """
+
+
+@dataclass
+class MessageObserver:
+    """Opaque handle returned by :meth:`BaseChatModel.observe_messages`.
+
+    The consumer MUST pass it back to :meth:`BaseChatModel.unobserve_messages`
+    when it no longer wants updates; otherwise the underlying subscription (and
+    the callback it references) leaks for the lifetime of the model.
+    """
+
+    _handle: Any = field(repr=False, compare=False)
+
+
 class BaseChatModel(ABC):
     """
     Common interface implemented by both YChat (collaborative) and WsChatRoom
@@ -282,4 +326,23 @@ class BaseChatModel(ABC):
 
     @abstractmethod
     def set_metadata(self, name: str, metadata: Any) -> None:
+        ...
+
+    @abstractmethod
+    def observe_messages(
+        self, callback: MessageObserverCallback
+    ) -> MessageObserver:
+        """Register ``callback`` to be invoked with a :class:`ChatMessageEvent`
+        for each message change.
+
+        Returns a :class:`MessageObserver` handle; pass it to
+        :meth:`unobserve_messages` to stop receiving updates and release the
+        underlying subscription.
+        """
+        ...
+
+    @abstractmethod
+    def unobserve_messages(self, observer: MessageObserver) -> None:
+        """Stop a message observer previously registered via
+        :meth:`observe_messages`."""
         ...

--- a/python/jupyterlab-chat/jupyterlab_chat/tests/test_message_observer.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/tests/test_message_observer.py
@@ -1,0 +1,152 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+"""Unit tests for the transport-agnostic message observer API.
+
+Covers ``observe_messages``/``unobserve_messages`` on both the WebSocket model
+(RTC-free) and the collaborative ``YChat``.
+"""
+from pathlib import Path
+from typing import List
+
+import pytest
+from pycrdt import Map
+
+from jupyterlab_chat.models import (
+    ChatMessageAction,
+    ChatMessageEvent,
+    NewMessage,
+    User,
+)
+from jupyterlab_chat.websocket_model import WsChatModel
+from jupyterlab_chat.ychat import YChat
+
+
+def _ws_model(tmp_path: Path) -> WsChatModel:
+    (tmp_path / "chat.chat").write_text("{}")
+    model = WsChatModel(path="chat.chat", root_dir=tmp_path)
+    model.load_from_file()
+    return model
+
+
+# --------------------------------------------------------------------------
+# WebSocket model (RTC-free)
+# --------------------------------------------------------------------------
+def test_ws_server_msg_sent_and_unobserve(tmp_path: Path) -> None:
+    model = _ws_model(tmp_path)
+    events: List[ChatMessageEvent] = []
+    token = model.observe_messages(events.append)
+
+    model.add_message(NewMessage(body="hi", sender="agent"))
+    assert len(events) == 1
+    assert events[0].action == ChatMessageAction.SERVER_MSG_SENT
+    assert events[0].message.body == "hi"
+
+    # After unobserve, no further events are delivered.
+    model.unobserve_messages(token)
+    model.add_message(NewMessage(body="again", sender="agent"))
+    assert len(events) == 1
+
+
+def test_ws_server_msg_updated(tmp_path: Path) -> None:
+    model = _ws_model(tmp_path)
+    msg_id = model.add_message(NewMessage(body="v1", sender="agent"))
+
+    events: List[ChatMessageEvent] = []
+    model.observe_messages(events.append)
+
+    updated = model.get_message(msg_id)
+    assert updated is not None
+    updated.body = "v2"
+    model.update_message(updated)
+
+    assert [e.action for e in events] == [ChatMessageAction.SERVER_MSG_UPDATED]
+    assert events[0].message.body == "v2"
+
+
+def test_ws_client_events(tmp_path: Path) -> None:
+    # CLIENT_* events are emitted by the WS handler; exercise the model's
+    # emission path directly here.
+    model = _ws_model(tmp_path)
+    msg_id = model.add_message(NewMessage(body="hi", sender="jovyan"))
+    message = model.get_message(msg_id)
+    assert message is not None
+
+    events: List[ChatMessageEvent] = []
+    model.observe_messages(events.append)
+    model._emit_message_event(ChatMessageAction.CLIENT_MSG_RECEIVED, message)
+    model._emit_message_event(ChatMessageAction.CLIENT_MSG_EDITED, message)
+
+    assert [e.action for e in events] == [
+        ChatMessageAction.CLIENT_MSG_RECEIVED,
+        ChatMessageAction.CLIENT_MSG_EDITED,
+    ]
+
+
+def test_ws_multiple_observers(tmp_path: Path) -> None:
+    model = _ws_model(tmp_path)
+    a: List[ChatMessageEvent] = []
+    b: List[ChatMessageEvent] = []
+    token_a = model.observe_messages(a.append)
+    model.observe_messages(b.append)
+
+    model.add_message(NewMessage(body="1", sender="agent"))
+    assert len(a) == 1 and len(b) == 1
+
+    model.unobserve_messages(token_a)
+    model.add_message(NewMessage(body="2", sender="agent"))
+    assert len(a) == 1 and len(b) == 2
+
+
+def test_ws_observer_error_is_isolated(tmp_path: Path) -> None:
+    model = _ws_model(tmp_path)
+    good: List[ChatMessageEvent] = []
+
+    def boom(event: ChatMessageEvent) -> None:
+        raise RuntimeError("observer blew up")
+
+    model.observe_messages(boom)
+    model.observe_messages(good.append)
+    # A failing observer must not prevent others from being notified.
+    model.add_message(NewMessage(body="hi", sender="agent"))
+    assert len(good) == 1
+
+
+# --------------------------------------------------------------------------
+# Collaborative model (YChat)
+# --------------------------------------------------------------------------
+def _insert_ymessage(chat: YChat, message: dict) -> None:
+    # raw_time=False avoids the server-timestamp reschedule (which uses an
+    # asyncio task) so the test stays synchronous.
+    message.setdefault("raw_time", False)
+    with chat._ydoc.transaction():
+        chat._ymessages.append(Map(message))
+
+
+def test_ychat_insert_classification_and_unobserve() -> None:
+    chat = YChat()
+    # Give the document an id first so flipping `dirty` does not schedule
+    # `create_id()` (which needs a running event loop).
+    chat.set_id("test-chat")
+    chat.dirty = False  # simulate a fully-loaded document
+    chat.set_user(User(username="human", name="H", display_name="H"))
+    chat.set_user(User(username="bot", name="B", display_name="B", bot=True))
+
+    events: List[ChatMessageEvent] = []
+    token = chat.observe_messages(events.append)
+
+    _insert_ymessage(
+        chat, {"id": "m1", "body": "from human", "time": 1.0, "sender": "human"}
+    )
+    _insert_ymessage(
+        chat, {"id": "m2", "body": "from bot", "time": 2.0, "sender": "bot"}
+    )
+
+    by_body = {e.message.body: e.action for e in events}
+    assert by_body["from human"] == ChatMessageAction.CLIENT_MSG_RECEIVED
+    assert by_body["from bot"] == ChatMessageAction.SERVER_MSG_SENT
+
+    chat.unobserve_messages(token)
+    _insert_ymessage(
+        chat, {"id": "m3", "body": "after", "time": 3.0, "sender": "human"}
+    )
+    assert "after" not in [e.message.body for e in events]

--- a/python/jupyterlab-chat/jupyterlab_chat/websocket_handler.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/websocket_handler.py
@@ -10,7 +10,7 @@ from typing import Dict
 from jupyter_server.base.handlers import JupyterHandler
 from tornado import web, websocket
 
-from .models import User
+from .models import ChatMessageAction, User
 from .websocket_model import WsChatModel
 
 
@@ -41,7 +41,9 @@ class WSChatHandler(JupyterHandler, websocket.WebSocketHandler):
 
     async def get(self, *args, **kwargs):
         self.pre_get()
-        await super().get(*args, **kwargs)
+        result = super().get(*args, **kwargs)
+        if result is not None:
+            await result
 
     def _parse_client_user(self):
         """Parse the optional client-provided identity from the connect query.
@@ -185,6 +187,11 @@ class WSChatHandler(JupyterHandler, websocket.WebSocketHandler):
         model.broadcast(
             json.dumps({"type": "msg", "message": model.resolve_message(message)})
         )
+        received = model.get_message(message["id"])
+        if received is not None:
+            model._emit_message_event(
+                ChatMessageAction.CLIENT_MSG_RECEIVED, received
+            )
 
     def _handle_update_message(self, data: dict, model: WsChatModel) -> None:
         msg_id = data.get("id")
@@ -203,6 +210,11 @@ class WSChatHandler(JupyterHandler, websocket.WebSocketHandler):
         model.broadcast(
             json.dumps({"type": "msg", "message": model.resolve_message(msg)})
         )
+        edited = model.get_message(msg_id)
+        if edited is not None:
+            model._emit_message_event(
+                ChatMessageAction.CLIENT_MSG_EDITED, edited
+            )
 
     def _store_attachments(self, attachments: list[dict], model: WsChatModel) -> list[str]:
         """Store attachment dicts via the model's set_attachment, return their IDs."""

--- a/python/jupyterlab-chat/jupyterlab_chat/websocket_model.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/websocket_model.py
@@ -2,23 +2,30 @@
 # Distributed under the terms of the Modified BSD License.
 
 import json
+import logging
 import time
 import uuid
 from dataclasses import asdict
 from pathlib import Path
-from typing import Any, Callable, Dict, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Union
 
 from tornado import websocket
 
 from .models import (
     BaseChatModel,
+    ChatMessageAction,
+    ChatMessageEvent,
     FileAttachment,
     Message,
+    MessageObserver,
+    MessageObserverCallback,
     NewMessage,
     NotebookAttachment,
     User,
     message_asdict_factory,
 )
+
+_log = logging.getLogger(__name__)
 
 
 class WsChatModel(BaseChatModel):
@@ -38,6 +45,7 @@ class WsChatModel(BaseChatModel):
         self._users: Dict[str, dict] = {}
         self._attachments: Dict[str, dict] = {}
         self._metadata: Dict[str, object] = {}
+        self._message_observers: List[MessageObserverCallback] = []
 
     # ------------------------------------------------------------------
     # Room-level helpers
@@ -147,6 +155,7 @@ class WsChatModel(BaseChatModel):
         self.broadcast(
             json.dumps({"type": "msg", "message": self.resolve_message(msg_dict)})
         )
+        self._emit_message_event(ChatMessageAction.SERVER_MSG_SENT, message)
         return msg_id
 
     def update_message(
@@ -172,6 +181,11 @@ class WsChatModel(BaseChatModel):
         self.broadcast(
             json.dumps({"type": "msg", "message": self.resolve_message(msg_dict)})
         )
+        updated = self.get_message(update.id)
+        if updated is not None:
+            self._emit_message_event(
+                ChatMessageAction.SERVER_MSG_UPDATED, updated
+            )
 
     def set_attachment(
         self, attachment: Union[FileAttachment, NotebookAttachment]
@@ -194,3 +208,33 @@ class WsChatModel(BaseChatModel):
 
     def set_metadata(self, name: str, metadata: Any) -> None:
         self._metadata[name] = metadata
+
+    # ------------------------------------------------------------------
+    # Message observers
+    # ------------------------------------------------------------------
+
+    def observe_messages(
+        self, callback: MessageObserverCallback
+    ) -> MessageObserver:
+        self._message_observers.append(callback)
+        return MessageObserver(_handle=callback)
+
+    def unobserve_messages(self, observer: MessageObserver) -> None:
+        try:
+            self._message_observers.remove(observer._handle)
+        except ValueError:
+            pass
+
+    def _emit_message_event(
+        self, action: ChatMessageAction, message: Message
+    ) -> None:
+        """Notify all message observers of a change. Observer errors are logged
+        but never interrupt message handling."""
+        if not self._message_observers:
+            return
+        event = ChatMessageEvent(action=action, message=message)
+        for callback in list(self._message_observers):
+            try:
+                callback(event)
+            except Exception:  # pragma: no cover - defensive
+                _log.exception("Message observer failed for %s", action)

--- a/python/jupyterlab-chat/jupyterlab_chat/ychat.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/ychat.py
@@ -13,7 +13,19 @@ from typing import Any, Callable, Optional, Set, Union
 from uuid import uuid4
 from pycrdt import Array, ArrayEvent, Map, MapEvent, Subscription
 
-from .models import BaseChatModel, message_asdict_factory, FileAttachment, NotebookAttachment, Message, NewMessage, User
+from .models import (
+    BaseChatModel,
+    ChatMessageAction,
+    ChatMessageEvent,
+    FileAttachment,
+    Message,
+    MessageObserver,
+    MessageObserverCallback,
+    NewMessage,
+    NotebookAttachment,
+    User,
+    message_asdict_factory,
+)
 from .utils import find_mentions
 
 
@@ -240,6 +252,51 @@ class YChat(YBaseDoc, BaseChatModel):
         """
         with self._ydoc.transaction():
             self._ymetadata.update({name: metadata})
+
+    def observe_messages(
+        self, callback: MessageObserverCallback
+    ) -> MessageObserver:
+        """Observe new messages by subscribing to the shared messages array.
+
+        Only genuine new messages (array inserts) are surfaced; in-place content
+        edits mutate a nested map and do not raise an array event, so
+        ``CLIENT_MSG_EDITED``/``SERVER_MSG_UPDATED`` are not emitted in RTC mode.
+        New messages are classified as server-sent when their sender is a bot
+        user, and client-received otherwise.
+        """
+        subscription: Subscription = self._ymessages.observe(
+            partial(self._dispatch_message_event, callback)
+        )
+        return MessageObserver(_handle=subscription)
+
+    def unobserve_messages(self, observer: MessageObserver) -> None:
+        subscription = observer._handle
+        if subscription is not None:
+            self._ymessages.unobserve(subscription)
+
+    def _dispatch_message_event(
+        self, callback: MessageObserverCallback, event: ArrayEvent
+    ) -> None:
+        # Skip while the document is still loading its pre-existing messages,
+        # and skip events that contain a delete (a message reposition performed
+        # by `_set_timestamp` is a delete+insert of an existing message, not a
+        # new one).
+        if self.dirty:
+            return
+        if any("delete" in value.keys() for value in event.delta):  # type:ignore[attr-defined]
+            return
+        for value in event.delta:  # type:ignore[attr-defined]
+            if "insert" not in value.keys():
+                continue
+            for item in value["insert"]:
+                message = Message(**item.to_py())
+                sender = self.get_user(message.sender)
+                action = (
+                    ChatMessageAction.SERVER_MSG_SENT
+                    if sender is not None and sender.bot
+                    else ChatMessageAction.CLIENT_MSG_RECEIVED
+                )
+                callback(ChatMessageEvent(action=action, message=message))
 
     async def create_id(self) -> str:
         """


### PR DESCRIPTION
## Motivation

Backend consumers such as the Jupyter AI router need to react to new chat messages. Today the only way to do that is to reach into `ychat.ymessages` and observe the shared CRDT array directly, which only works when real-time collaboration is enabled. Now that `jupyter-collaboration` is optional (#489), there is no way to listen to messages in the WebSocket configuration, so the router cannot function there.

## Summary

This adds a small message-observer API to the shared `BaseChatModel`: register a callback with `observe_messages` and release it with `unobserve_messages`, using the handle it returns so the subscription can't leak. Callbacks receive a typed event describing what happened to a message: received from or edited by a client, or sent/updated by the server. Both transports implement it, so a consumer can follow a chat's messages without knowing whether RTC is active.

## Technical details

- In RTC mode the model wraps the shared array observer under the hood and classifies each new message by its sender (a bot sender is treated as server, otherwise client). In-place edits mutate a nested map and don't raise an array event, so only new-message events are surfaced in RTC for now.

- In the WebSocket configuration all four event kinds are emitted directly from the message-handling paths.

- This is the model-side API only. Wiring the router to consume it transport-agnostically (via the server-side ChatManager) is a follow-up.

## Testing

Unit tests cover both transports: the event kinds, sender classification, and that unobserving stops delivery.