### PR TITLE
Implement `YChat.broadcast_writing_status()`

### DIFF
--- a/packages/jupyterlab-chat/src/__tests__/writers-awareness.spec.ts
+++ b/packages/jupyterlab-chat/src/__tests__/writers-awareness.spec.ts
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+import { Doc } from 'yjs';
+import {
+  applyAwarenessUpdate,
+  Awareness,
+  encodeAwarenessUpdate
+} from 'y-protocols/awareness';
+
+import { collectWritersFromAwareness } from '../model';
+
+// The current user, occupying the local awareness slot. `IChatModel.name`-style
+// identity: writers are matched/excluded by `user.username`.
+const ME = { username: 'me', name: 'Me', display_name: 'Me' };
+
+function makeAwareness(): Awareness {
+  return new Awareness(new Doc());
+}
+
+/**
+ * Copy every client state from `source` into `target`, exactly as the awareness
+ * protocol does over the wire. After this, `target.getStates()` contains its own
+ * local client plus every client of `source`.
+ */
+function sync(source: Awareness, target: Awareness): void {
+  const clients = Array.from(source.getStates().keys());
+  applyAwarenessUpdate(target, encodeAwarenessUpdate(source, clients), 'test');
+}
+
+/**
+ * A "local" awareness whose own slot is the current user, plus any remote
+ * client states merged in.
+ */
+function localAwarenessWith(...remotes: Awareness[]): Awareness {
+  const local = makeAwareness();
+  local.setLocalStateField('user', ME);
+  for (const remote of remotes) {
+    sync(remote, local);
+  }
+  return local;
+}
+
+describe('collectWritersFromAwareness', () => {
+  it('reads a server-published set of writers from a single slot', () => {
+    const server = makeAwareness();
+    server.setLocalState({
+      user: { username: 'server' },
+      writers: [
+        { user: { username: 'bot' }, messageID: 'm1' },
+        { user: { username: 'bot-2' }, typingIndicator: 'Writing...' }
+      ]
+    });
+
+    const writers = collectWritersFromAwareness(
+      localAwarenessWith(server).getStates(),
+      ME.username
+    );
+
+    expect(writers).toEqual([
+      { user: { username: 'bot' }, messageID: 'm1' },
+      { user: { username: 'bot-2' }, typingIndicator: 'Writing...' }
+    ]);
+  });
+
+  it('reads a peer advertising its own typing on its own slot', () => {
+    const peer = makeAwareness();
+    peer.setLocalState({ user: { username: 'peer' }, isWriting: 'msg-9' });
+
+    const writers = collectWritersFromAwareness(
+      localAwarenessWith(peer).getStates(),
+      ME.username
+    );
+
+    expect(writers).toEqual([
+      {
+        user: { username: 'peer' },
+        messageID: 'msg-9',
+        typingIndicator: undefined
+      }
+    ]);
+  });
+
+  it('maps isWriting===true to no messageID', () => {
+    const peer = makeAwareness();
+    peer.setLocalState({ user: { username: 'peer' }, isWriting: true });
+
+    const writers = collectWritersFromAwareness(
+      localAwarenessWith(peer).getStates(),
+      ME.username
+    );
+
+    expect(writers).toHaveLength(1);
+    expect(writers[0].messageID).toBeUndefined();
+  });
+
+  it('does not show the current user when they broadcast their own typing', () => {
+    // The local client advertises its own writing status on its own slot...
+    const local = makeAwareness();
+    local.setLocalState({ user: ME, isWriting: 'my-msg' });
+    // ...while a real peer is also typing.
+    const peer = makeAwareness();
+    peer.setLocalState({ user: { username: 'peer' }, isWriting: 'p1' });
+    sync(peer, local);
+
+    const writers = collectWritersFromAwareness(local.getStates(), ME.username);
+
+    // Only the peer shows; the current user never sees themselves.
+    expect(writers.map(w => w.user.username)).toEqual(['peer']);
+  });
+
+  it('excludes the current user even from a server-published writer set', () => {
+    const server = makeAwareness();
+    server.setLocalState({
+      user: { username: 'server' },
+      writers: [{ user: ME, messageID: 'm1' }]
+    });
+
+    const writers = collectWritersFromAwareness(
+      localAwarenessWith(server).getStates(),
+      ME.username
+    );
+
+    expect(writers).toEqual([]);
+  });
+
+  it('ignores malformed or untrusted awareness state', () => {
+    // Real clients can write anything into their own slot.
+    const p1 = makeAwareness();
+    p1.setLocalState({ writers: 'not-an-array', isWriting: 123 });
+    const p2 = makeAwareness();
+    p2.setLocalState({
+      writers: ['garbage', { messageID: 'm1' }, { user: 'nope' }]
+    });
+    const p3 = makeAwareness();
+    p3.setLocalState({ user: 'not-an-object', isWriting: true });
+    const p4 = makeAwareness();
+    p4.setLocalState({ user: { name: 'no-username' }, isWriting: true });
+    const p5 = makeAwareness();
+    // A valid server writer, but with a wrong-typed typingIndicator.
+    p5.setLocalState({
+      writers: [{ user: { username: 'bot' }, typingIndicator: 42 }]
+    });
+
+    const writers = collectWritersFromAwareness(
+      localAwarenessWith(p1, p2, p3, p4, p5).getStates(),
+      ME.username
+    );
+
+    // Only the one well-formed writer survives, with the bad field dropped.
+    expect(writers).toEqual([{ user: { username: 'bot' } }]);
+  });
+
+  it('merges concurrent server writers and a typing peer', () => {
+    const server = makeAwareness();
+    server.setLocalState({
+      user: { username: 'server' },
+      writers: [
+        { user: { username: 'bot' }, messageID: 'm1' },
+        { user: { username: 'bot-2' }, messageID: 'm2' }
+      ]
+    });
+    const peer = makeAwareness();
+    peer.setLocalState({ user: { username: 'peer' }, isWriting: true });
+
+    const writers = collectWritersFromAwareness(
+      localAwarenessWith(server, peer).getStates(),
+      ME.username
+    );
+
+    expect(writers.map(w => w.user.username).sort()).toEqual([
+      'bot',
+      'bot-2',
+      'peer'
+    ]);
+  });
+});

