### PR TITLE
Attribute server-side messages to a user via add_message(user=...)

### DIFF
--- a/python/jupyterlab-chat/jupyterlab_chat/__init__.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/__init__.py
@@ -15,7 +15,7 @@ import jupyter_ydoc  # noqa: F401
 
 from jupyter_server.utils import url_path_join
 
-from .models import BaseChatModel  # noqa: F401
+from .models import BaseChatModel, ChatUser  # noqa: F401
 from .rtc_lib import (  # noqa: F401
     RTC_PROVIDERS,
     RTCProvider,

--- a/python/jupyterlab-chat/jupyterlab_chat/models.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/models.py
@@ -364,3 +364,85 @@ class BaseChatModel(ABC):
         presence (e.g. the WebSocket model) override it.
         """
         # no-op by default
+
+    def add_user(self, user: "User") -> "ChatUser":
+        """Register ``user`` in the chat and return a :class:`ChatUser` bound to it.
+
+        This is the server-side entry point for adding a distinct identity (such
+        as an AI agent) to a chat. The returned :class:`ChatUser` remembers both
+        the model and the identity, so it can send messages and broadcast
+        writing status as ``user`` without passing the identity on every call.
+        """
+        self.set_user(user)
+        return ChatUser(model=self, user=user)
+
+    def send_message(
+        self,
+        user: "User",
+        body: str,
+        *,
+        mime_model: Optional[MimeModel] = None,
+        trigger_actions: list[Callable] | None = None,
+    ) -> str:
+        """Send a message to the chat attributed to ``user``.
+
+        ``user`` is registered in the chat first if it is not already present,
+        so a server-side sender can attribute a message to any identity it owns
+        without a separate :meth:`set_user`/:meth:`add_user` call. This lets
+        multiple AI agents share a chat while each sends under its own identity.
+
+        Returns the ID of the new message.
+        """
+        if user.username not in self.get_users():
+            self.set_user(user)
+        return self.add_message(
+            NewMessage(body=body, sender=user.username, mime_model=mime_model),
+            trigger_actions=trigger_actions,
+        )
+
+
+@dataclass
+class ChatUser:
+    """A :class:`User` identity bound to a chat model.
+
+    Returned by :meth:`BaseChatModel.add_user`. It forwards calls to the model
+    while supplying its own ``user``, so a server-side sender (such as an AI
+    agent) can send messages and advertise writing status under its own identity
+    without repeating the ``user`` argument on every call::
+
+        chat_user = chat.add_user(user=my_persona_user)
+        chat_user.send_message("Hello!")
+        chat_user.broadcast_writing_status({"typingIndicator": "thinking..."})
+    """
+
+    model: "BaseChatModel"
+    """ The chat model this user belongs to. """
+
+    user: "User"
+    """ The identity this ``ChatUser`` sends messages and status as. """
+
+    def send_message(
+        self,
+        body: str,
+        *,
+        mime_model: Optional[MimeModel] = None,
+        trigger_actions: list[Callable] | None = None,
+    ) -> str:
+        """Send a message to the chat attributed to this user.
+
+        Returns the ID of the new message.
+        """
+        return self.model.send_message(
+            self.user,
+            body,
+            mime_model=mime_model,
+            trigger_actions=trigger_actions,
+        )
+
+    def broadcast_writing_status(self, status: Optional[dict] = None) -> None:
+        """Broadcast an ephemeral writing status on behalf of this user.
+
+        ``status`` is ``None`` when the user stopped, or a mapping with optional
+        ``messageID`` and ``typingIndicator`` keys.
+        """
+        self.model.broadcast_writing_status(self.user, status)

--- a/python/jupyterlab-chat/jupyterlab_chat/models.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/models.py
@@ -88,8 +88,13 @@ class NewMessage:
     body: str
     """ The content of the message """
 
-    sender: str
-    """ The message sender unique id """
+    sender: Optional[str] = None
+    """
+    The message sender unique id.
+
+    Optional: when the message is added via ``add_message(..., user=...)`` the
+    sender is taken from that user, so this may be omitted.
+    """
 
     mime_model: Optional[MimeModel] = None
     """
@@ -302,7 +307,16 @@ class BaseChatModel(ABC):
         self,
         new_message: NewMessage,
         trigger_actions: list[Callable] | None = None,
+        user: Optional["User"] = None,
     ) -> str:
