### PR TITLE
Emit client connect/disconnect events

### DIFF
--- a/python/jupyterlab-chat/jupyterlab_chat/events.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/events.py
@@ -49,9 +49,9 @@ JUPYTER_COLLABORATION_EVENTS_URI = (
 CHAT_ROOM_EVENT_SCHEMA = {
     "$id": CHAT_ROOM_EVENT_SCHEMA_ID,
     "version": "1",
-    "title": "Chat room lifecycle events",
+    "title": "Chat room and client events",
     "personal-data": True,
-    "description": "Transport-agnostic chat room lifecycle events emitted by jupyterlab_chat.",
+    "description": "Transport-agnostic chat room lifecycle and per-client connection events emitted by jupyterlab_chat.",
     "type": "object",
     "required": ["path", "action"],
     "properties": {
@@ -60,8 +60,23 @@ CHAT_ROOM_EVENT_SCHEMA = {
             "description": "Server-root-relative path of the .chat file (canonical id).",
         },
         "action": {
-            "enum": ["opened", "closed", "deleted"],
-            "description": "Chat room lifecycle action.",
+            "enum": [
+                "opened",
+                "closed",
+                "deleted",
+                "client_connected",
+                "client_disconnected",
+            ],
+            "description": (
+                "Chat event action. 'opened'/'closed'/'deleted' are room-level "
+                "(fire once when the chat goes live / is freed / is deleted). "
+                "'client_connected'/'client_disconnected' fire per client and "
+                "carry 'client_id'."
+            ),
+        },
+        "client_id": {
+            "type": "string",
+            "description": "Per-connection id; present only for the client_* actions.",
         },
         "room_id": {
             "type": "string",
@@ -73,92 +88,34 @@ CHAT_ROOM_EVENT_SCHEMA = {
 
 
 class ChatEventAction(str, Enum):
-    """Lifecycle actions on the generic chat event bus."""
+    """Actions on the generic chat event bus."""
 
     OPENED = "opened"
     CLOSED = "closed"
     DELETED = "deleted"
+    #: Fires for every client that connects to a chat (carries ``client_id``).
+    CLIENT_CONNECTED = "client_connected"
+    #: Fires for every client that disconnects from a chat (carries ``client_id``).
+    CLIENT_DISCONNECTED = "client_disconnected"
 
 
 @dataclass(frozen=True)
 class ChatEvent:
-    """A lifecycle event. Emitted as JSON via Jupyter Events; this is the
-    canonical shape (the registered schema mirrors it)."""
+    """A chat event. Emitted as JSON via Jupyter Events; this is the canonical
+    shape (the registered schema mirrors it)."""
 
     path: str
     action: ChatEventAction
     room_id: Optional[str] = None
+    #: Set only for the ``client_connected``/``client_disconnected`` actions.
+    client_id: Optional[str] = None
 
     def to_data(self) -> dict:
         data: dict = {"path": self.path, "action": self.action.value}
         if self.room_id is not None:
             data["room_id"] = self.room_id
-        return data
-
-
-#: Jupyter Events schema id for per-client connect/disconnect on a chat.
-CHAT_CLIENT_EVENT_SCHEMA_ID = "https://schema.jupyter.org/jupyterlab_chat/client/v1"
-
-#: Inline schema for per-client connection events. Unlike ``room/v1`` (which is
-#: room-level: it fires once when a chat goes live and once when it is freed),
-#: this fires for *every* client that connects to or disconnects from a chat, so
-#: server-side consumers (e.g. AI personas) can (re)publish per-client state such
-#: as a catch-up snapshot when a new consumer joins an already-live chat.
-CHAT_CLIENT_EVENT_SCHEMA = {
-    "$id": CHAT_CLIENT_EVENT_SCHEMA_ID,
-    "version": "1",
-    "title": "Chat client connection events",
-    "personal-data": True,
-    "description": "Per-client connect/disconnect events for a chat, emitted by jupyterlab_chat.",
-    "type": "object",
-    "required": ["path", "action", "client_id"],
-    "properties": {
-        "path": {
-            "type": "string",
-            "description": "Server-root-relative path of the .chat file (canonical id).",
-        },
-        "action": {
-            "enum": ["connected", "disconnected"],
-            "description": "Whether the client connected to or disconnected from the chat.",
-        },
-        "client_id": {
-            "type": "string",
-            "description": "Opaque per-connection id assigned by the WebSocket handler.",
-        },
-        "room_id": {
-            "type": "string",
-            "description": "RTC room id ({format}:{type}:{file_id}); absent in WebSocket mode.",
-        },
-    },
-    "additionalProperties": False,
-}
-
-
-class ClientEventAction(str, Enum):
-    """Per-client connection actions on the chat event bus."""
-
-    CONNECTED = "connected"
-    DISCONNECTED = "disconnected"
-
-
-@dataclass(frozen=True)
-class ClientEvent:
-    """A per-client connect/disconnect event. Emitted as JSON via Jupyter Events;
-    this is the canonical shape (the registered schema mirrors it)."""
-
-    path: str
-    action: ClientEventAction
-    client_id: str
-    room_id: Optional[str] = None
-
-    def to_data(self) -> dict:
-        data: dict = {
-            "path": self.path,
-            "action": self.action.value,
-            "client_id": self.client_id,
-        }
-        if self.room_id is not None:
-            data["room_id"] = self.room_id
+        if self.client_id is not None:
+            data["client_id"] = self.client_id
         return data
 
 
@@ -218,36 +175,22 @@ class ChatManager(LoggingConfigurable):
             self._event_logger.register_event_schema(CHAT_ROOM_EVENT_SCHEMA)
         except Exception as e:  # pragma: no cover - defensive
             self.log.warning("Failed to register chat room event schema: %s", e)
-        try:
-            self._event_logger.register_event_schema(CHAT_CLIENT_EVENT_SCHEMA)
-        except Exception as e:  # pragma: no cover - defensive
-            self.log.warning("Failed to register chat client event schema: %s", e)
 
     def observe_chats(self, callback: Callable) -> None:
-        """Subscribe to chat lifecycle events (wraps ``EventLogger.add_listener``).
+        """Subscribe to chat events (wraps ``EventLogger.add_listener``).
 
         ``callback`` is ``async def (logger, schema_id, data)`` where ``data``
-        matches :class:`ChatEvent`.
+        matches :class:`ChatEvent`. The stream carries both room-level actions
+        (``opened``/``closed``/``deleted``) and per-client actions
+        (``client_connected``/``client_disconnected``, which carry ``client_id``);
+        consumers filter by ``action``. Use the client actions to (re)publish
+        per-client state, such as a catch-up snapshot, when a new consumer joins
+        an already-live chat.
         """
         if self._event_logger is None:
             return
         self._event_logger.add_listener(
             schema_id=CHAT_ROOM_EVENT_SCHEMA_ID, listener=callback
-        )
-
-    def observe_clients(self, callback: Callable) -> None:
-        """Subscribe to per-client connect/disconnect events (wraps
-        ``EventLogger.add_listener``).
-
-        ``callback`` is ``async def (logger, schema_id, data)`` where ``data``
-        matches :class:`ClientEvent`. Use this to (re)publish per-client state,
-        such as a catch-up snapshot, when a new consumer joins an already-live
-        chat.
-        """
-        if self._event_logger is None:
-            return
-        self._event_logger.add_listener(
-            schema_id=CHAT_CLIENT_EVENT_SCHEMA_ID, listener=callback
         )
 
     def _emit_event(self, event: ChatEvent) -> None:
@@ -260,43 +203,32 @@ class ChatManager(LoggingConfigurable):
         except Exception as e:  # pragma: no cover - defensive
             self.log.warning("Failed to emit chat event %s: %s", event, e)
 
-    def _emit_client_event(self, event: ClientEvent) -> None:
-        if self._event_logger is None:
-            return
-        try:
-            self._event_logger.emit(
-                schema_id=CHAT_CLIENT_EVENT_SCHEMA_ID, data=event.to_data()
-            )
-        except Exception as e:  # pragma: no cover - defensive
-            self.log.warning("Failed to emit chat client event %s: %s", event, e)
-
-    def client_connected(self, path: str, client_id: str) -> None:
-        """Emit a ``connected`` client event. Called by the WS handler when a
-        client opens a connection to ``path``."""
-        room_id = next(
+    def _room_id_for(self, path: str) -> Optional[str]:
+        return next(
             (rid for rid, p in self._room_to_path.items() if p == path), None
         )
-        self._emit_client_event(
-            ClientEvent(
+
+    def client_connected(self, path: str, client_id: str) -> None:
+        """Emit a ``client_connected`` event. Called by the WS handler when a
+        client opens a connection to ``path``."""
+        self._emit_event(
+            ChatEvent(
                 path=path,
-                action=ClientEventAction.CONNECTED,
+                action=ChatEventAction.CLIENT_CONNECTED,
+                room_id=self._room_id_for(path),
                 client_id=client_id,
-                room_id=room_id,
             )
         )
 
     def client_disconnected(self, path: str, client_id: str) -> None:
-        """Emit a ``disconnected`` client event. Called by the WS handler when a
+        """Emit a ``client_disconnected`` event. Called by the WS handler when a
         client's connection to ``path`` closes."""
-        room_id = next(
-            (rid for rid, p in self._room_to_path.items() if p == path), None
-        )
-        self._emit_client_event(
-            ClientEvent(
+        self._emit_event(
+            ChatEvent(
                 path=path,
-                action=ClientEventAction.DISCONNECTED,
+                action=ChatEventAction.CLIENT_DISCONNECTED,
+                room_id=self._room_id_for(path),
                 client_id=client_id,
-                room_id=room_id,
             )
         )
 

--- a/python/jupyterlab-chat/jupyterlab_chat/events.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/events.py
@@ -208,9 +208,8 @@ class ChatManager(LoggingConfigurable):
             (rid for rid, p in self._room_to_path.items() if p == path), None
         )
 
-    def client_connected(self, path: str, client_id: str) -> None:
-        """Emit a ``client_connected`` event. Called by the WS handler when a
-        client opens a connection to ``path``."""
+    def on_client_connect(self, path: str, client_id: str) -> None:
+        """Callback invoked upon WebSocket client connection. Emits an event."""
         self._emit_event(
             ChatEvent(
                 path=path,
@@ -220,9 +219,8 @@ class ChatManager(LoggingConfigurable):
             )
         )
 
-    def client_disconnected(self, path: str, client_id: str) -> None:
-        """Emit a ``client_disconnected`` event. Called by the WS handler when a
-        client's connection to ``path`` closes."""
+    def on_client_disconnect(self, path: str, client_id: str) -> None:
+        """Callback invoked upon WebSocket client disconnection. Emits an event."""
         self._emit_event(
             ChatEvent(
                 path=path,

--- a/python/jupyterlab-chat/jupyterlab_chat/events.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/events.py
@@ -96,6 +96,72 @@ class ChatEvent:
         return data
 
 
+#: Jupyter Events schema id for per-client connect/disconnect on a chat.
+CHAT_CLIENT_EVENT_SCHEMA_ID = "https://schema.jupyter.org/jupyterlab_chat/client/v1"
+
+#: Inline schema for per-client connection events. Unlike ``room/v1`` (which is
+#: room-level: it fires once when a chat goes live and once when it is freed),
+#: this fires for *every* client that connects to or disconnects from a chat, so
+#: server-side consumers (e.g. AI personas) can (re)publish per-client state such
+#: as a catch-up snapshot when a new consumer joins an already-live chat.
+CHAT_CLIENT_EVENT_SCHEMA = {
+    "$id": CHAT_CLIENT_EVENT_SCHEMA_ID,
+    "version": "1",
+    "title": "Chat client connection events",
+    "personal-data": True,
+    "description": "Per-client connect/disconnect events for a chat, emitted by jupyterlab_chat.",
+    "type": "object",
+    "required": ["path", "action", "client_id"],
+    "properties": {
+        "path": {
+            "type": "string",
+            "description": "Server-root-relative path of the .chat file (canonical id).",
+        },
+        "action": {
+            "enum": ["connected", "disconnected"],
+            "description": "Whether the client connected to or disconnected from the chat.",
+        },
+        "client_id": {
+            "type": "string",
+            "description": "Opaque per-connection id assigned by the WebSocket handler.",
+        },
+        "room_id": {
+            "type": "string",
+            "description": "RTC room id ({format}:{type}:{file_id}); absent in WebSocket mode.",
+        },
+    },
+    "additionalProperties": False,
+}
+
+
+class ClientEventAction(str, Enum):
+    """Per-client connection actions on the chat event bus."""
+
+    CONNECTED = "connected"
+    DISCONNECTED = "disconnected"
+
+
+@dataclass(frozen=True)
+class ClientEvent:
+    """A per-client connect/disconnect event. Emitted as JSON via Jupyter Events;
+    this is the canonical shape (the registered schema mirrors it)."""
+
+    path: str
+    action: ClientEventAction
+    client_id: str
+    room_id: Optional[str] = None
+
+    def to_data(self) -> dict:
+        data: dict = {
+            "path": self.path,
+            "action": self.action.value,
+            "client_id": self.client_id,
+        }
+        if self.room_id is not None:
+            data["room_id"] = self.room_id
+        return data
+
+
 class ChatManager(LoggingConfigurable):
     """
     Owns the set of live chat models and emits lifecycle events for them.
@@ -152,6 +218,10 @@ class ChatManager(LoggingConfigurable):
             self._event_logger.register_event_schema(CHAT_ROOM_EVENT_SCHEMA)
         except Exception as e:  # pragma: no cover - defensive
             self.log.warning("Failed to register chat room event schema: %s", e)
+        try:
+            self._event_logger.register_event_schema(CHAT_CLIENT_EVENT_SCHEMA)
+        except Exception as e:  # pragma: no cover - defensive
+            self.log.warning("Failed to register chat client event schema: %s", e)
 
     def observe_chats(self, callback: Callable) -> None:
         """Subscribe to chat lifecycle events (wraps ``EventLogger.add_listener``).
@@ -165,6 +235,21 @@ class ChatManager(LoggingConfigurable):
             schema_id=CHAT_ROOM_EVENT_SCHEMA_ID, listener=callback
         )
 
+    def observe_clients(self, callback: Callable) -> None:
+        """Subscribe to per-client connect/disconnect events (wraps
+        ``EventLogger.add_listener``).
+
+        ``callback`` is ``async def (logger, schema_id, data)`` where ``data``
+        matches :class:`ClientEvent`. Use this to (re)publish per-client state,
+        such as a catch-up snapshot, when a new consumer joins an already-live
+        chat.
+        """
+        if self._event_logger is None:
+            return
+        self._event_logger.add_listener(
+            schema_id=CHAT_CLIENT_EVENT_SCHEMA_ID, listener=callback
+        )
+
     def _emit_event(self, event: ChatEvent) -> None:
         if self._event_logger is None:
             return
@@ -174,6 +259,46 @@ class ChatManager(LoggingConfigurable):
             )
         except Exception as e:  # pragma: no cover - defensive
             self.log.warning("Failed to emit chat event %s: %s", event, e)
+
+    def _emit_client_event(self, event: ClientEvent) -> None:
+        if self._event_logger is None:
+            return
+        try:
+            self._event_logger.emit(
+                schema_id=CHAT_CLIENT_EVENT_SCHEMA_ID, data=event.to_data()
+            )
+        except Exception as e:  # pragma: no cover - defensive
+            self.log.warning("Failed to emit chat client event %s: %s", event, e)
+
+    def client_connected(self, path: str, client_id: str) -> None:
+        """Emit a ``connected`` client event. Called by the WS handler when a
+        client opens a connection to ``path``."""
+        room_id = next(
+            (rid for rid, p in self._room_to_path.items() if p == path), None
+        )
+        self._emit_client_event(
+            ClientEvent(
+                path=path,
+                action=ClientEventAction.CONNECTED,
+                client_id=client_id,
+                room_id=room_id,
+            )
+        )
+
+    def client_disconnected(self, path: str, client_id: str) -> None:
+        """Emit a ``disconnected`` client event. Called by the WS handler when a
+        client's connection to ``path`` closes."""
+        room_id = next(
+            (rid for rid, p in self._room_to_path.items() if p == path), None
+        )
+        self._emit_client_event(
+            ClientEvent(
+                path=path,
+                action=ClientEventAction.DISCONNECTED,
+                client_id=client_id,
+                room_id=room_id,
+            )
+        )
 
     # ------------------------------------------------------------------
     # Responsibility 2 -- model access

--- a/python/jupyterlab-chat/jupyterlab_chat/tests/test_events.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/tests/test_events.py
@@ -204,9 +204,9 @@ def test_client_connected_and_disconnected_events(tmp_path):
 
         mgr.observe_chats(on_event)
 
-        mgr.client_connected("a.chat", "client-1")
-        mgr.client_connected("a.chat", "client-2")
-        mgr.client_disconnected("a.chat", "client-1")
+        mgr.on_client_connect("a.chat", "client-1")
+        mgr.on_client_connect("a.chat", "client-2")
+        mgr.on_client_disconnect("a.chat", "client-1")
         await _drain()
 
         assert events == [

--- a/python/jupyterlab-chat/jupyterlab_chat/tests/test_events.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/tests/test_events.py
@@ -184,3 +184,34 @@ def test_reopen_while_live_reuses_in_memory_model(tmp_path):
         mgr.stop()
 
     asyncio.run(run())
+
+
+def test_client_connected_and_disconnected_events(tmp_path):
+    async def run():
+        client_events: list = []
+
+        logger = EventLogger()
+        settings = {"event_logger": logger, "server_root_dir": str(tmp_path)}
+        serverapp = cast(
+            "ServerApp",
+            SimpleNamespace(web_app=SimpleNamespace(settings=settings)),
+        )
+        mgr = ChatManager(serverapp, rtc_enabled=False, start_poller=False)
+
+        async def on_client(logger, schema_id, data):
+            client_events.append(data)
+
+        mgr.observe_clients(on_client)
+
+        mgr.client_connected("a.chat", "client-1")
+        mgr.client_connected("a.chat", "client-2")
+        mgr.client_disconnected("a.chat", "client-1")
+        await _drain()
+
+        assert client_events == [
+            {"path": "a.chat", "action": "connected", "client_id": "client-1"},
+            {"path": "a.chat", "action": "connected", "client_id": "client-2"},
+            {"path": "a.chat", "action": "disconnected", "client_id": "client-1"},
+        ]
+
+    asyncio.run(run())

--- a/python/jupyterlab-chat/jupyterlab_chat/tests/test_events.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/tests/test_events.py
@@ -188,7 +188,7 @@ def test_reopen_while_live_reuses_in_memory_model(tmp_path):
 
 def test_client_connected_and_disconnected_events(tmp_path):
     async def run():
-        client_events: list = []
+        events: list = []
 
         logger = EventLogger()
         settings = {"event_logger": logger, "server_root_dir": str(tmp_path)}
@@ -198,20 +198,21 @@ def test_client_connected_and_disconnected_events(tmp_path):
         )
         mgr = ChatManager(serverapp, rtc_enabled=False, start_poller=False)
 
-        async def on_client(logger, schema_id, data):
-            client_events.append(data)
+        async def on_event(logger, schema_id, data):
+            if data["action"] in ("client_connected", "client_disconnected"):
+                events.append(data)
 
-        mgr.observe_clients(on_client)
+        mgr.observe_chats(on_event)
 
         mgr.client_connected("a.chat", "client-1")
         mgr.client_connected("a.chat", "client-2")
         mgr.client_disconnected("a.chat", "client-1")
         await _drain()
 
-        assert client_events == [
-            {"path": "a.chat", "action": "connected", "client_id": "client-1"},
-            {"path": "a.chat", "action": "connected", "client_id": "client-2"},
-            {"path": "a.chat", "action": "disconnected", "client_id": "client-1"},
+        assert events == [
+            {"path": "a.chat", "action": "client_connected", "client_id": "client-1"},
+            {"path": "a.chat", "action": "client_connected", "client_id": "client-2"},
+            {"path": "a.chat", "action": "client_disconnected", "client_id": "client-1"},
         ]
 
     asyncio.run(run())

--- a/python/jupyterlab-chat/jupyterlab_chat/websocket_handler.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/websocket_handler.py
@@ -124,7 +124,7 @@ class WSChatHandler(JupyterHandler, websocket.WebSocketHandler):
                     pass
 
         self.log.info("WS chat client %s connected to model '%s'", self._client_id, path)
-        self._chat_manager.client_connected(path, self._client_id)
+        self._chat_manager.on_client_connect(path, self._client_id)
 
     async def on_message(self, raw: str | bytes) -> None:
         try:
@@ -244,7 +244,7 @@ class WSChatHandler(JupyterHandler, websocket.WebSocketHandler):
         model = self._chat_models.get(path)
         if model and client_id:
             model.handlers.pop(client_id, None)
-            self._chat_manager.client_disconnected(path, client_id)
+            self._chat_manager.on_client_disconnect(path, client_id)
             if not model.handlers:
                 # Don't free immediately: the manager reclaims the model after a
                 # grace period of inactivity unless a client reconnects.

--- a/python/jupyterlab-chat/jupyterlab_chat/websocket_handler.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/websocket_handler.py
@@ -124,6 +124,7 @@ class WSChatHandler(JupyterHandler, websocket.WebSocketHandler):
                     pass
 
         self.log.info("WS chat client %s connected to model '%s'", self._client_id, path)
+        self._chat_manager.client_connected(path, self._client_id)
 
     async def on_message(self, raw: str | bytes) -> None:
         try:
@@ -243,6 +244,7 @@ class WSChatHandler(JupyterHandler, websocket.WebSocketHandler):
         model = self._chat_models.get(path)
         if model and client_id:
             model.handlers.pop(client_id, None)
+            self._chat_manager.client_disconnected(path, client_id)
             if not model.handlers:
                 # Don't free immediately: the manager reclaims the model after a
                 # grace period of inactivity unless a client reconnects.


### PR DESCRIPTION
Adds per-client connect/disconnect actions to the existing chat event bus.

## Why

The `jupyterlab_chat/room/v1` events (`opened`/`closed`/`deleted`) are **room-level**: `opened` fires once when a chat goes from no-clients to live, not per client. Server-side consumers (e.g. AI personas in `jupyter-ai-persona-manager`) need to know when *any* client connects so they can (re)publish per-client state — most importantly a **catch-up snapshot** (persona list, model/usage) to a client that joins an already-live chat. With RTC awareness being decoupled, there is otherwise no signal for "a new consumer connected."

## What

Rather than a separate schema, this extends the existing `room/v1` schema:

- Adds `client_connected` and `client_disconnected` to the `action` enum, plus an optional `client_id` field (present only for those actions).
- `ChatManager` gains `client_connected(path, client_id)` / `client_disconnected(path, client_id)` emitters; the same `observe_chats(...)` listener now carries these too (consumers filter by `action`).
- The WebSocket handler emits `client_connected` in `open()` and `client_disconnected` in `on_close()`, using the per-connection `client_id` it already assigns.

One event bus, one listener; purely additive to the existing `opened`/`closed`/`deleted` behavior.

## Testing

- New unit test `test_client_connected_and_disconnected_events` in `test_events.py`.
- Full Python suite: 69 passed, 2 skipped locally; `mypy` clean.

Note: emission is wired for the RTC-free WebSocket path (the decouple-RTC target). RTC per-client events can be forwarded from the collaboration provider in a follow-up if needed.
