### PR TITLE
Announce the writing indicator to assistive technology

### DIFF
--- a/packages/jupyter-chat/src/__tests__/writing-indicator.spec.tsx
+++ b/packages/jupyter-chat/src/__tests__/writing-indicator.spec.tsx
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+import React, { act } from 'react';
+import { createRoot, Root } from 'react-dom/client';
+
+// React 18 asks test environments to declare themselves, otherwise every
+// `act` call warns.
+(
+  globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+import { WritingIndicator } from '../components/writing-indicator';
+import { IChatModel } from '../model';
+import { IUser } from '../types';
+
+const alice: IUser = { username: 'a', name: 'Alice', display_name: 'Alice' };
+
+const writer = (user: IUser, typingIndicator?: string): IChatModel.IWriter =>
+  ({ user, typingIndicator }) as IChatModel.IWriter;
+
+describe('WritingIndicator accessibility', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  const render = (writers: IChatModel.IWriter[]) => {
+    act(() => {
+      root.render(<WritingIndicator writers={writers} />);
+    });
+    return container.querySelector('.jp-chat-writers') as HTMLElement;
+  };
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it('is a polite live region, so a reply on its way is announced', () => {
+    // The indicator is the only signal that someone is replying. Without a
+    // live region it is visible text that assistive technology never speaks.
+    const el = render([]);
+    expect(el.getAttribute('role')).toBe('status');
+    expect(el.getAttribute('aria-live')).toBe('polite');
+  });
+
+  it('reads the whole phrase rather than a fragment of it', () => {
+    // Without aria-atomic, a change to part of the text can be announced on
+    // its own, so a reader hears a bare name with no context.
+    expect(render([]).getAttribute('aria-atomic')).toBe('true');
+  });
+
+  it('announces who is writing', () => {
+    expect(render([writer(alice)]).textContent).toContain('Alice is typing');
+  });
+
+  it('announces a custom indicator, not just a generic one', () => {
+    const el = render([writer(alice, 'is running `ripgrep`')]);
+    expect(el.textContent).toContain('Alice is running `ripgrep`');
+  });
+
+  it('says nothing when nobody is writing', () => {
+    // The container is always rendered to reserve space, and holds a
+    // non-breaking space as a placeholder. That placeholder must not be
+    // announced as if it were a message.
+    const text = (render([]).textContent ?? '').replace(/ /g, '').trim();
+    expect(text).toBe('');
+  });
+});

--- a/packages/jupyter-chat/src/components/writing-indicator.tsx
+++ b/packages/jupyter-chat/src/components/writing-indicator.tsx
@@ -92,6 +92,18 @@ export function WritingIndicator(
   return (
     <Box
       className={WRITERS_ELEMENT_CLASSNAME}
+      // The indicator already says something useful, "Alice is typing..." or
+      // "Jupyternaut is running `ripgrep`", but only on screen. Announcing it
+      // politely means a screen reader user learns a reply is coming without
+      // being interrupted mid-sentence.
+      //
+      // The region is the container rather than the text, so it is present in
+      // the accessibility tree before a writer appears and the change is
+      // announced. `aria-atomic` keeps the phrase together: without it a name
+      // change alone can be read out on its own, stripped of its context.
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
       sx={{
         ...props.sx,
         minHeight: '16px'


### PR DESCRIPTION
The writing indicator already says something useful. It reads "Alice is typing...", or when a writer supplies its own phrase, "Jupyternaut is running `ripgrep`". None of it reaches a screen reader, because the container is not a live region. So the only signal that a reply is on its way is visible text that is never spoken.

There are no live regions anywhere in the package today: no `aria-live`, `role="status"`, `role="log"`, `role="alert"` or `aria-atomic` across all 109 `.ts`/`.tsx` source files. This adds the one that matters most.

## The change

Three attributes on the existing container, no visual change and no new dependency.

**`role="status"` and `aria-live="polite"`.** Polite rather than assertive, because a reply arriving is not urgent enough to interrupt whatever the reader is part-way through hearing.

**On the container rather than the text**, so the region is in the accessibility tree before anyone starts writing. A live region created at the same moment its content appears is unreliable: some assistive technology only announces changes to regions it was already tracking.

**`aria-atomic="true"`**, so the phrase is read as a whole. Without it a change to part of the text can be announced on its own, and a reader hears a bare name with no indication of what it refers to. That is a real risk here, because the text is rebuilt as writers join and leave.

The placeholder is unaffected. The container still reserves its 16px, and the non-breaking space it holds when nobody is writing stays out of the accessibility tree, because the text is `visibility: hidden` in that state.

## Tests

Added `writing-indicator.spec.tsx`, covering the live-region attributes, the announced phrase in both the default and custom-indicator forms, and that the placeholder is not announced as if it were a message.

It uses React's own `act` and `createRoot` rather than a testing library, so **no new dependency**. I checked the two accessibility assertions genuinely fail without the change:

```
✕ is a polite live region, so a reply on its way is announced
    Expected: "status"   Received: null
✕ reads the whole phrase rather than a fragment of it
    Expected: "true"     Received: null
```

The other three pass either way, which is intentional: they are regression guards on behaviour this change must not alter.

Full package suite is green, **8 suites, 62 tests**. `build:lib` typechecks clean, eslint is clean on the component, and both files pass `prettier --check`.

## Scope

Deliberately narrow. The same package has other gaps worth looking at separately, most obviously that the message list is not marked up as a log, so newly arrived messages are not announced at all. I would rather land this small piece and discuss that one on its own than widen the change here. Happy to follow up if it would be useful.