+        """Add a message to the chat.
+
+        When ``user`` is provided, it is registered in the chat (if not already
+        present) and the message is attributed to it, so a server-side sender
+        such as an AI agent can send under its own identity without a separate
+        :meth:`set_user` call. When ``user`` is omitted, ``new_message.sender``
+        is used instead (and is required in that case).
+        """
         ...
 
     @abstractmethod
@@ -376,30 +390,6 @@ class BaseChatModel(ABC):
         self.set_user(user)
         return ChatUser(model=self, user=user)
 
-    def send_message(
-        self,
-        user: "User",
-        body: str,
-        *,
-        mime_model: Optional[MimeModel] = None,
-        trigger_actions: list[Callable] | None = None,
-    ) -> str:
-        """Send a message to the chat attributed to ``user``.
-
-        ``user`` is registered in the chat first if it is not already present,
-        so a server-side sender can attribute a message to any identity it owns
-        without a separate :meth:`set_user`/:meth:`add_user` call. This lets
-        multiple AI agents share a chat while each sends under its own identity.
-
-        Returns the ID of the new message.
-        """
-        if user.username not in self.get_users():
-            self.set_user(user)
-        return self.add_message(
-            NewMessage(body=body, sender=user.username, mime_model=mime_model),
-            trigger_actions=trigger_actions,
-        )
-
 
 @dataclass
 class ChatUser:
@@ -432,11 +422,10 @@ class ChatUser:
 
         Returns the ID of the new message.
         """
-        return self.model.send_message(
-            self.user,
-            body,
-            mime_model=mime_model,
+        return self.model.add_message(
+            NewMessage(body=body, mime_model=mime_model),
             trigger_actions=trigger_actions,
+            user=self.user,
         )
 
     def broadcast_writing_status(self, status: Optional[dict] = None) -> None:

--- a/python/jupyterlab-chat/jupyterlab_chat/tests/test_chat_user.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/tests/test_chat_user.py
@@ -1,17 +1,18 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
-"""Tests for the server-side ``add_user``/``send_message`` API and ``ChatUser``.
+"""Tests for sending messages under a chosen identity.
 
-The API lives on ``BaseChatModel`` and is implemented in terms of the abstract
-``set_user``/``add_message``/``broadcast_writing_status`` primitives, so it must
-behave identically on both transports (``YChat`` and ``WsChatModel``).
+``add_message`` accepts an optional ``user``: when provided, the user is
+registered in the chat and the message is attributed to it. The behaviour must
+be identical on both transports (``YChat`` and ``WsChatModel``). The ``add_user``
+/ ``ChatUser`` convenience layer builds on the same primitive.
 """
 
 import json
 
 import pytest
 
-from ..models import ChatUser, User
+from ..models import ChatUser, NewMessage, User
 from ..websocket_model import WsChatModel
 from ..ychat import YChat
 
@@ -38,35 +39,45 @@ def model(request, tmp_path):
     return WsChatModel(path="chat.chat", root_dir=tmp_path)
 
 
-def test_add_user_registers_and_returns_chat_user(model):
-    chat_user = model.add_user(BOT)
+# ---------------------------------------------------------------------------
+# add_message(user=...)
+# ---------------------------------------------------------------------------
 
-    assert isinstance(chat_user, ChatUser)
-    assert chat_user.user is BOT
-    assert chat_user.model is model
+def test_add_message_with_user_registers_and_attributes(model):
+    assert BOT.username not in model.get_users()
+
+    msg_id = model.add_message(NewMessage(body="Hello from the server"), user=BOT)
+
+    # The user is registered on first send.
     assert BOT.username in model.get_users()
