### PR TITLE
fix: avoid background tasks for synchronous YChat updates

### DIFF
--- a/python/jupyterlab-chat/jupyterlab_chat/tests/test_message_observer.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/tests/test_message_observer.py
@@ -5,6 +5,7 @@
 Covers ``observe_messages``/``unobserve_messages`` on both the WebSocket model
 (RTC-free) and the collaborative ``YChat``.
 """
+import asyncio
 from pathlib import Path
 from typing import List
 
@@ -115,8 +116,8 @@ def test_ws_observer_error_is_isolated(tmp_path: Path) -> None:
 # Collaborative model (YChat)
 # --------------------------------------------------------------------------
 def _insert_ymessage(chat: YChat, message: dict) -> None:
-    # raw_time=False avoids the server-timestamp reschedule (which uses an
-    # asyncio task) so the test stays synchronous.
+    # raw_time=False avoids the server-timestamp reschedule so the test stays
+    # synchronous.
     message.setdefault("raw_time", False)
     with chat._ydoc.transaction():
         chat._ymessages.append(Map(message))
@@ -150,3 +151,19 @@ def test_ychat_insert_classification_and_unobserve() -> None:
         chat, {"id": "m3", "body": "after", "time": 3.0, "sender": "human"}
     )
     assert "after" not in [e.message.body for e in events]
+
+
+@pytest.mark.asyncio
+async def test_ychat_timestamp_update_preserves_insert_event() -> None:
+    chat = YChat()
+    chat.set_id("test-chat")
+    chat.dirty = False
+    events: List[ChatMessageEvent] = []
+    chat.observe_messages(events.append)
+
+    chat.add_message(NewMessage(body="from human", sender="human"))
+    await asyncio.sleep(0)
+
+    assert len(events) == 1
+    assert events[0].message.body == "from human"
+    assert chat.get_messages()[0].raw_time is False

--- a/python/jupyterlab-chat/jupyterlab_chat/tests/test_ychat.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/tests/test_ychat.py
@@ -1,9 +1,13 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+import asyncio
 from dataclasses import asdict
-import pytest
+from unittest.mock import patch
 from uuid import uuid4
+
+import pytest
+
 from ..models import message_asdict_factory, Message, NewMessage, User
 from ..ychat import YChat
 from ..utils import find_mentions
@@ -38,6 +42,47 @@ def test_initialize_ychat():
     assert chat._get_messages() == []
     assert chat._get_users() == {}
     assert chat.get_metadata() == {}
+
+
+def test_create_id_updates_metadata_synchronously():
+    chat = YChat()
+
+    document_id = chat.create_id()
+
+    assert document_id == chat.get_id()
+
+
+@pytest.mark.asyncio
+async def test_initialize_creates_id_without_a_background_task():
+    chat = YChat()
+
+    with patch.object(chat, "create_task", side_effect=AssertionError):
+        chat.dirty = False
+    await asyncio.sleep(0)
+
+    assert chat.get_id() is not None
+    assert not chat._background_tasks
+
+
+@pytest.mark.asyncio
+async def test_raw_message_timestamp_is_updated_without_a_background_task():
+    chat = YChat()
+    chat.set_id("test-chat")
+    chat.dirty = False
+    timestamp = 123.0
+
+    with (
+        patch("jupyterlab_chat.ychat.time.time", return_value=timestamp),
+        patch.object(chat, "create_task", side_effect=AssertionError),
+    ):
+        chat.add_message(create_new_message())
+    await asyncio.sleep(0)
+
+    message = chat.get_messages()[0]
+    assert message.time == timestamp
+    assert message.raw_time is False
+    assert not chat._background_tasks
+
 
 def test_user_ignores_mention_name_ctor_arg():
     user = User(

--- a/python/jupyterlab-chat/jupyterlab_chat/ychat.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/ychat.py
@@ -64,6 +64,17 @@ class YChat(YBaseDoc, BaseChatModel):
         self._background_tasks.add(task)
         task.add_done_callback(self._background_tasks.discard)
 
+    @staticmethod
+    def _schedule_callback(callback: Callable[..., Any], *args: Any) -> None:
+        """Run a synchronous document update after the current YDoc event."""
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError as exc:
+            raise RuntimeError(
+                "YChat document updates require a running event loop"
+            ) from exc
+        loop.call_soon(callback, *args)
+
     @property
     def ymessages(self) -> Array:
         return self._ymessages
@@ -306,7 +317,7 @@ class YChat(YBaseDoc, BaseChatModel):
                 )
                 callback(ChatMessageEvent(action=action, message=message))
 
-    async def create_id(self) -> str:
+    def create_id(self) -> str:
         """
         Creates a new ID for the document.
         """
@@ -423,7 +434,7 @@ class YChat(YBaseDoc, BaseChatModel):
         if self.dirty:
             return
         if (self.get_id() is None):
-            self.create_task(self.create_id())
+            self._schedule_callback(self.create_id)
         if self._ystate_subscription is not None:
             self._ystate.unobserve(self._ystate_subscription)
             self._ystate_subscription = None
@@ -466,9 +477,9 @@ class YChat(YBaseDoc, BaseChatModel):
         for idx in range(index, index + inserted_count):
             message_dict = self._ymessages[idx]
             if message_dict and message_dict.get("raw_time", True):  # type:ignore[attr-defined]
-                self.create_task(self._set_timestamp(idx, timestamp))
+                self._schedule_callback(self._set_timestamp, idx, timestamp)
 
-    async def _set_timestamp(self, msg_idx: int, timestamp: float):
+    def _set_timestamp(self, msg_idx: int, timestamp: float) -> None:
         """
         Update the timestamp of a message and reinsert it at the correct position.
         """


### PR DESCRIPTION
Fixes #509

## Summary

- Keep `YChat.create_task()` available for genuine asynchronous extension work.
- Make the internal `create_id()` and `_set_timestamp()` updates synchronous.
- Schedule those document mutations on the next event-loop tick from YDoc observers.
- Add regression coverage for ID initialization, timestamp normalization, message observer delivery, and the absence of internal background tasks.

## Why

`create_id()` and `_set_timestamp()` do not await anything, so wrapping them in tracked background tasks adds unnecessary lifetime and scheduling overhead. Calling them directly from a YDoc observer is not safe, though: observer callbacks run inside a read-only transaction, and the write would fail. Deferring the synchronous callback by one event-loop tick preserves the transaction boundary without creating a task that retains the chat document.

## Testing

- `pytest -vv -r ap --cov` — 73 passed, 2 skipped (RTC integration tests)
- `mypy python/jupyterlab-chat` — passed
- `git diff --check` — passed