### PR TITLE
Allow displaying cell output widget as message

### DIFF
--- a/packages/jupyter-chat/src/components/messages/message-renderer.tsx
+++ b/packages/jupyter-chat/src/components/messages/message-renderer.tsx
@@ -20,6 +20,12 @@ const RENDERED_CLASS = 'jp-chat-rendered-message';
 const DEFAULT_MIME_TYPE = 'text/markdown';
 
 /**
+ * The class name added to an output area widget. This is required to display cell
+ * output as a message in the chat.
+ */
+const OUTPUT_AREA_CLASS = 'jp-OutputArea';
+
+/**
  * The type of the props for the MessageRenderer component.
  */
 type MessageRendererProps = {
@@ -55,6 +61,8 @@ function MessageRendererBase(props: MessageRendererProps): JSX.Element {
 
   // Allow edition only on text messages.
   const [canEdit, setCanEdit] = useState<boolean>(false);
+
+  const [isOutputArea, setIsOutputArea] = useState<boolean>(false);
 
   // Each element is a two-tuple with the structure [codeToolbarRoot, codeToolbarProps].
   const [codeToolbarDefns, setCodeToolbarDefns] = useState<
@@ -129,6 +137,8 @@ function MessageRendererBase(props: MessageRendererProps): JSX.Element {
       // This is necessary to render latex.
       MessageLoop.sendMessage(renderer, Widget.Msg.AfterAttach);
 
+      setIsOutputArea(!isMarkdownRenderer);
+
       // Add code toolbar if markdown has been rendered.
       if (isMarkdownRenderer) {
         const newCodeToolbarDefns: [HTMLDivElement, CodeToolbarProps][] = [];
@@ -164,7 +174,7 @@ function MessageRendererBase(props: MessageRendererProps): JSX.Element {
     <>
       {renderedContent && (
         <div
-          className={RENDERED_CLASS}
+          className={`${RENDERED_CLASS}${isOutputArea ? ` ${OUTPUT_AREA_CLASS}` : ''}`}
           ref={node => node && node.replaceChildren(renderedContent)}
         />
       )}


### PR DESCRIPTION
This PR add `jp-OutputArea` area class to the messages rendering a mime-bundle.

Some widgets are looking for this class to correctly display the widget.

More context in this [doc string](https://github.com/jupyterlite/ai/blob/93837d57d5b92576460f7f171d782a06640247ce/packages/ai/src/rendered-message-outputarea.ts#L7-L14) from `jupyterlite-ai`, included in https://github.com/jupyterlite/ai/pull/272.

cc. @jtpio 