-    assert model.get_users()[BOT.username].username == BOT.username
-
-
-def test_send_message_attributes_message_to_user(model):
-    msg_id = model.send_message(BOT, "Hello from the server")
-
     message = model.get_message(msg_id)
     assert message is not None
     assert message.body == "Hello from the server"
     assert message.sender == BOT.username
 
 
-def test_send_message_registers_user_if_absent(model):
-    # No prior add_user / set_user call.
-    assert BOT.username not in model.get_users()
+def test_add_message_user_overrides_message_sender(model):
+    # Even if a sender is set on the NewMessage, the explicit user wins.
+    msg_id = model.add_message(
+        NewMessage(body="hi", sender="someone-else"), user=BOT
+    )
 
-    model.send_message(BOT, "First contact")
-
-    assert BOT.username in model.get_users()
+    assert model.get_message(msg_id).sender == BOT.username
 
 
-def test_send_message_does_not_reregister_existing_user(model):
+def test_add_message_without_user_uses_message_sender(model):
+    # The pre-existing behaviour is unchanged when no user is passed.
+    msg_id = model.add_message(NewMessage(body="hi", sender="agent"))
+
+    assert model.get_message(msg_id).sender == "agent"
+
+
+def test_add_message_requires_sender_or_user(model):
+    with pytest.raises(ValueError):
+        model.add_message(NewMessage(body="orphan message"))
+
+
+def test_add_message_does_not_reregister_existing_user(model):
     model.set_user(BOT)
     calls = []
     original_set_user = model.set_user
@@ -77,22 +88,32 @@ def test_send_message_does_not_reregister_existing_user(model):
 
     model.set_user = tracking_set_user  # type: ignore[method-assign]
 
-    model.send_message(BOT, "Second message")
+    model.add_message(NewMessage(body="second"), user=BOT)
 
-    # The user was already present, so send_message should not re-register it.
+    # BOT was already present, so add_message should not re-register it.
     assert calls == []
 
 
 def test_multiple_bots_share_one_chat(model):
-    a = model.add_user(BOT)
-    b = model.add_user(BOT2)
-
-    id_a = a.send_message("from bot 1")
-    id_b = b.send_message("from bot 2")
+    id_a = model.add_message(NewMessage(body="from bot 1"), user=BOT)
+    id_b = model.add_message(NewMessage(body="from bot 2"), user=BOT2)
 
     assert model.get_message(id_a).sender == BOT.username
     assert model.get_message(id_b).sender == BOT2.username
     assert {BOT.username, BOT2.username} <= set(model.get_users())
+
+
+# ---------------------------------------------------------------------------
+# add_user() -> ChatUser convenience layer
+# ---------------------------------------------------------------------------
+
+def test_add_user_registers_and_returns_chat_user(model):
+    chat_user = model.add_user(BOT)
+
+    assert isinstance(chat_user, ChatUser)
+    assert chat_user.user is BOT
+    assert chat_user.model is model
+    assert BOT.username in model.get_users()
 
 
 def test_chat_user_send_message_forwards(model):