--- a/packages/jupyterlab-chat/src/model.ts
+++ b/packages/jupyterlab-chat/src/model.ts
@@ -38,6 +38,102 @@ const WRITING_DELAY = 1000;
 const WS_WRITING_TIMEOUT = 3000;
 
 /**
+ * Coerce an untrusted value to an `IUser`, or `null` if it is not one.
+ * Awareness state is written by arbitrary clients, so the only field we rely on
+ * is a string `username`.
+ */
+function asUser(value: unknown): IUser | null {
+  if (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as { username?: unknown }).username === 'string'
+  ) {
+    return value as IUser;
+  }
+  return null;
+}
+
+/**
+ * Coerce an untrusted value to an `IWriter`, or `null` if it is not one.
+ */
+function asWriter(value: unknown): IChatModel.IWriter | null {
+  if (typeof value !== 'object' || value === null) {
+    return null;
+  }
+  const record = value as Record<string, unknown>;
+  const user = asUser(record.user);
+  if (!user) {
+    return null;
+  }
+  return {
+    user,
+    messageID:
+      typeof record.messageID === 'string' ? record.messageID : undefined,
+    typingIndicator:
+      typeof record.typingIndicator === 'string'
+        ? record.typingIndicator
+        : undefined
+  };
+}
+
+/**
+ * Build the writers list from the raw awareness states of a collaborative chat.
+ *
+ * Two shapes appear on the shared awareness channel: a peer advertising its own
+ * typing on its own slot (`isWriting`), and the set of writers a server-side
+ * sender (e.g. AI personas) publishes as a `writers` list on a single slot,
+ * since those senders have no awareness client of their own. Duplicate
+ * usernames are collapsed downstream by `updateWriters`.
+ *
+ * Awareness state is untrusted (any client can write anything), so every field
+ * is validated before use and malformed entries are dropped. Exported for tests.
+ */
+export function collectWritersFromAwareness(
+  states: Map<number, Record<string, unknown>>,
+  localUsername: string
+): IChatModel.IWriter[] {
+  const writers: IChatModel.IWriter[] = [];
+  // The current user must never see themselves as a writer, whichever slot
+  // advertises them (their own typing slot, or a server-published set).
+  const pushWriter = (writer: IChatModel.IWriter | null): void => {
+    if (writer && writer.user.username !== localUsername) {
+      writers.push(writer);
+    }
+  };
+  for (const state of states.values()) {
+    if (typeof state !== 'object' || state === null) {
+      continue;
+    }
+
+    // A server-side sender publishes the whole writer set on one slot.
+    if (Array.isArray(state.writers)) {
+      for (const entry of state.writers) {
+        pushWriter(asWriter(entry));
+      }
+    }
+
+    // A peer advertises its own typing on its own slot. `isWriting` is `true`
+    // (writing, no target message) or the string ID of the message being
+    // written; anything else is ignored.
+    const isWriting = state.isWriting;
+    if (isWriting === true || (typeof isWriting === 'string' && isWriting)) {
+      const user = asUser(state.user);
+      if (user) {
+        pushWriter({
+          user,
+          messageID: typeof isWriting === 'string' ? isWriting : undefined,
+          typingIndicator:
+            typeof state.typingIndicator === 'string'
+              ? state.typingIndicator
+              : undefined
+        });
+      }
+    }
+  }
+  return writers;
+}
+
+/**
  * Chat model namespace.
  */
 export namespace LabChatModel {
@@ -385,26 +481,15 @@ export class LabChatModel
 
   /**
    * Triggered when an awareness state changes.
-   * Used to populate the writers list.
+   * Used to populate the writers list from the shared awareness channel.
    */
   onAwarenessChange = () => {
-    const writers: IChatModel.IWriter[] = [];
-    const states = this.sharedModel.awareness.getStates();
-    for (const stateID of states.keys()) {
-      const state = states.get(stateID);
-      if (!state || !state.user || state.user.username === this.user.username) {
-        continue;
-      }
-      if (state.isWriting !== undefined && state.isWriting !== false) {
-        const writer: IChatModel.IWriter = {
-          user: state.user,
-          messageID: state.isWriting === true ? undefined : state.isWriting,
-          typingIndicator: state.typingIndicator ?? undefined
-        };
-        writers.push(writer);
-      }
-    }
-    this.updateWriters(writers);
+    this.updateWriters(
+      collectWritersFromAwareness(
+        this.sharedModel.awareness.getStates(),
+        this.user.username
+      )
+    );
   };
 
   /**

--- a/python/jupyterlab-chat/jupyterlab_chat/models.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/models.py
@@ -347,6 +347,7 @@ class BaseChatModel(ABC):
         :meth:`observe_messages`."""
         ...
 
+    @abstractmethod
     def broadcast_writing_status(
         self,
         user: "User",
@@ -359,7 +360,10 @@ class BaseChatModel(ABC):
         typing indicator. ``status`` is ``None`` when the user stopped, or a
         mapping with optional ``messageID`` and ``typingIndicator`` keys.
 
-        The default implementation is a no-op; transports that support live
-        presence (e.g. the WebSocket model) override it.
+        This is abstract: every transport MUST implement it so the writers API
+        stays transport-complete. The WebSocket model relays a ``writing`` frame
+        to connected clients; the collaborative (:class:`YChat`) model writes the
+        status into the shared awareness channel. Both surface the writer through
+        the same frontend ``writersChanged`` signal.
         """
-        # no-op by default
+        ...

--- a/python/jupyterlab-chat/jupyterlab_chat/tests/test_ychat_writing.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/tests/test_ychat_writing.py
@@ -1,0 +1,128 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+"""Tests for the collaborative (YChat) writing-status awareness relay.
+
+Server-side senders (e.g. AI personas) have no awareness client of their own, so
+``YChat.broadcast_writing_status`` publishes the whole set of current writers as
+a list under the document's own awareness slot (the ``writers`` field). The
+frontend scans every awareness slot for that field and merges it into the single
+``writersChanged`` signal, so RTC and RTC-free consumers read from one source.
+"""
+
+from dataclasses import asdict
+
+from pycrdt import Awareness
+
+from ..models import BaseChatModel, User
+from ..ychat import WRITERS_AWARENESS_KEY, YChat
+
+BOT = User(username="bot", name="bot", display_name="Bot Agent", bot=True)
+BOT2 = User(username="bot-2", name="bot-2", display_name="Second Bot", bot=True)
+
+
+def _chat_with_room_awareness() -> YChat:
+    """A YChat with an attached awareness, as a collaboration room provides."""
+    chat = YChat()
+    chat.awareness = Awareness(ydoc=chat._ydoc)
+    return chat
+
+
+def _published_writers(chat: YChat) -> list:
+    """The writer set the document currently publishes on its own slot."""
+    awareness = chat.awareness
+    assert awareness is not None
+    state = awareness.get_local_state() or {}
+    return state.get(WRITERS_AWARENESS_KEY, [])
+
+
+def test_broadcast_writing_status_is_abstract():
+    """The base model must not be instantiable without an implementation, so a
+    future transport cannot silently inherit a no-op again."""
+    assert getattr(
+        BaseChatModel.broadcast_writing_status, "__isabstractmethod__", False
+    )
+
+
+def test_writing_status_with_message_id():
+    chat = _chat_with_room_awareness()
+    chat.broadcast_writing_status(BOT, {"messageID": "msg-1"})
+
+    writers = _published_writers(chat)
+    assert writers == [{"user": asdict(BOT), "messageID": "msg-1"}]
+
+
+def test_writing_status_without_message_id():
+    chat = _chat_with_room_awareness()
+    chat.broadcast_writing_status(BOT, {"typingIndicator": "Writing..."})
+
+    writers = _published_writers(chat)
+    assert writers == [{"user": asdict(BOT), "typingIndicator": "Writing..."}]
+
+
+def test_writing_status_preserves_all_user_fields():
+    chat = _chat_with_room_awareness()
+    chat.broadcast_writing_status(BOT, {"messageID": "m1"})
+
+    writers = _published_writers(chat)
+    assert writers == [{"user": asdict(BOT), "messageID": "m1"}]
+    # The full User is serialized (asdict), so bot survives for consumers that
+    # distinguish AI writers from humans.
+    assert writers[0]["user"]["bot"] is True
+
+
+def test_stop_removes_writer_from_the_set():
+    chat = _chat_with_room_awareness()
+    chat.broadcast_writing_status(BOT, {"messageID": "m1"})
+    assert len(_published_writers(chat)) == 1
+
+    chat.broadcast_writing_status(BOT, None)
+    assert _published_writers(chat) == []
+
+
+def test_same_user_reuses_one_entry():
+    chat = _chat_with_room_awareness()
+    chat.broadcast_writing_status(BOT, {"messageID": "m1"})
+    chat.broadcast_writing_status(BOT, {"messageID": "m2"})
+
+    writers = _published_writers(chat)
+    assert len(writers) == 1
+    assert writers[0]["messageID"] == "m2"
+
+
+def test_concurrent_writers_share_one_slot():
+    chat = _chat_with_room_awareness()
+    chat.broadcast_writing_status(BOT, {"messageID": "m1"})
+    chat.broadcast_writing_status(BOT2, {"messageID": "m2"})
+
+    writers = _published_writers(chat)
+    assert len(writers) == 2
+    by_user = {w["user"]["username"]: w["messageID"] for w in writers}
+    assert by_user == {"bot": "m1", "bot-2": "m2"}
+
+    # Stopping one writer must not clear the other.
+    chat.broadcast_writing_status(BOT, None)
+    writers = _published_writers(chat)
+    assert [w["user"]["username"] for w in writers] == ["bot-2"]
+
+
+def test_writing_status_is_not_persisted():
+    chat = _chat_with_room_awareness()
+    chat.broadcast_writing_status(BOT, {"messageID": "m1"})
+
+    # Ephemeral: writing status lives only in awareness, never in the document.
+    assert chat._get_messages() == []
+    assert chat.get_metadata() == {}
+    assert chat._get_users() == {}
+
+
+def test_no_awareness_is_a_noop():
+    """Before a room attaches (awareness is None), broadcasting must not raise;
+    the writer is tracked and published once awareness is available."""
+    chat = YChat()
+    assert chat.awareness is None
+    chat.broadcast_writing_status(BOT, {"messageID": "m1"})  # must not raise
+
+    chat.awareness = Awareness(ydoc=chat._ydoc)
+    chat.broadcast_writing_status(BOT2, {"messageID": "m2"})
+    usernames = {w["user"]["username"] for w in _published_writers(chat)}
+    assert usernames == {"bot", "bot-2"}

--- a/python/jupyterlab-chat/jupyterlab_chat/ychat.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/ychat.py
@@ -28,6 +28,14 @@ from .models import (
 )
 from .utils import find_mentions
 
+# Awareness state field under which the collaborative model publishes the set of
+# users currently writing (e.g. AI personas). Server-side senders have no
+# awareness client of their own, so rather than fake a client per writer, the
+# whole set is published as a list under the document's own awareness slot and
+# clients scan every slot for this field. See `onAwarenessChange` in the
+# frontend model.
+WRITERS_AWARENESS_KEY = "writers"
+
 
 class YChat(YBaseDoc, BaseChatModel):
     def __init__(self, *args, **kwargs):
@@ -49,6 +57,10 @@ class YChat(YBaseDoc, BaseChatModel):
 
         # Lookup table to get message index from its ID.
         self._indexes_by_id: dict[str, int] = {}
+
+        # In-memory set of users currently writing (keyed by username), the
+        # source of truth published to the awareness channel. Ephemeral.
+        self._writers: dict[str, dict] = {}
 
     @property
     def version(self) -> str:
@@ -252,6 +264,49 @@ class YChat(YBaseDoc, BaseChatModel):
         """
         with self._ydoc.transaction():
             self._ymetadata.update({name: metadata})
+
+    def broadcast_writing_status(
+        self,
+        user: User,
+        status: Optional[dict] = None,
+    ) -> None:
+        """Broadcast ``user``'s writing status over the awareness channel.
+
+        ``user`` is a :class:`User`, serialized with ``dataclasses.asdict()`` so
+        every field (including ``bot``) survives to the client. ``status`` is
+        ``None`` when the user stopped, or a mapping with optional
+        ``messageID``/``typingIndicator`` keys. The full set of writers is
+        published as a list under the document's own awareness slot (the field
+        named by :data:`WRITERS_AWARENESS_KEY`), which every client scans; the
+        awareness channel keeps that slot alive on its own, so no per-writer
+        client or heartbeat is needed. Ephemeral: never persisted to the
+        ``.chat`` document.
+        """
+        if status is None:
+            self._writers.pop(user.username, None)
+        else:
+            writer: dict = {"user": asdict(user)}
+            message_id = status.get("messageID")
+            if message_id is not None:
+                writer["messageID"] = message_id
+            typing_indicator = status.get("typingIndicator")
+            if typing_indicator is not None:
+                writer["typingIndicator"] = typing_indicator
+            self._writers[user.username] = writer
+        self._publish_writers()
+
+    def _publish_writers(self) -> None:
+        """Publish the current writer set to the awareness channel.
+
+        Writes to the document's own awareness slot (no client-ID juggling). A
+        no-op until the document is attached to a collaboration room, which is
+        always the case when a server-side sender writes.
+        """
+        if self.awareness is None:
+            return
+        self.awareness.set_local_state_field(
+            WRITERS_AWARENESS_KEY, list(self._writers.values())
+        )
 
     def observe_messages(
         self, callback: MessageObserverCallback


### PR DESCRIPTION
## Motivation

The Writers API (#497) let server-side senders such as AI personas drive the chat typing indicator, but it was only wired up for the RTC-free WebSocket model. In collaborative mode the `YChat` model inherited a no-op, so a persona writing a reply never actually showed as writing, and the stop button that keys off an active writer stayed dead.

This went unnoticed because consumers used to write the persona's awareness slot themselves. Once they stop doing that, the writers API turns out to have never been complete for the RTC path.

## Summary

Server-side writers now show as writing in collaborative mode, same as over WebSocket. `broadcast_writing_status` is also now abstract on the base model, so every transport has to implement it and a future backend cannot silently regress to a no-op.

## Technical details

Rather than fake an awareness client per writer, `YChat` publishes the whole set of current writers as a list under its own awareness slot; clients scan every slot for that field. The awareness channel already keeps a participant's own slot alive, so there is no heartbeat to manage. Writing status is ephemeral and never persisted to the `.chat` document.

On the frontend, the collaborative model now merges that published set with a peer's own typing slot into the existing `writersChanged` signal, so every component reads writers from one transport-neutral source whether or not RTC is on. This is a slightly breaking change to how writers are represented in awareness.

## Testing

Python tests assert the writer set published on the awareness slot (message-id, typing-only, stop, concurrent writers, non-persistence, and the no-room no-op). A frontend unit test covers the awareness-to-writers merge (both shapes, dedupe, local-user exclusion).