### PR TITLE
[WIP] Generic pub/sub API for chat models (RTC + RTC-free)

### DIFF
--- a/docs/design/pubsub-api.md
+++ b/docs/design/pubsub-api.md
@@ -118,7 +118,7 @@ to the same topic and stay in sync through the YDoc.
 
 The chat topic is special here: the server sends the message history the instant a
 client connects, because the client needs the file's contents to render anything.
-The web client therefore must be able to `sub("/chat/messages", ...)` *before* the
+The web client therefore must be able to `sub("/chat/messages", ...)` _before_ the
 WebSocket is open. Subscriptions are registered locally and flushed on connect, so
 the first thing the callback receives is the history catchup, followed by live
 edits on the same ordered connection.

--- a/docs/design/pubsub-api.md
+++ b/docs/design/pubsub-api.md
@@ -1,0 +1,189 @@
+# A pub/sub API for Jupyter Chat
+
+## Overview
+
+Jupyter Chat should expose a single, generic pub/sub bus. Consumers publish and
+subscribe to named topics; the server relays payloads to every subscriber of a
+topic. This one primitive can power many features that today each need bespoke
+wiring:
+
+- new messages and message edits,
+- typing state of web clients and of server-side agents,
+- server-published session info in real time: available personas, models, and
+  settings (see the persona-manager's
+  [awareness models](https://github.com/jupyter-ai-contrib/jupyter-ai-persona-manager/blob/main/jupyter_ai_persona_manager/awareness_models.py)).
+
+Under RTC, document awareness already provides exactly this. Awareness is versatile:
+any peer can attach arbitrary data under a key, and every other peer sees it, with
+no new handler code. That flexibility is why personas can broadcast their model and
+usage today without touching `jupyterlab-chat`.
+
+The RTC-free path has no equivalent. `WsChatModel` ships a fixed protocol
+(`connection` / `users` / `msg` / `writing`) that only supports those message types.
+A consumer that wants to broadcast anything new must either patch
+`jupyterlab-chat` or open its own WebSocket per feature. The pub/sub API closes that
+gap: it gives the RTC-free path the same open-ended extensibility awareness gives
+the RTC path, behind one API that both transports implement.
+
+## API
+
+Add three methods to the base models: to `BaseChatModel` (per-chat channel) and to
+`ChatManager` (global channel):
+
+```python
+def pub(self, topic: str, data: Any) -> None: ...
+def sub(self, topic: str, callback: Callable[[Payload], None]) -> SubToken: ...
+def unsub(self, token: SubToken) -> None: ...
+```
+
+Everything on the wire is one payload:
+
+```python
+@dataclass
+class Payload:
+    client_id: str   # who published it (enables replicated sets + cleanup on leave)
+    data: Any        # arbitrary; publishers and subscribers agree on the shape
+```
+
+A subscriber receives the current state of the topic on subscribe, then every
+subsequent payload. Because a WebSocket delivers in order and never drops a frame
+on a live connection, a client that joins mid-stream (e.g. while an agent is
+streaming a reply) cannot miss anything.
+
+## Topics
+
+Each topic is a category of payloads.
+
+**The chat topic is special.** It carries the chat document (messages, users,
+metadata). It is uniquely ordered, potentially large, and backed by an actual file
+on the server (`.chat`). It is not a generic in-memory bus: under RTC it is the
+YDoc, and under RTC-free it is `WsChatModel` plus the file. Subscribing yields the
+message history and then live updates.
+
+**Every other topic is a generic pub/sub bus.** Payloads are relayed to
+subscribers and each peer keeps its own view. Two merge behaviors, chosen by the
+payload type:
+
+- A **dict** payload is merged by top-level key (last writer wins per key; a key
+  set to `null` deletes it). This is a replicated set/dictionary.
+- **Anything else** replaces the topic's value (last writer wins).
+
+The merge is applied by each peer, not the server, because it must work the same
+whether the transport is the YDoc/awareness (RTC) or our own WS (RTC-free). The
+`client_id` lets a subscriber attribute keys to a publisher and drop them when that
+publisher disconnects (a stopped/crashed writer's key is removed automatically).
+
+## Implementation with RTC
+
+The chat topic is the YDoc. `sub("/chat/...")` wraps the `YChat` observer API and
+`pub` mutates the shared types. A peer that joins gets the whole document through
+normal Yjs sync, so catchup is automatic and ordering is guaranteed by the CRDT.
+
+Every other topic maps to awareness. Publishing sets a field on the peer's own
+awareness state; subscribing observes awareness and folds the per-client states
+locally (which is what the frontend already does to build the writers list). This
+reuses the existing Y-protocol WebSocket, so there is no new server code.
+
+## Implementation without RTC
+
+There is no YDoc sync, so the chat topic is special and needs explicit handling.
+`WsChatModel` owns the chat document and persists it to the `.chat` file. As soon
+as a client connects, the server sends a catchup message carrying the full message
+history; web clients always receive it because the server knows they are connected
+(they hold the WebSocket). After catchup, edits stream as ordinary payloads on the
+same ordered connection, so a client that connected mid-stream misses nothing.
+Conceptually the chat topic is still just an observer over the document model,
+the same shape as wrapping the YDoc observer under RTC; the only RTC-free-specific
+step is sending that catchup ourselves instead of relying on Yjs sync.
+
+Every other topic is a small in-memory relay: the server fans each published
+payload out to the topic's subscribers over the one WebSocket per chat, and each
+peer folds them locally exactly as in the RTC case. The server tracks which
+`client_id` contributed which keys so it can relay a removal when that connection
+closes (this is what clears a crashed writer).
+
+## Use cases
+
+### Chat flow (with RTC)
+
+```python
+chat.sub("/chat/messages", on_message)   # analogous to ychat.ymessages.observe(...)
+```
+
+Under RTC this wraps the `YChat` observer directly, so `on_message` fires for every
+created or edited message. Multiple browser tabs and server-side agents subscribe
+to the same topic and stay in sync through the YDoc.
+
+### Chat flow (without RTC)
+
+The chat topic is special here: the server sends the message history the instant a
+client connects, because the client needs the file's contents to render anything.
+The web client therefore must be able to `sub("/chat/messages", ...)` *before* the
+WebSocket is open. Subscriptions are registered locally and flushed on connect, so
+the first thing the callback receives is the history catchup, followed by live
+edits on the same ordered connection.
+
+```python
+chat.sub("/chat/messages", on_message)   # registered even before the socket opens
+# on connect: server pushes full history, then streams subsequent edits
+```
+
+### Writers
+
+`/writers` is a replicated dictionary keyed by user id. Each writer contributes
+only its own key and retracts it with `null`; a key also drops automatically when
+that peer disconnects. Any number of peers can subscribe to watch the live set.
+
+```python
+# each writer publishes its own key
+chat.pub("/writers", {user1_id: {"typing": True}})     # from client 1
+chat.pub("/writers", {user2_id: {"typing": True}})     # from client 2
+chat.pub("/writers", {user1_id: None})                 # client 1 stopped
+
+# every subscriber converges to the merged set
+chat.sub("/writers", lambda p: render_writers(p.data))
+# -> {user1: {...}, user2: {...}} -> {user2: {...}}
+```
+
+### Jupyter AI: advertising personas
+
+The persona manager publishes the available personas on a per-chat topic; the UI
+subscribes to render the selector. Because the value is a plain list, each update
+replaces the previous one.
+
+```python
+chat.pub("/personas", [
+    {"id": "jupyternaut", "name": "Jupyternaut", "avatar_url": "..."},
+    {"id": "code",        "name": "Code",        "avatar_url": "..."},
+])
+chat.sub("/personas", lambda p: update_persona_selector(p.data))
+```
+
+Per-persona state that several personas contribute to at once (model config, usage)
+uses a `/personas/...` dict topic keyed by persona id, so each persona owns its key:
+
+```python
+chat.pub("/personas/usage", {persona_id: {"input_tokens": 1200, "cost_amount": 0.03}})
+```
+
+### Global awareness state
+
+The `ChatManager` exposes a global pub/sub channel at `/api/chats/all` for state
+that is not tied to one chat. It is the RTC-free analog of global awareness. For
+example, broadcasting a settings change to every connected client:
+
+```python
+manager.pub("/settings", {"default_chat_dir": "chats/"})
+manager.sub("/settings", lambda p: apply_settings(p.data))
+```
+
+The same channel can carry the cross-chat persona list, feature flags, or anything
+else a client should react to globally.
+
+## Notes
+
+- Publishing is open to any peer, matching the awareness/YDoc trust model today.
+- Presence topics are last-writer-wins, so out-of-order updates under RTC are
+  harmless: a subscriber only ever wants the latest value of a key.
+- `observe_messages`, `broadcast_writing_status`, and `ChatManager.observe_chats`
+  become thin wrappers over `sub`/`pub` on the relevant topic.

--- a/python/jupyterlab-chat/jupyterlab_chat/awareness_pubsub.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/awareness_pubsub.py
@@ -1,0 +1,163 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+"""Awareness-backed pub/sub for the RTC (``YChat``) transport.
+
+Presence topics map onto ``pycrdt`` awareness, whose native semantics already
+match the pub/sub presence model: awareness is a map of client-id -> state dict,
+and the value every peer observes for a key is the fold across all clients'
+states. This module exposes that as the same raw-:class:`Payload` stream the
+in-memory :class:`~jupyterlab_chat.pubsub.PubSubBus` produces, so a consumer's
+:class:`~jupyterlab_chat.pubsub.MergeView` folds identically on both transports.
+
+Each logical publisher (``client_id`` string) owns a distinct awareness slot.
+``pycrdt.Awareness`` only exposes one local ``client_id`` per instance, so -- as
+the persona-manager already does -- we temporarily swap ``awareness.client_id``
+to write a given slot.
+"""
+from __future__ import annotations
+
+import logging
+import random
+from contextlib import contextmanager
+from itertools import count
+from typing import Any, Callable, Dict, Iterator, Optional
+
+from pycrdt import Awareness
+
+from .pubsub import Payload, PubSubCallback, SubToken
+
+_log = logging.getLogger(__name__)
+
+
+class AwarenessBus:
+    """Exposes awareness as a topic-based pub/sub bus of raw :class:`Payload`s.
+
+    A topic is a field key within a client's awareness state; that field's value
+    is that client's contribution to the topic. Subscribers receive one payload
+    per contributing client (both on the initial snapshot and on every change),
+    and a ``data=None`` payload when a client retracts a topic or disconnects.
+    """
+
+    def __init__(self, awareness: Awareness) -> None:
+        self._aw = awareness
+        self._orig_client_id = awareness.client_id
+        # logical client_id -> awareness (int) client id, and the reverse map.
+        self._slot_of: Dict[str, int] = {}
+        self._logical_of: Dict[int, str] = {}
+        self._subs: Dict[str, Dict[int, PubSubCallback]] = {}
+        # topic -> contributor key -> last data delivered (for change detection).
+        self._seen: Dict[str, Dict[str, Any]] = {}
+        self._ids = count()
+        self._aw_subscription: Optional[str] = None
+
+    # ------------------------------------------------------------------
+    # Publish
+    # ------------------------------------------------------------------
+    def pub(self, topic: str, data: Any, client_id: str = "server") -> None:
+        slot = self._slot(client_id)
+        with self._as_client(slot):
+            state = dict(self._aw.get_local_state() or {})
+            if data is None:
+                state.pop(topic, None)
+            else:
+                state[topic] = data
+            self._aw.set_local_state(state)
+
+    def remove_client(self, client_id: str) -> None:
+        """Drop a logical publisher's whole awareness slot (all its topics)."""
+        slot = self._slot_of.get(client_id)
+        if slot is None:
+            return
+        with self._as_client(slot):
+            self._aw.set_local_state(None)
+
+    # ------------------------------------------------------------------
+    # Subscribe
+    # ------------------------------------------------------------------
+    def sub(self, topic: str, callback: PubSubCallback) -> SubToken:
+        self._ensure_observer()
+        sub_id = next(self._ids)
+        self._subs.setdefault(topic, {})[sub_id] = callback
+        # Snapshot: replay each client's current contribution to this topic.
+        seen = self._seen.setdefault(topic, {})
+        for cid, state in list(self._aw.states.items()):
+            if topic in state:
+                key = self._key(cid)
+                seen[key] = state[topic]
+                self._safe(callback, Payload(client_id=key, data=state[topic]))
+        return SubToken(lambda: self._remove_sub(topic, sub_id))
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+    def _slot(self, client_id: str) -> int:
+        slot = self._slot_of.get(client_id)
+        if slot is None:
+            slot = random.getrandbits(32)
+            self._slot_of[client_id] = slot
+            self._logical_of[slot] = client_id
+        return slot
+
+    def _key(self, awareness_client_id: int) -> str:
+        """Stable contributor key for a payload: the logical client_id for slots
+        we own, otherwise the awareness client id as a string."""
+        return self._logical_of.get(awareness_client_id, str(awareness_client_id))
+
+    @contextmanager
+    def _as_client(self, slot: int) -> Iterator[None]:
+        self._aw.client_id = slot
+        try:
+            yield
+        finally:
+            self._aw.client_id = self._orig_client_id
+
+    def _ensure_observer(self) -> None:
+        if self._aw_subscription is None:
+            self._aw_subscription = self._aw.observe(self._on_awareness)
+
+    def _remove_sub(self, topic: str, sub_id: int) -> None:
+        subs = self._subs.get(topic)
+        if subs is not None:
+            subs.pop(sub_id, None)
+            if not subs:
+                self._subs.pop(topic, None)
+
+    def _on_awareness(self, action: str, change: Any) -> None:
+        # Only react to genuine state changes, not the periodic "update" renewals
+        # (which fire on the awareness heartbeat even when nothing changed).
+        if action != "change":
+            return
+        changes, _origin = change
+        states = self._aw.states
+        touched = list(changes.get("added", [])) + list(changes.get("updated", []))
+        removed = list(changes.get("removed", []))
+        for topic, subs in list(self._subs.items()):
+            if not subs:
+                continue
+            seen = self._seen.setdefault(topic, {})
+            for cid in touched:
+                key = self._key(cid)
+                state = states.get(cid, {})
+                if topic in state:
+                    if seen.get(key) != state[topic]:
+                        seen[key] = state[topic]
+                        self._emit(topic, Payload(client_id=key, data=state[topic]))
+                elif key in seen:
+                    del seen[key]
+                    self._emit(topic, Payload(client_id=key, data=None))
+            for cid in removed:
+                key = self._key(cid)
+                if key in seen:
+                    del seen[key]
+                    self._emit(topic, Payload(client_id=key, data=None))
+
+    def _emit(self, topic: str, payload: Payload) -> None:
+        for callback in list(self._subs.get(topic, {}).values()):
+            self._safe(callback, payload)
+
+    @staticmethod
+    def _safe(callback: PubSubCallback, payload: Payload) -> None:
+        try:
+            callback(payload)
+        except Exception:  # pragma: no cover - defensive
+            _log.exception("awareness pub/sub subscriber callback failed")

--- a/python/jupyterlab-chat/jupyterlab_chat/events.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/events.py
@@ -23,13 +23,14 @@ import time
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable, Optional
+from typing import TYPE_CHECKING, Any, Callable, Optional
 
 from tornado.ioloop import PeriodicCallback
 from traitlets import Float
 from traitlets.config import LoggingConfigurable
 
 from .websocket_model import WsChatModel
+from .pubsub import PubSubBus, PubSubCallback, SubToken
 
 if TYPE_CHECKING:
     from jupyter_server.serverapp import ServerApp
@@ -129,6 +130,10 @@ class ChatManager(LoggingConfigurable):
         # ``ws_chat_models`` dict; kept under the same key for compatibility).
         self._settings["ws_chat_models"] = self._models
 
+        # Global pub/sub channel (see docs/design/pubsub-api.md). Carries state
+        # not tied to a single chat, e.g. cross-chat settings.
+        self._pubsub_bus = PubSubBus()
+
         self._register_schema()
         if rtc_enabled:
             self._wire_rtc_forwarding()
@@ -164,6 +169,23 @@ class ChatManager(LoggingConfigurable):
         self._event_logger.add_listener(
             schema_id=CHAT_ROOM_EVENT_SCHEMA_ID, listener=callback
         )
+
+    # ------------------------------------------------------------------
+    # Global pub/sub channel
+    # ------------------------------------------------------------------
+    def pub(self, topic: str, data: Any, client_id: str = "server") -> None:
+        """Publish ``data`` on the global channel (see the per-chat API on
+        :class:`~jupyterlab_chat.models.BaseChatModel`)."""
+        self._pubsub_bus.pub(topic, data, client_id)
+
+    def sub(self, topic: str, callback: PubSubCallback) -> SubToken:
+        """Subscribe to a global topic; the subscriber is seeded with the
+        current state and then receives every subsequent payload."""
+        return self._pubsub_bus.sub(topic, callback)
+
+    def unsub(self, token: SubToken) -> None:
+        """Cancel a global subscription created by :meth:`sub`."""
+        self._pubsub_bus.unsub(token)
 
     def _emit_event(self, event: ChatEvent) -> None:
         if self._event_logger is None:

--- a/python/jupyterlab-chat/jupyterlab_chat/models.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/models.py
@@ -374,6 +374,9 @@ class BaseChatModel(ABC):
     #: (ordered, file-backed) and bridges to ``observe_messages`` rather than the
     #: generic in-memory bus.
     CHAT_MESSAGES_TOPIC = "/chat/messages"
+    CHAT_USERS_TOPIC = "/chat/users"
+    CHAT_METADATA_TOPIC = "/chat/metadata"
+    CHAT_ATTACHMENTS_TOPIC = "/chat/attachments"
 
     _pubsub_bus: Optional[PubSubBus] = None
 

--- a/python/jupyterlab-chat/jupyterlab_chat/models.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/models.py
@@ -2,10 +2,12 @@
 # Distributed under the terms of the Modified BSD License.
 
 from abc import ABC, abstractmethod
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from enum import Enum
 from typing import Any, Callable, Literal, Optional, Tuple, Union
 from jupyter_server.auth import User as JupyterUser
+
+from .pubsub import Payload, PubSubBus, PubSubCallback, SubToken
 
 
 def message_asdict_factory(data):
@@ -364,3 +366,71 @@ class BaseChatModel(ABC):
         presence (e.g. the WebSocket model) override it.
         """
         # no-op by default
+
+    # ------------------------------------------------------------------
+    # Generic pub/sub API
+    # ------------------------------------------------------------------
+    #: Reserved topic exposing the chat document's messages. It is special
+    #: (ordered, file-backed) and bridges to ``observe_messages`` rather than the
+    #: generic in-memory bus.
+    CHAT_MESSAGES_TOPIC = "/chat/messages"
+
+    _pubsub_bus: Optional[PubSubBus] = None
+
+    def _pubsub(self) -> PubSubBus:
+        if self._pubsub_bus is None:
+            self._pubsub_bus = PubSubBus()
+        return self._pubsub_bus
+
+    def pub(self, topic: str, data: Any, client_id: str = "server") -> None:
+        """Publish ``data`` to ``topic`` (see :mod:`jupyterlab_chat.pubsub`)."""
+        self._pubsub().pub(topic, data, client_id)
+
+    def sub(self, topic: str, callback: PubSubCallback) -> SubToken:
+        """Subscribe to ``topic``. The subscriber is seeded with the current
+        state and then receives every subsequent payload.
+
+        The reserved :data:`CHAT_MESSAGES_TOPIC` bridges to the message history
+        and ``observe_messages`` so the chat flow uses the same API as any other
+        topic.
+        """
+        if topic == self.CHAT_MESSAGES_TOPIC:
+            return self._sub_chat_messages(callback)
+        return self._pubsub().sub(topic, callback)
+
+    def unsub(self, token: SubToken) -> None:
+        """Cancel a subscription created by :meth:`sub`."""
+        token._release()
+
+    def remove_client(self, client_id: str) -> None:
+        """Drop all pub/sub contributions published by ``client_id`` (e.g. when
+        its connection closes), relaying a clearing payload on each topic."""
+        self._pubsub().remove_client(client_id)
+
+    def _sub_chat_messages(self, callback: PubSubCallback) -> SubToken:
+        # Catchup: replay the current messages to this subscriber, then stream
+        # subsequent create/update events.
+        for message in self.get_messages():
+            callback(Payload(client_id=message.sender, data=_message_payload(message)))
+
+        def _on_event(event: "ChatMessageEvent") -> None:
+            callback(
+                Payload(
+                    client_id=event.message.sender,
+                    data=_message_payload(event.message, event.action),
+                )
+            )
+
+        observer = self.observe_messages(_on_event)
+        return SubToken(lambda: self.unobserve_messages(observer))
+
+
+def _message_payload(
+    message: "Message", action: Optional["ChatMessageAction"] = None
+) -> dict:
+    """Serialize a :class:`Message` for delivery on the ``/chat/messages`` topic,
+    optionally tagging it with the :class:`ChatMessageAction` that produced it."""
+    data = asdict(message, dict_factory=message_asdict_factory)
+    if action is not None:
+        data["action"] = action.value
+    return data

--- a/python/jupyterlab-chat/jupyterlab_chat/pubsub.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/pubsub.py
@@ -1,0 +1,177 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+"""A generic pub/sub bus for Jupyter Chat.
+
+This is the transport-agnostic core of the pub/sub API described in
+``docs/design/pubsub-api.md``. Consumers ``pub``/``sub``/``unsub`` to named
+topics; the bus relays raw :class:`Payload`s to the subscribers of a topic and
+retains the latest contribution per publisher so a late subscriber can catch up.
+
+The bus deliberately does **not** merge payloads. Merging is a per-peer concern
+(see :class:`MergeView`), because it must work identically whether the transport
+is the YDoc/awareness (RTC) or this in-memory bus (RTC-free).
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from itertools import count
+from typing import Any, Callable, Dict, Optional, Set
+
+_log = logging.getLogger(__name__)
+
+
+@dataclass
+class Payload:
+    """A single pub/sub message.
+
+    ``client_id`` identifies the publisher. It is what lets a subscriber
+    attribute keys to a contributor (for replicated sets such as the writers
+    list) and drop them when that contributor goes away.
+    """
+
+    client_id: str
+    data: Any
+
+
+#: A subscriber callback, invoked with each :class:`Payload` on its topic.
+PubSubCallback = Callable[[Payload], None]
+
+
+class SubToken:
+    """Opaque handle returned by :meth:`PubSubBus.sub`.
+
+    Pass it to :meth:`PubSubBus.unsub` (or call the model's ``unsub``) to stop
+    receiving updates and release the underlying subscription.
+    """
+
+    def __init__(self, teardown: Callable[[], None]) -> None:
+        self._teardown = teardown
+        self._active = True
+
+    def _release(self) -> None:
+        if self._active:
+            self._active = False
+            self._teardown()
+
+
+class PubSubBus:
+    """An in-memory relay of :class:`Payload`s, grouped by topic.
+
+    Responsibilities:
+      * fan a published payload out to the topic's current subscribers,
+      * retain the latest payload per publisher so a new subscriber can be
+        seeded (the "catchup" snapshot),
+      * relay a clearing payload (``data=None``) when a publisher retracts its
+        contribution or disconnects.
+    """
+
+    def __init__(self) -> None:
+        self._subs: Dict[str, Dict[int, PubSubCallback]] = {}
+        self._retained: Dict[str, Dict[str, Any]] = {}
+        self._ids = count()
+
+    def pub(self, topic: str, data: Any, client_id: str = "server") -> None:
+        """Publish ``data`` to ``topic`` on behalf of ``client_id``.
+
+        ``data=None`` retracts this publisher's contribution to the topic.
+        """
+        retained = self._retained.setdefault(topic, {})
+        if data is None:
+            retained.pop(client_id, None)
+        else:
+            retained[client_id] = data
+        self._emit(topic, Payload(client_id=client_id, data=data))
+
+    def sub(self, topic: str, callback: PubSubCallback) -> SubToken:
+        """Subscribe ``callback`` to ``topic`` and immediately replay the
+        current retained payloads to it (and only it)."""
+        sub_id = next(self._ids)
+        self._subs.setdefault(topic, {})[sub_id] = callback
+        for client_id, data in list(self._retained.get(topic, {}).items()):
+            self._safe(callback, Payload(client_id=client_id, data=data))
+        return SubToken(lambda: self._remove(topic, sub_id))
+
+    def unsub(self, token: SubToken) -> None:
+        """Stop a subscription created by :meth:`sub`."""
+        token._release()
+
+    def remove_client(self, client_id: str) -> None:
+        """Drop everything ``client_id`` published, relaying a clearing payload
+        on each affected topic. Called when a connection closes."""
+        for topic, retained in list(self._retained.items()):
+            if client_id in retained:
+                retained.pop(client_id, None)
+                self._emit(topic, Payload(client_id=client_id, data=None))
+
+    def _remove(self, topic: str, sub_id: int) -> None:
+        subs = self._subs.get(topic)
+        if subs is not None:
+            subs.pop(sub_id, None)
+            if not subs:
+                self._subs.pop(topic, None)
+
+    def _emit(self, topic: str, payload: Payload) -> None:
+        for callback in list(self._subs.get(topic, {}).values()):
+            self._safe(callback, payload)
+
+    @staticmethod
+    def _safe(callback: PubSubCallback, payload: Payload) -> None:
+        try:
+            callback(payload)
+        except Exception:  # pragma: no cover - defensive
+            _log.exception("pub/sub subscriber callback failed")
+
+
+class MergeView:
+    """Folds a stream of :class:`Payload`s into a topic's current value.
+
+    The rule, applied per peer:
+
+    * a **dict** payload is merged by top-level key (a key mapped to ``None``
+      deletes it) -- this is a replicated set/dictionary,
+    * any **other** value replaces the whole value (last writer wins),
+    * a payload whose ``data`` is ``None`` drops that publisher's contribution.
+    """
+
+    def __init__(self) -> None:
+        self._value: Any = None
+        self._keys_by_client: Dict[str, Set[str]] = {}
+        self._replaced_by: Optional[str] = None
+
+    @property
+    def value(self) -> Any:
+        return self._value
+
+    def apply(self, payload: Payload) -> None:
+        client_id, data = payload.client_id, payload.data
+        if data is None:
+            self._drop_client(client_id)
+        elif isinstance(data, dict):
+            self._merge(client_id, data)
+        else:
+            self._value = data
+            self._replaced_by = client_id
+            self._keys_by_client.clear()
+
+    def _merge(self, client_id: str, data: Dict[str, Any]) -> None:
+        if not isinstance(self._value, dict):
+            self._value = {}
+            self._replaced_by = None
+        owned = self._keys_by_client.setdefault(client_id, set())
+        for key, val in data.items():
+            if val is None:
+                self._value.pop(key, None)
+                owned.discard(key)
+            else:
+                self._value[key] = val
+                owned.add(key)
+
+    def _drop_client(self, client_id: str) -> None:
+        owned = self._keys_by_client.pop(client_id, set())
+        if isinstance(self._value, dict):
+            for key in owned:
+                self._value.pop(key, None)
+        elif self._replaced_by == client_id:
+            self._value = None
+            self._replaced_by = None

--- a/python/jupyterlab-chat/jupyterlab_chat/tests/test_pubsub.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/tests/test_pubsub.py
@@ -1,0 +1,208 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+"""Unit tests for the generic pub/sub API.
+
+Covers the transport-agnostic :class:`PubSubBus` and :class:`MergeView`, the
+``pub``/``sub``/``unsub`` surface on :class:`WsChatModel` (a ``BaseChatModel``),
+the special ``/chat/messages`` bridge, and the global channel on ``ChatManager``.
+"""
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, List, cast
+
+from jupyterlab_chat.events import ChatManager
+from jupyterlab_chat.models import NewMessage
+from jupyterlab_chat.pubsub import MergeView, Payload, PubSubBus
+from jupyterlab_chat.websocket_model import WsChatModel
+
+
+def _ws_model(tmp_path: Path) -> WsChatModel:
+    (tmp_path / "chat.chat").write_text("{}")
+    model = WsChatModel(path="chat.chat", root_dir=tmp_path)
+    model.load_from_file()
+    return model
+
+
+def _manager(tmp_path: Path) -> ChatManager:
+    settings = {"server_root_dir": str(tmp_path)}
+    serverapp = cast(Any, SimpleNamespace(web_app=SimpleNamespace(settings=settings)))
+    return ChatManager(serverapp, rtc_enabled=False, start_poller=False)
+
+
+# ---------------------------------------------------------------------------
+# PubSubBus
+# ---------------------------------------------------------------------------
+def test_bus_relays_to_subscribers() -> None:
+    bus = PubSubBus()
+    got: List[Payload] = []
+    bus.sub("/topic", got.append)
+    bus.pub("/topic", {"a": 1}, client_id="c1")
+    assert got == [Payload(client_id="c1", data={"a": 1})]
+
+
+def test_bus_snapshot_replays_retained_to_new_subscriber_only() -> None:
+    bus = PubSubBus()
+    first: List[Payload] = []
+    bus.sub("/topic", first.append)
+    bus.pub("/topic", {"a": 1}, client_id="c1")
+    bus.pub("/topic", {"b": 2}, client_id="c2")
+
+    # A late subscriber is seeded with both retained contributions.
+    late: List[Payload] = []
+    bus.sub("/topic", late.append)
+    assert sorted((p.client_id, tuple(p.data.items())) for p in late) == [
+        ("c1", (("a", 1),)),
+        ("c2", (("b", 2),)),
+    ]
+    # The first subscriber saw only the two live publishes, not a replay.
+    assert len(first) == 2
+
+
+def test_bus_none_clears_retained_and_relays() -> None:
+    bus = PubSubBus()
+    bus.pub("/topic", {"a": 1}, client_id="c1")
+    got: List[Payload] = []
+    bus.sub("/topic", got.append)  # replay -> one payload
+    bus.pub("/topic", None, client_id="c1")  # clear
+    assert got[-1] == Payload(client_id="c1", data=None)
+
+    # A brand-new subscriber gets no replay, since the contribution is gone.
+    fresh: List[Payload] = []
+    bus.sub("/topic", fresh.append)
+    assert fresh == []
+
+
+def test_bus_remove_client_relays_clear_for_each_topic() -> None:
+    bus = PubSubBus()
+    got: List[Payload] = []
+    bus.sub("/x", got.append)
+    bus.sub("/y", got.append)
+    bus.pub("/x", 1, client_id="c1")
+    bus.pub("/y", 2, client_id="c1")
+    got.clear()
+
+    bus.remove_client("c1")
+    assert Payload("c1", None) in got
+    assert len([p for p in got if p.data is None]) == 2
+
+
+def test_bus_unsub_stops_delivery() -> None:
+    bus = PubSubBus()
+    got: List[Payload] = []
+    token = bus.sub("/topic", got.append)
+    bus.pub("/topic", 1, client_id="c1")
+    bus.unsub(token)
+    bus.pub("/topic", 2, client_id="c1")
+    assert [p.data for p in got] == [1]
+
+
+# ---------------------------------------------------------------------------
+# MergeView
+# ---------------------------------------------------------------------------
+def test_mergeview_merges_dicts_across_clients() -> None:
+    view = MergeView()
+    view.apply(Payload("c1", {"user1": {"typing": True}}))
+    view.apply(Payload("c2", {"user2": {"typing": True}}))
+    assert view.value == {"user1": {"typing": True}, "user2": {"typing": True}}
+
+
+def test_mergeview_null_key_deletes() -> None:
+    view = MergeView()
+    view.apply(Payload("c1", {"user1": True}))
+    view.apply(Payload("c1", {"user1": None}))
+    assert view.value == {}
+
+
+def test_mergeview_drops_client_contribution_on_none() -> None:
+    view = MergeView()
+    view.apply(Payload("c1", {"user1": True}))
+    view.apply(Payload("c2", {"user2": True}))
+    view.apply(Payload("c1", None))  # c1 gone (disconnect)
+    assert view.value == {"user2": True}
+
+
+def test_mergeview_non_dict_replaces() -> None:
+    view = MergeView()
+    view.apply(Payload("c1", ["a", "b"]))
+    view.apply(Payload("c2", ["c"]))
+    assert view.value == ["c"]
+
+
+def test_bus_plus_mergeview_writers_flow() -> None:
+    """End-to-end replicated-set: two writers converge, then one leaves."""
+    bus = PubSubBus()
+    view = MergeView()
+    bus.sub("/writers", view.apply)
+    bus.pub("/writers", {"user1": {"typing": True}}, client_id="c1")
+    bus.pub("/writers", {"user2": {"typing": True}}, client_id="c2")
+    assert set(view.value) == {"user1", "user2"}
+    bus.remove_client("c1")
+    assert set(view.value) == {"user2"}
+
+
+# ---------------------------------------------------------------------------
+# BaseChatModel pub/sub (via WsChatModel)
+# ---------------------------------------------------------------------------
+def test_model_pub_sub_generic_topic(tmp_path: Path) -> None:
+    model = _ws_model(tmp_path)
+    view = MergeView()
+    model.sub("/personas/usage", view.apply)
+    model.pub("/personas/usage", {"jupyternaut": {"input_tokens": 10}}, client_id="p1")
+    assert view.value == {"jupyternaut": {"input_tokens": 10}}
+
+
+def test_model_remove_client_clears_writers(tmp_path: Path) -> None:
+    model = _ws_model(tmp_path)
+    view = MergeView()
+    model.sub("/writers", view.apply)
+    model.pub("/writers", {"u1": True}, client_id="c1")
+    model.pub("/writers", {"u2": True}, client_id="c2")
+    model.remove_client("c1")
+    assert set(view.value) == {"u2"}
+
+
+def test_model_unsub_stops_delivery(tmp_path: Path) -> None:
+    model = _ws_model(tmp_path)
+    got: List[Payload] = []
+    token = model.sub("/settings", got.append)
+    model.pub("/settings", {"theme": "dark"}, client_id="c1")
+    model.unsub(token)
+    model.pub("/settings", {"theme": "light"}, client_id="c1")
+    assert [p.data for p in got] == [{"theme": "dark"}]
+
+
+# ---------------------------------------------------------------------------
+# The special /chat/messages topic
+# ---------------------------------------------------------------------------
+def test_chat_messages_topic_snapshot_and_live(tmp_path: Path) -> None:
+    model = _ws_model(tmp_path)
+    model.add_message(NewMessage(body="history", sender="jovyan"))
+
+    got: List[Payload] = []
+    token = model.sub(model.CHAT_MESSAGES_TOPIC, got.append)
+
+    # Snapshot: the existing message is replayed on subscribe.
+    assert [p.data["body"] for p in got] == ["history"]
+
+    # Live: a new message is delivered as an event payload with its action.
+    model.add_message(NewMessage(body="live", sender="agent"))
+    assert got[-1].data["body"] == "live"
+    assert got[-1].data["action"] == "server_msg_sent"
+    assert got[-1].client_id == "agent"
+
+    # After unsub, no more deliveries.
+    model.unsub(token)
+    model.add_message(NewMessage(body="after", sender="agent"))
+    assert [p.data["body"] for p in got] == ["history", "live"]
+
+
+# ---------------------------------------------------------------------------
+# Global channel on ChatManager
+# ---------------------------------------------------------------------------
+def test_manager_global_channel(tmp_path: Path) -> None:
+    mgr = _manager(tmp_path)
+    got: List[Payload] = []
+    mgr.sub("/settings", got.append)
+    mgr.pub("/settings", {"default_chat_dir": "chats/"})
+    assert got[-1].data == {"default_chat_dir": "chats/"}
+    assert got[-1].client_id == "server"

--- a/python/jupyterlab-chat/jupyterlab_chat/tests/test_pubsub.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/tests/test_pubsub.py
@@ -197,6 +197,32 @@ def test_chat_messages_topic_snapshot_and_live(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Document topics on WsChatModel (parity with YChat)
+# ---------------------------------------------------------------------------
+def test_ws_users_document_topic(tmp_path: Path) -> None:
+    model = _ws_model(tmp_path)
+    got: List[Payload] = []
+    model.sub(model.CHAT_USERS_TOPIC, got.append)
+    assert got[-1].data == {}  # snapshot (empty)
+    model.pub(model.CHAT_USERS_TOPIC, {"username": "u1", "name": "U1"})
+    assert "u1" in got[-1].data and got[-1].data["u1"]["username"] == "u1"
+
+
+def test_ws_metadata_document_topic(tmp_path: Path) -> None:
+    model = _ws_model(tmp_path)
+    got: List[Payload] = []
+    model.sub(model.CHAT_METADATA_TOPIC, got.append)
+    model.pub(model.CHAT_METADATA_TOPIC, {"default_persona": "jupyternaut"})
+    assert got[-1].data.get("default_persona") == "jupyternaut"
+
+
+def test_ws_pub_message_appends(tmp_path: Path) -> None:
+    model = _ws_model(tmp_path)
+    model.pub(model.CHAT_MESSAGES_TOPIC, {"body": "hi", "sender": "jovyan"})
+    assert [m.body for m in model.get_messages()] == ["hi"]
+
+
+# ---------------------------------------------------------------------------
 # Global channel on ChatManager
 # ---------------------------------------------------------------------------
 def test_manager_global_channel(tmp_path: Path) -> None:

--- a/python/jupyterlab-chat/jupyterlab_chat/tests/test_pubsub_ychat.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/tests/test_pubsub_ychat.py
@@ -1,0 +1,116 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+"""Pub/sub API tests for the RTC transport (``YChat``).
+
+Exercises document topics (backed by the shared Y types) and presence topics
+(backed by awareness), verifying that the raw-payload stream folds through
+``MergeView`` identically to the RTC-free bus.
+"""
+from typing import List
+from uuid import uuid4
+
+import asyncio
+
+from jupyterlab_chat.models import NewMessage, User
+from jupyterlab_chat.pubsub import MergeView, Payload
+from jupyterlab_chat.ychat import YChat
+
+
+def _ychat() -> YChat:
+    chat = YChat()
+    # Assign an id up front so we don't trigger the lazy create_id() task (which
+    # needs a running loop), and clear dirty so message observers fire.
+    chat.set_id(uuid4().hex)
+    chat.dirty = False
+    return chat
+
+
+# ---------------------------------------------------------------------------
+# Document topics
+# ---------------------------------------------------------------------------
+def test_ychat_sub_messages_snapshot_and_live() -> None:
+    async def run() -> None:
+        chat = _ychat()
+        bot = User(username="agent", name="Agent", display_name="Agent", bot=True)
+        chat.set_user(bot)
+        chat.add_message(NewMessage(body="history", sender="agent"))
+
+        got: List[Payload] = []
+        token = chat.sub(chat.CHAT_MESSAGES_TOPIC, got.append)
+        # Snapshot replays the existing message.
+        assert [p.data["body"] for p in got] == ["history"]
+
+        # A new message streams as a live event.
+        chat.add_message(NewMessage(body="live", sender="agent"))
+        assert got[-1].data["body"] == "live"
+
+        chat.unsub(token)
+        chat.add_message(NewMessage(body="after", sender="agent"))
+        assert [p.data["body"] for p in got] == ["history", "live"]
+
+    asyncio.run(run())
+
+
+def test_ychat_sub_users_replace_semantics() -> None:
+    chat = _ychat()
+    got: List[Payload] = []
+    chat.sub(chat.CHAT_USERS_TOPIC, got.append)
+    # Snapshot (empty), then a whole-map update on each change.
+    assert got[-1].data == {}
+    chat.pub(chat.CHAT_USERS_TOPIC, {"username": "u1", "name": "U1"})
+    assert "u1" in got[-1].data
+    assert got[-1].data["u1"]["username"] == "u1"
+
+
+def test_ychat_pub_message_appends_to_ydoc() -> None:
+    async def run() -> None:
+        chat = _ychat()
+        chat.pub(chat.CHAT_MESSAGES_TOPIC, {"body": "hi", "sender": "jovyan"})
+        assert [m.body for m in chat.get_messages()] == ["hi"]
+
+    asyncio.run(run())
+
+
+def test_ychat_metadata_topic() -> None:
+    chat = _ychat()
+    got: List[Payload] = []
+    chat.sub(chat.CHAT_METADATA_TOPIC, got.append)
+    chat.pub(chat.CHAT_METADATA_TOPIC, {"default_persona": "jupyternaut"})
+    assert got[-1].data.get("default_persona") == "jupyternaut"
+
+
+# ---------------------------------------------------------------------------
+# Presence topics (awareness)
+# ---------------------------------------------------------------------------
+def test_ychat_presence_merge_across_publishers() -> None:
+    chat = _ychat()
+    view = MergeView()
+    chat.sub("/writers", view.apply)
+    chat.pub("/writers", {"user1": {"typing": True}}, client_id="user1")
+    chat.pub("/writers", {"user2": {"typing": True}}, client_id="user2")
+    assert set(view.value) == {"user1", "user2"}
+
+
+def test_ychat_presence_retract_and_remove() -> None:
+    chat = _ychat()
+    view = MergeView()
+    chat.sub("/writers", view.apply)
+    chat.pub("/writers", {"user1": {"typing": True}}, client_id="user1")
+    chat.pub("/writers", {"user2": {"typing": True}}, client_id="user2")
+
+    # Explicit retract of a whole slot.
+    chat.pub("/writers", None, client_id="user1")
+    assert set(view.value) == {"user2"}
+
+    # Disconnect cleanup drops the remaining slot.
+    chat.remove_client("user2")
+    assert view.value in ({}, None) or set(view.value) == set()
+
+
+def test_ychat_presence_snapshot_on_late_subscribe() -> None:
+    chat = _ychat()
+    chat.pub("/personas", {"jupyternaut": {"name": "Jupyternaut"}}, client_id="mgr")
+
+    view = MergeView()
+    chat.sub("/personas", view.apply)  # late subscriber gets the snapshot
+    assert view.value == {"jupyternaut": {"name": "Jupyternaut"}}

--- a/python/jupyterlab-chat/jupyterlab_chat/websocket_handler.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/websocket_handler.py
@@ -243,6 +243,8 @@ class WSChatHandler(JupyterHandler, websocket.WebSocketHandler):
         model = self._chat_models.get(path)
         if model and client_id:
             model.handlers.pop(client_id, None)
+            # Drop this client's pub/sub contributions (e.g. its writers entry).
+            model.remove_client(client_id)
             if not model.handlers:
                 # Don't free immediately: the manager reclaims the model after a
                 # grace period of inactivity unless a client reconnects.

--- a/python/jupyterlab-chat/jupyterlab_chat/websocket_model.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/websocket_model.py
@@ -6,11 +6,13 @@ import logging
 import time
 import uuid
 from dataclasses import asdict
+from itertools import count
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Union
 
 from tornado import websocket
 
+from .pubsub import Payload, PubSubCallback, SubToken
 from .models import (
     BaseChatModel,
     ChatMessageAction,
@@ -46,6 +48,10 @@ class WsChatModel(BaseChatModel):
         self._attachments: Dict[str, dict] = {}
         self._metadata: Dict[str, object] = {}
         self._message_observers: List[MessageObserverCallback] = []
+        # Subscribers to document map topics (/chat/users, /chat/metadata,
+        # /chat/attachments), notified with the whole current map on each change.
+        self._doc_subs: Dict[str, Dict[int, PubSubCallback]] = {}
+        self._doc_sub_ids = count()
 
     # ------------------------------------------------------------------
     # Room-level helpers
@@ -233,13 +239,16 @@ class WsChatModel(BaseChatModel):
             None,
         ) or str(uuid.uuid4())
         self._attachments[att_id] = att_dict
+        self._notify_document(self.CHAT_ATTACHMENTS_TOPIC)
         return att_id
 
     def set_user(self, user: User) -> None:
         self._users[user.username] = asdict(user)
+        self._notify_document(self.CHAT_USERS_TOPIC)
 
     def set_metadata(self, name: str, metadata: Any) -> None:
         self._metadata[name] = metadata
+        self._notify_document(self.CHAT_METADATA_TOPIC)
 
     # ------------------------------------------------------------------
     # Message observers
@@ -270,3 +279,74 @@ class WsChatModel(BaseChatModel):
                 callback(event)
             except Exception:  # pragma: no cover - defensive
                 _log.exception("Message observer failed for %s", action)
+
+    # ------------------------------------------------------------------
+    # Generic pub/sub API (RTC-free transport)
+    #
+    # Document topics (/chat/*) route to the model's own state (persisted to the
+    # .chat file); presence topics use the inherited in-memory PubSubBus. This is
+    # the RTC-free counterpart to YChat's Y-type / awareness implementation.
+    # ------------------------------------------------------------------
+    def pub(self, topic: str, data: Any, client_id: str = "server") -> None:
+        if topic == self.CHAT_MESSAGES_TOPIC:
+            self.add_message(NewMessage(**data))
+        elif topic == self.CHAT_USERS_TOPIC:
+            self.set_user(User(**data))
+        elif topic == self.CHAT_METADATA_TOPIC:
+            for key, value in dict(data).items():
+                self.set_metadata(key, value)
+        elif topic == self.CHAT_ATTACHMENTS_TOPIC:
+            attachment: Union[FileAttachment, NotebookAttachment] = (
+                NotebookAttachment(**data)
+                if data.get("type") == "notebook"
+                else FileAttachment(**data)
+            )
+            self.set_attachment(attachment)
+        else:
+            self._pubsub().pub(topic, data, client_id)
+
+    def sub(self, topic: str, callback: PubSubCallback) -> SubToken:
+        if topic == self.CHAT_MESSAGES_TOPIC:
+            return self._sub_chat_messages(callback)
+        if topic in (
+            self.CHAT_USERS_TOPIC,
+            self.CHAT_METADATA_TOPIC,
+            self.CHAT_ATTACHMENTS_TOPIC,
+        ):
+            return self._sub_document(topic, callback)
+        return self._pubsub().sub(topic, callback)
+
+    def _current_document(self, topic: str) -> dict:
+        if topic == self.CHAT_USERS_TOPIC:
+            return dict(self._users)
+        if topic == self.CHAT_METADATA_TOPIC:
+            return dict(self._metadata)
+        if topic == self.CHAT_ATTACHMENTS_TOPIC:
+            return dict(self._attachments)
+        return {}
+
+    def _sub_document(self, topic: str, callback: PubSubCallback) -> SubToken:
+        # Snapshot with the whole current mapping, then re-notify on each change
+        # (replace semantics, matching YChat's document Map subscription).
+        callback(Payload(client_id="server", data=self._current_document(topic)))
+        sub_id = next(self._doc_sub_ids)
+        self._doc_subs.setdefault(topic, {})[sub_id] = callback
+        return SubToken(lambda: self._remove_doc_sub(topic, sub_id))
+
+    def _remove_doc_sub(self, topic: str, sub_id: int) -> None:
+        subs = self._doc_subs.get(topic)
+        if subs is not None:
+            subs.pop(sub_id, None)
+            if not subs:
+                self._doc_subs.pop(topic, None)
+
+    def _notify_document(self, topic: str) -> None:
+        subs = self._doc_subs.get(topic)
+        if not subs:
+            return
+        payload = Payload(client_id="server", data=self._current_document(topic))
+        for callback in list(subs.values()):
+            try:
+                callback(payload)
+            except Exception:  # pragma: no cover - defensive
+                _log.exception("Document subscriber failed for %s", topic)

--- a/python/jupyterlab-chat/jupyterlab_chat/ychat.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/ychat.py
@@ -11,8 +11,10 @@ from functools import partial
 from jupyter_ydoc.ybasedoc import YBaseDoc
 from typing import Any, Callable, Optional, Set, Union
 from uuid import uuid4
-from pycrdt import Array, ArrayEvent, Map, MapEvent, Subscription
+from pycrdt import Array, ArrayEvent, Awareness, Map, MapEvent, Subscription
 
+from .awareness_pubsub import AwarenessBus
+from .pubsub import Payload, PubSubCallback, SubToken
 from .models import (
     BaseChatModel,
     ChatMessageAction,
@@ -478,3 +480,79 @@ class YChat(YBaseDoc, BaseChatModel):
             if msg_idx != new_idx:
                 message = self._ymessages.pop(msg_idx)
                 self._ymessages.insert(new_idx, message)
+
+    # ------------------------------------------------------------------
+    # Generic pub/sub API (RTC transport)
+    #
+    # Document topics (/chat/*) map to the shared Y types; presence topics map
+    # to awareness. This is the RTC implementation of the pub/sub API declared
+    # on BaseChatModel; see docs/design/pubsub-api.md.
+    # ------------------------------------------------------------------
+    # Document topics (/chat/*) map to the shared Y types; presence topics map
+    # to awareness. Topic constants are inherited from BaseChatModel.
+
+    _presence_bus: Optional[AwarenessBus] = None
+
+    def _presence(self) -> AwarenessBus:
+        """The awareness-backed bus for presence topics, created lazily.
+
+        ``YChat.awareness`` is only set once the document is attached to a room;
+        when absent we create one over the same ``Doc`` (mirroring the
+        persona-manager) so presence works in-process too.
+        """
+        if self._presence_bus is None:
+            if self.awareness is None:
+                self.awareness = Awareness(ydoc=self._ydoc)
+            self._presence_bus = AwarenessBus(self.awareness)
+        return self._presence_bus
+
+    def pub(self, topic: str, data: Any, client_id: str = "server") -> None:
+        if topic.startswith("/chat"):
+            self._pub_document(topic, data)
+        else:
+            self._presence().pub(topic, data, client_id)
+
+    def sub(self, topic: str, callback: PubSubCallback) -> SubToken:
+        if topic == self.CHAT_MESSAGES_TOPIC:
+            # Reuse the base bridge: history snapshot + observe_messages stream.
+            return self._sub_chat_messages(callback)
+        if topic == self.CHAT_USERS_TOPIC:
+            return self._sub_map(self._yusers, callback)
+        if topic == self.CHAT_METADATA_TOPIC:
+            return self._sub_map(self._ymetadata, callback)
+        if topic == self.CHAT_ATTACHMENTS_TOPIC:
+            return self._sub_map(self._yattachments, callback)
+        return self._presence().sub(topic, callback)
+
+    def remove_client(self, client_id: str) -> None:
+        self._presence().remove_client(client_id)
+
+    def _sub_map(self, ymap: Map, callback: PubSubCallback) -> SubToken:
+        """Subscribe to a document Map topic: deliver the whole current mapping
+        as the snapshot, then the whole updated mapping on every change (document
+        topics use replace semantics, not the presence merge)."""
+        callback(Payload(client_id="server", data=ymap.to_py() or {}))
+        subscription = ymap.observe(
+            lambda _event: callback(
+                Payload(client_id="server", data=ymap.to_py() or {})
+            )
+        )
+        return SubToken(lambda: ymap.unobserve(subscription))
+
+    def _pub_document(self, topic: str, data: Any) -> None:
+        if topic == self.CHAT_MESSAGES_TOPIC:
+            self.add_message(NewMessage(**data))
+        elif topic == self.CHAT_USERS_TOPIC:
+            self.set_user(User(**data))
+        elif topic == self.CHAT_METADATA_TOPIC:
+            for key, value in dict(data).items():
+                self.set_metadata(key, value)
+        elif topic == self.CHAT_ATTACHMENTS_TOPIC:
+            attachment: Union[FileAttachment, NotebookAttachment] = (
+                NotebookAttachment(**data)
+                if data.get("type") == "notebook"
+                else FileAttachment(**data)
+            )
+            self.set_attachment(attachment)
+        else:  # pragma: no cover - defensive; unknown /chat/* topic
+            raise ValueError(f"Unknown document topic: {topic}")


### PR DESCRIPTION
> [!WARNING]
> **WIP — this has not been reviewed by anyone yet.** Opened for visibility and CI. Design, naming, and scope are all subject to change. Do not merge.

Implements the generic pub/sub API proposed in #510, now on **both transports** (RTC and RTC-free).

## Core

- **`jupyterlab_chat/pubsub.py`**
  - `Payload { client_id, data }` — the single wire shape.
  - `PubSubBus` — in-memory relay: fans payloads to a topic's subscribers, retains the latest payload per publisher (catchup snapshot), and relays a clearing payload on retract/disconnect. It does not merge.
  - `MergeView` — the per-peer fold: dict payloads merge by top-level key (`null` deletes a key), non-dict replaces, `None` drops a publisher's contribution.
- **`BaseChatModel`** declares the API: `pub` / `sub` / `unsub` / `remove_client`, the reserved document-topic constants, and the `/chat/messages` bridge to `observe_messages`.
- **`ChatManager`** carries the same API for the global channel.

## RTC transport (`YChat`)

- **Document topics** map to the shared Y types: `/chat/messages` reuses the `observe_messages` bridge; `/chat/users`, `/chat/metadata`, `/chat/attachments` subscribe to the Y `Map`s (whole-map replace on change). `pub` routes to the typed methods (`add_message` / `set_user` / `set_metadata` / `set_attachment`).
- **Presence topics** map to awareness via **`awareness_pubsub.py::AwarenessBus`**. Each logical `client_id` owns its own awareness slot (swapping `awareness.client_id`, as the persona-manager does). The bus emits the *same raw-`Payload` stream* the in-memory bus does — one payload per contributing client, plus a `None` payload on retract/disconnect — so a consumer's `MergeView` folds identically on both transports. Awareness is created lazily over the `Doc` when the document isn't attached to a room.

## RTC-free transport (`WsChatModel`)

- **Document topics** route to the model's own state (persisted to `.chat`), with whole-map change notifications on `set_user` / `set_metadata` / `set_attachment`.
- **Presence topics** use the inherited in-memory `PubSubBus`; WS disconnect calls `remove_client` to drop a gone client's contributions (e.g. its writers entry).

## Testing

- `pytest python/jupyterlab-chat` → 93 passed, 2 skipped (existing + new `test_pubsub.py`, `test_pubsub_ychat.py`), covering the bus, `MergeView`, both transports' document + presence topics, and the global channel.
- `mypy python/jupyterlab-chat` → clean.

## Still out of scope

- The **frontend TypeScript** and the **WebSocket wire protocol** are not changed yet; this PR is the model-layer API on the server side. Wiring the browser client to `pub`/`sub` over the socket is the next step.

Tracks #510.