--- a/python/jupyterlab-chat/jupyterlab_chat/tests/test_chat_user.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/tests/test_chat_user.py
@@ -1,0 +1,143 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+"""Tests for the server-side ``add_user``/``send_message`` API and ``ChatUser``.
+
+The API lives on ``BaseChatModel`` and is implemented in terms of the abstract
+``set_user``/``add_message``/``broadcast_writing_status`` primitives, so it must
+behave identically on both transports (``YChat`` and ``WsChatModel``).
+"""
+
+import json
+
+import pytest
+
+from ..models import ChatUser, User
+from ..websocket_model import WsChatModel
+from ..ychat import YChat
+
+
+BOT = User(username="bot-1", name="Bot One", display_name="Bot One", bot=True)
+BOT2 = User(username="bot-2", name="Bot Two", display_name="Bot Two", bot=True)
+
+
+class _FakeHandler:
+    """Captures messages written to a connected WS client."""
+
+    def __init__(self):
+        self.messages = []
+
+    def write_message(self, message):
+        self.messages.append(message)
+
+
+@pytest.fixture(params=["ychat", "ws"])
+def model(request, tmp_path):
+    """A ``BaseChatModel`` of each transport, so tests cover both."""
+    if request.param == "ychat":
+        return YChat()
+    return WsChatModel(path="chat.chat", root_dir=tmp_path)
+
+
+def test_add_user_registers_and_returns_chat_user(model):
+    chat_user = model.add_user(BOT)
+
+    assert isinstance(chat_user, ChatUser)
+    assert chat_user.user is BOT
+    assert chat_user.model is model
+    assert BOT.username in model.get_users()
+    assert model.get_users()[BOT.username].username == BOT.username
+
+
+def test_send_message_attributes_message_to_user(model):
+    msg_id = model.send_message(BOT, "Hello from the server")
+
+    message = model.get_message(msg_id)
+    assert message is not None
+    assert message.body == "Hello from the server"
+    assert message.sender == BOT.username
+
+
+def test_send_message_registers_user_if_absent(model):
+    # No prior add_user / set_user call.
+    assert BOT.username not in model.get_users()
+
+    model.send_message(BOT, "First contact")
+
+    assert BOT.username in model.get_users()
+
+
+def test_send_message_does_not_reregister_existing_user(model):
+    model.set_user(BOT)
+    calls = []
+    original_set_user = model.set_user
+
+    def tracking_set_user(user):
+        calls.append(user)
+        original_set_user(user)
+
+    model.set_user = tracking_set_user  # type: ignore[method-assign]
+
+    model.send_message(BOT, "Second message")
+
+    # The user was already present, so send_message should not re-register it.
+    assert calls == []
+
+
+def test_multiple_bots_share_one_chat(model):
+    a = model.add_user(BOT)
+    b = model.add_user(BOT2)
+
+    id_a = a.send_message("from bot 1")
+    id_b = b.send_message("from bot 2")
+
+    assert model.get_message(id_a).sender == BOT.username
+    assert model.get_message(id_b).sender == BOT2.username
+    assert {BOT.username, BOT2.username} <= set(model.get_users())
+
+
+def test_chat_user_send_message_forwards(model):
+    chat_user = model.add_user(BOT)
+
+    msg_id = chat_user.send_message("Sent via ChatUser")
+
+    message = model.get_message(msg_id)
+    assert message is not None
+    assert message.sender == BOT.username
+    assert message.body == "Sent via ChatUser"
+
+
+def test_chat_user_broadcast_writing_status_forwards_ws(tmp_path):
+    """On the WS transport the status reaches connected clients as this user."""
+    model = WsChatModel(path="chat.chat", root_dir=tmp_path)
+    handler = _FakeHandler()
+    model.handlers["client-1"] = handler  # type: ignore[assignment]
+
+    chat_user = model.add_user(BOT)
+    chat_user.broadcast_writing_status({"typingIndicator": "thinking..."})
+
+    frame = json.loads(handler.messages[-1])
+    assert frame["type"] == "writing"
+    assert frame["state"] is True
+    assert frame["typingIndicator"] == "thinking..."
+    assert frame["user"]["username"] == BOT.username
+
+
+def test_chat_user_broadcast_writing_status_stop_ws(tmp_path):
+    model = WsChatModel(path="chat.chat", root_dir=tmp_path)
+    handler = _FakeHandler()
+    model.handlers["client-1"] = handler  # type: ignore[assignment]
+
+    chat_user = model.add_user(BOT)
+    chat_user.broadcast_writing_status(None)
+
+    frame = json.loads(handler.messages[-1])
+    assert frame["state"] is False
+    assert frame["user"]["username"] == BOT.username
+
+
+def test_base_broadcast_writing_status_is_noop_on_ychat():
+    """YChat does not implement live presence, so this must not raise."""
+    chat = YChat()
+    chat_user = chat.add_user(BOT)
+    # Should be a no-op, not an error.
+    chat_user.broadcast_writing_status({"typingIndicator": "x"})

