### PR TITLE
Require `User` to be a dataclass in backend

### DIFF
--- a/python/jupyterlab-chat/jupyterlab_chat/models.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/models.py
@@ -349,16 +349,15 @@ class BaseChatModel(ABC):
 
     def broadcast_writing_status(
         self,
-        user: Union["User", dict],
+        user: "User",
         status: Optional[dict] = None,
     ) -> None:
         """Broadcast an ephemeral "user is writing" status on behalf of ``user``.
 
-        ``user`` is a :class:`User` (or a mapping with at least ``username``),
-        allowing server-side senders such as AI agents -- which each have their
-        own user identity -- to advertise a typing indicator. ``status`` is
-        ``None`` when the user stopped, or a mapping with optional ``messageID``
-        and ``typingIndicator`` keys.
+        ``user`` is a :class:`User`, allowing server-side senders such as AI
+        agents -- which each have their own user identity -- to advertise a
+        typing indicator. ``status`` is ``None`` when the user stopped, or a
+        mapping with optional ``messageID`` and ``typingIndicator`` keys.
 
         The default implementation is a no-op; transports that support live
         presence (e.g. the WebSocket model) override it.

--- a/python/jupyterlab-chat/jupyterlab_chat/tests/test_writing.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/tests/test_writing.py
@@ -41,23 +41,28 @@ def test_broadcast_writing_status_frame(tmp_path):
     assert frame["user"]["display_name"] == "Bot-Agent"
 
 
-def test_broadcast_writing_status_accepts_user_dict(tmp_path):
+def test_broadcast_writing_status_preserves_bot_flag(tmp_path):
+    """`bot` must survive serialization: consumers (e.g. a stop button) use
+    `user.bot` to distinguish AI writers from humans. Regression for the
+    persona stop button never enabling because the writer's `bot` was dropped.
+    """
     model, handler = _model_with_client(tmp_path)
+    bot_user = User(username="jovyan-bot", name="Agent", bot=True)
+    human = User(username="jovyan", name="Jovyan")
 
-    model.broadcast_writing_status(
-        {"username": "alice", "display_name": "Alice"}, {"messageID": "m1"}
-    )
+    model.broadcast_writing_status(bot_user, {"typingIndicator": "Writing..."})
+    model.broadcast_writing_status(human, {"typingIndicator": "typing"})
 
-    frame = json.loads(handler.messages[0])
-    assert frame["user"] == {"username": "alice", "display_name": "Alice"}
-    assert frame["state"] is True
-    assert frame["messageID"] == "m1"
+    bot_frame = json.loads(handler.messages[0])
+    human_frame = json.loads(handler.messages[1])
+    assert bot_frame["user"]["bot"] is True
+    assert human_frame["user"]["bot"] is False
 
 
 def test_broadcast_writing_status_stop(tmp_path):
     model, handler = _model_with_client(tmp_path)
 
-    model.broadcast_writing_status({"username": "bot"}, None)
+    model.broadcast_writing_status(User(username="bot"), None)
 
     frame = json.loads(handler.messages[0])
     assert frame["state"] is False
@@ -68,7 +73,7 @@ def test_broadcast_writing_status_stop(tmp_path):
 def test_writing_is_not_persisted(tmp_path):
     model, _ = _model_with_client(tmp_path)
 
-    model.broadcast_writing_status({"username": "bot"}, {"typingIndicator": "x"})
+    model.broadcast_writing_status(User(username="bot"), {"typingIndicator": "x"})
 
     # Ephemeral: broadcasting a writing status must not create/modify the file.
     assert not (tmp_path / "chat.chat").exists()

--- a/python/jupyterlab-chat/jupyterlab_chat/websocket_model.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/websocket_model.py
@@ -84,29 +84,18 @@ class WsChatModel(BaseChatModel):
             except websocket.WebSocketClosedError:
                 pass
 
-    def broadcast_writing_status(self, user, status=None) -> None:
+    def broadcast_writing_status(self, user: User, status=None) -> None:
         """Broadcast an ephemeral writing status for ``user`` to all clients.
 
-        Not persisted to the ``.chat`` file. ``user`` may be a ``User`` or a
-        mapping (with at least ``username``); ``status`` is ``None`` (stopped) or
-        a mapping with optional ``messageID``/``typingIndicator``. The full user
-        object is included so recipients can display the writer without having
-        seen a message from them.
+        Not persisted to the ``.chat`` file. ``user`` is a :class:`User`;
+        ``status`` is ``None`` (stopped) or a mapping with optional
+        ``messageID``/``typingIndicator``. The full user object is included so
+        recipients can display the writer (and tell bots from humans via
+        ``user.bot``) without having seen a message from them.
         """
-        if isinstance(user, dict):
-            user_dict = user
-        else:
-            user_dict = {
-                "username": user.username,
-                "name": getattr(user, "name", None),
-                "display_name": getattr(user, "display_name", None),
-                "initials": getattr(user, "initials", None),
-                "color": getattr(user, "color", None),
-                "avatar_url": getattr(user, "avatar_url", None),
-            }
         payload: dict = {
             "type": "writing",
-            "user": user_dict,
+            "user": asdict(user),
             "state": status is not None,
         }
         if status:


### PR DESCRIPTION
## Summary

`broadcast_writing_status` hand-enumerated the writer's `User` fields when building the WS frame, which silently dropped `bot`. RTC-free clients then received a `writing` status whose `user.bot` was `undefined`.

Any consumer that distinguishes AI writers from humans via `user.bot` breaks: e.g. a stop/cancel button that enables only while an AI persona is writing (`chatModel.writers.some(w => w.user.bot)`) never enables, even though the backend `User(bot=True)` set it and the frontend (`IUser.bot`, `_onWsWriting`) passes the user through verbatim.

## Fix

`user` is always a `User` (a dataclass); no caller passed a dict. So:

- Require `user: User` (dropped the unused `Union[User, dict]` path).
- Serialize with `dataclasses.asdict(user)` instead of a hand-written field list, so **every** field -- including `bot`, and any added later -- survives the round trip. This removes the drift that caused the bug.

Adds a regression test asserting `bot` is preserved for both a bot and a human writer.

## Testing

`pytest jupyterlab_chat/tests` -- 68 passed, 2 skipped.

## Context

Surfaced by the jupyter-ai-persona-manager RTC-removal E2E matrix: the RTC-free (`WsChatModel`) leg's cancel-response test failed because the persona stop button never enabled. This fixes that transport. The RTC (`YChat`) transport has a separate gap -- `broadcast_writing_status` is still a no-op there -- tracked separately.