### PR TITLE
Return typed attachments from `YChat.get_attachments()`

### DIFF
--- a/python/jupyterlab-chat/jupyterlab_chat/ychat.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/ychat.py
@@ -215,19 +215,12 @@ class YChat(YBaseDoc, BaseChatModel):
         Values are typed as `FileAttachment` or `NotebookAttachment`
         """
         result: dict[str, Union[FileAttachment, NotebookAttachment]] = {}
-        for att_id, att_dict in self._get_attachments().items():
+        for att_id, att_dict in (self._yattachments.to_py() or {}).items():
             if att_dict.get("type") == "notebook":
                 result[att_id] = NotebookAttachment(**att_dict)
             else:
                 result[att_id] = FileAttachment(**att_dict)
         return result
-
-    def _get_attachments(self) -> dict[str, dict]:
-        """
-        Returns the attachments of the document as raw dicts. Used internally
-        where a JSON-serializable form is required.
-        """
-        return self._yattachments.to_py() or {}
 
     def set_attachment(self, attachment: Union[FileAttachment, NotebookAttachment]) -> str:
         """
@@ -243,8 +236,8 @@ class YChat(YBaseDoc, BaseChatModel):
         # a new ID
         attachment_json = json.dumps(asdict(attachment), sort_keys=True)
         attachment_id = None
-        for id, att in self._get_attachments().items():
-            if json.dumps(att, sort_keys=True) == attachment_json:
+        for id, att in self.get_attachments().items():
+            if json.dumps(asdict(att), sort_keys=True) == attachment_json:
                 attachment_id = id
                 break
         if not attachment_id:
@@ -343,7 +336,10 @@ class YChat(YBaseDoc, BaseChatModel):
             {
                 "messages": self._get_messages(),
                 "users": self._get_users(),
-                "attachments": self._get_attachments(),
+                "attachments": {
+                    att_id: asdict(att)
+                    for att_id, att in self.get_attachments().items()
+                },
                 "metadata": self.get_metadata()
             },
             indent=2

--- a/python/jupyterlab-chat/jupyterlab_chat/ychat.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/ychat.py
@@ -211,6 +211,21 @@ class YChat(YBaseDoc, BaseChatModel):
         """
         Returns all attachments in the chat as a dictionary, indexed by
         attachment ID.
+
+        Values are typed as `FileAttachment` or `NotebookAttachment`
+        """
+        result: dict[str, Union[FileAttachment, NotebookAttachment]] = {}
+        for att_id, att_dict in self._get_attachments().items():
+            if att_dict.get("type") == "notebook":
+                result[att_id] = NotebookAttachment(**att_dict)
+            else:
+                result[att_id] = FileAttachment(**att_dict)
+        return result
+
+    def _get_attachments(self) -> dict[str, dict]:
+        """
+        Returns the attachments of the document as raw dicts. Used internally
+        where a JSON-serializable form is required.
         """
         return self._yattachments.to_py() or {}
 
@@ -228,7 +243,7 @@ class YChat(YBaseDoc, BaseChatModel):
         # a new ID
         attachment_json = json.dumps(asdict(attachment), sort_keys=True)
         attachment_id = None
-        for id, att in self.get_attachments().items():
+        for id, att in self._get_attachments().items():
             if json.dumps(att, sort_keys=True) == attachment_json:
                 attachment_id = id
                 break
@@ -328,7 +343,7 @@ class YChat(YBaseDoc, BaseChatModel):
             {
                 "messages": self._get_messages(),
                 "users": self._get_users(),
-                "attachments": self.get_attachments(),
+                "attachments": self._get_attachments(),
                 "metadata": self.get_metadata()
             },
             indent=2


### PR DESCRIPTION
The BaseChatModel abstract method declares:
  
```
  @abstractmethod
  def get_attachments(self) -> dict[str, Union[FileAttachment, NotebookAttachment]]:
```
  `YChat.get_attachments()` and `WsChatModel.get_attachments()` return different types
  **YChat.get_attachments() returned raw dicts violating the signature.**


Fixed so that all implementations of BaseChatModel.get_attachments() return the declared type.