### PR TITLE
Backport #519 to 0.24.x: announce the writing indicator to assistive technology

### DIFF
--- a/packages/jupyter-chat/src/__tests__/writing-indicator.spec.tsx
+++ b/packages/jupyter-chat/src/__tests__/writing-indicator.spec.tsx
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+import React, { act } from 'react';
+import { createRoot, Root } from 'react-dom/client';
+
+// React 18 asks test environments to declare themselves, otherwise every
+// `act` call warns.
+(
+  globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+import { WritingIndicator } from '../components/writing-indicator';
+import { IChatModel } from '../model';
+import { IUser } from '../types';
+
+const alice: IUser = { username: 'a', name: 'Alice', display_name: 'Alice' };
+const bob: IUser = { username: 'b', name: 'Bob', display_name: 'Bob' };
+
+const writer = (user: IUser): IChatModel.IWriter =>
+  ({ user }) as IChatModel.IWriter;
+
+describe('WritingIndicator accessibility', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  const render = (writers: IChatModel.IWriter[]) => {
+    act(() => {
+      root.render(<WritingIndicator writers={writers} />);
+    });
+    return container.querySelector('.jp-chat-writers') as HTMLElement;
+  };
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it('is a polite live region, so a reply on its way is announced', () => {
+    // The indicator is the only signal that someone is replying. Without a
+    // live region it is visible text that assistive technology never speaks.
+    const el = render([]);
+    expect(el.getAttribute('role')).toBe('status');
+    expect(el.getAttribute('aria-live')).toBe('polite');
+  });
+
+  it('reads the whole phrase rather than a fragment of it', () => {
+    // Without aria-atomic, a change to part of the text can be announced on
+    // its own, so a reader hears a bare name with no context.
+    expect(render([]).getAttribute('aria-atomic')).toBe('true');
+  });
+
+  it('announces who is writing', () => {
+    expect(render([writer(alice)]).textContent).toContain('Alice is typing');
+  });
+
+  it('announces every writer, not just the first', () => {
+    const el = render([writer(alice), writer(bob)]);
+    expect(el.textContent).toContain('Alice');
+    expect(el.textContent).toContain('Bob');
+  });
+
+  it('says nothing when nobody is writing', () => {
+    // The container is always rendered to reserve space, and holds a
+    // non-breaking space as a placeholder. That placeholder must not be
+    // announced as if it were a message.
+    const text = (render([]).textContent ?? '').replace(/ /g, '').trim();
+    expect(text).toBe('');
+  });
+});

--- a/packages/jupyter-chat/src/components/writing-indicator.tsx
+++ b/packages/jupyter-chat/src/components/writing-indicator.tsx
@@ -76,6 +76,18 @@ export function WritingIndicator(
   return (
     <Box
       className={WRITERS_ELEMENT_CLASSNAME}
+      // The indicator already says something useful, "Alice is typing..." or
+      // "Jupyternaut is running `ripgrep`", but only on screen. Announcing it
+      // politely means a screen reader user learns a reply is coming without
+      // being interrupted mid-sentence.
+      //
+      // The region is the container rather than the text, so it is present in
+      // the accessibility tree before a writer appears and the change is
+      // announced. `aria-atomic` keeps the phrase together: without it a name
+      // change alone can be read out on its own, stripped of its context.
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
       sx={{
         ...props.sx,
         minHeight: '16px'


### PR DESCRIPTION
Backport of #519 to `0.24.x`, as @dlqqq suggested there.

To be clear about the motive: I do not need this in a release myself. `main` is prepping v0.25.0 with the RTC decoupling behind it, so the stable line could be waiting a while, and this seemed worth having there for people on it sooner rather than later.

## The component change is identical to #519

Three attributes on the existing container, no visual change, no new dependency. Cherry-picked cleanly, no conflicts.

## The test differs in exactly one case, and that is worth flagging

`main` asserts that a custom `typingIndicator` renders, "Jupyternaut is running `ripgrep`". **That feature does not exist on `0.24.x`**: `formatWritersText` here has no branch for it, and the component never reads it. The cherry-picked test therefore failed on this branch with:

```
● announces a custom indicator, not just a generic one
    Expected substring: "Alice is running `ripgrep`"
    Received string:    "Alice is typing..."
```

I replaced that one case with multiple-writer phrasing, which this branch does support. The other four are unchanged.

## Verification on this branch, not carried over from #519

- Full package suite green: **7 suites, 57 tests**
- `build:lib` typechecks clean
- `prettier --check` clean on both files
- The two accessibility assertions fail against the parent commit, so they are not vacuous:

```
✕ is a polite live region, so a reply on its way is announced
    Expected: "status"   Received: null
✕ reads the whole phrase rather than a fragment of it
    Expected: "true"     Received: null
```

The other three pass either way by design. They are regression guards on behaviour this must not alter.