--- a/python/jupyterlab-chat/jupyterlab_chat/websocket_model.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/websocket_model.py
@@ -167,10 +167,27 @@ class WsChatModel(BaseChatModel):
         self,
         new_message: NewMessage,
         trigger_actions: list[Callable] | None = None,
+        user: Optional[User] = None,
     ) -> str:
+        # Resolve the sender. When a user is provided, register it and attribute
+        # the message to it; otherwise use the sender carried on the message.
+        sender: Optional[str]
+        if user is not None:
+            if user.username not in self.get_users():
+                self.set_user(user)
+            sender = user.username
+        else:
+            sender = new_message.sender
+        if not sender:
+            raise ValueError(
+                "add_message requires either new_message.sender or a user"
+            )
+
         timestamp = time.time()
         msg_id = str(uuid.uuid4())
-        message = Message(**asdict(new_message), time=timestamp, id=msg_id)
+        message_data = asdict(new_message)
+        message_data["sender"] = sender
+        message = Message(**message_data, time=timestamp, id=msg_id)
 
         if trigger_actions:
             for callback in trigger_actions:

--- a/python/jupyterlab-chat/jupyterlab_chat/ychat.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/ychat.py
@@ -140,7 +140,7 @@ class YChat(YBaseDoc, BaseChatModel):
         """
         return self._ymessages.to_py() or []
 
-    def add_message(self, new_message: NewMessage, trigger_actions: list[Callable] | None = None) -> str:
+    def add_message(self, new_message: NewMessage, trigger_actions: list[Callable] | None = None, user: Optional[User] = None) -> str:
         """
         Append a message to the document.
 
@@ -148,14 +148,34 @@ class YChat(YBaseDoc, BaseChatModel):
             new_message: The message to add
             trigger_actions: List of callbacks to execute on the message. Defaults to [find_mentions].
                            Each callback receives (message, chat) as arguments.
+            user: Optional sender identity. When provided, it is registered in
+                  the chat (if absent) and the message is attributed to it,
+                  overriding ``new_message.sender``. When omitted,
+                  ``new_message.sender`` is used and is required.
         """
         if trigger_actions is None:
             trigger_actions = [find_mentions]
 
+        # Resolve the sender. When a user is provided, register it so the
+        # message can be attributed to it (and so mention resolution can see it).
+        sender: Optional[str]
+        if user is not None:
+            if user.username not in self.get_users():
+                self.set_user(user)
+            sender = user.username
+        else:
+            sender = new_message.sender
+        if not sender:
+            raise ValueError(
+                "add_message requires either new_message.sender or a user"
+            )
+
         timestamp: float = time.time()
         uid = str(uuid4())
+        message_data = asdict(new_message)
+        message_data["sender"] = sender
         message = Message(
-            **asdict(new_message),
+            **message_data,
             time=timestamp,
             id=uid,
         )


### PR DESCRIPTION
## Summary

Adds an optional `user` argument to `add_message`, so a server-side sender (such as an AI agent) can attribute a message to any identity it owns. When `user` is passed, it is registered in the chat if absent and the message is sent under that identity; otherwise the existing `new_message.sender` is used. This behaves identically on both transports (YChat and WsChatModel).

This replaces the awareness hacking that `jupyter-ai-persona-manager` does today to make server-side messages appear to come from a persona (or from a "System" user for system-level commands).

Also included is the small `add_user`/`ChatUser` convenience from the issue: `add_user(user)` registers a user and returns a `ChatUser` that remembers the model and identity, so an agent can call `send_message(...)` and `broadcast_writing_status(...)` without repeating its `user` on every call.

Closes #508

## Technical details

`NewMessage.sender` is now optional, since the sender can come from the `user` argument instead. `add_message` raises if neither a user nor a sender is given.

## Testing

New `test_chat_user.py` covers the `user` path on both transports (registration, sender attribution, sender override, the sender-or-user requirement, multiple bots sharing a chat) plus the `ChatUser` convenience layer and WebSocket writing-status forwarding.