### PR TITLE
Add get_path() to server-side chat models

### DIFF
--- a/packages/jupyter-chat/src/model.ts
+++ b/packages/jupyter-chat/src/model.ts
@@ -34,6 +34,11 @@ import {
  */
 export interface IChatModel extends IDisposable {
   /**
+   * The unique id of the chat, when known. Implemented by `AbstractChatModel`.
+   */
+  id?: string;
+
+  /**
    * The chat model name.
    */
   name: string;
@@ -1000,6 +1005,10 @@ export namespace IChatModel {
  */
 export interface IChatContext {
   /**
+   * The unique id of the chat, when known.
+   */
+  readonly id?: string;
+  /**
    * The name of the chat.
    */
   readonly name: string;
@@ -1029,6 +1038,10 @@ export interface IChatContext {
 export abstract class AbstractChatContext implements IChatContext {
   constructor(options: { model: IChatModel }) {
     this._model = options.model;
+  }
+
+  get id(): string | undefined {
+    return this._model.id;
   }
 
   get name(): string {

--- a/packages/jupyterlab-chat/src/model.ts
+++ b/packages/jupyterlab-chat/src/model.ts
@@ -306,7 +306,9 @@ export class LabChatModel
       this._wsHandler.ready
         .then(() => {
           if (!this.id) {
-            this.id = UUID.uuid4();
+            // Prefer the server-assigned id (from the connection frame); fall
+            // back to a local id only for older servers that do not send one.
+            this.id = this._wsHandler!.chatId ?? UUID.uuid4();
           }
         })
         .catch(e => console.error('WS chat connection failed', e));

--- a/packages/jupyterlab-chat/src/websocket-handler.ts
+++ b/packages/jupyterlab-chat/src/websocket-handler.ts
@@ -102,6 +102,15 @@ export class WebSocketHandler {
     return this._ready.promise;
   }
 
+  /**
+   * The server-assigned chat id, received on the connection message. Available
+   * once `ready` has resolved; `undefined` against older servers that do not
+   * send it.
+   */
+  get chatId(): string | undefined {
+    return this._chatId;
+  }
+
   setPath(path: string): void {
     this._path = path;
   }
@@ -166,6 +175,7 @@ export class WebSocketHandler {
 
   private _handleMessage(data: any): void {
     if (data.type === 'connection') {
+      this._chatId = data.id as string | undefined;
       this._usersMap = (data.users as Record<string, IUser>) ?? {};
       this._usersChanged.emit(this._usersMap);
       for (const msg of (data.messages as any[]) ?? []) {
@@ -270,6 +280,7 @@ export class WebSocketHandler {
 
   private _path = '';
   private _disposed = false;
+  private _chatId: string | undefined;
   private _user: IUser | null = null;
   private _socket: WebSocket | null = null;
   private _serverSettings: ServerConnection.ISettings;

--- a/python/jupyterlab-chat/jupyterlab_chat/events.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/events.py
@@ -405,9 +405,11 @@ class ChatManager(LoggingConfigurable):
             collaboration = self._settings["jupyter_server_ydoc"]
             model = await collaboration.get_document(room_id=room_id, copy=False)
             if model is not None:
-                # Give the document its room id so get_path() can recover the
-                # file id (the room id's last ':'-delimited component).
+                # Record the room id (so get_path() can recover the file id) and
+                # the initial path, both taken from the room lifecycle event
+                # (self._room_to_path is populated from that event's `path`).
                 model.room_id = room_id
+                model.initial_path = self._room_to_path.get(room_id)
             return model
         except Exception as e:  # pragma: no cover - depends on RTC install
             self.log.warning("Could not resolve YChat for room %s: %s", room_id, e)

--- a/python/jupyterlab-chat/jupyterlab_chat/events.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/events.py
@@ -279,7 +279,9 @@ class ChatManager(LoggingConfigurable):
             if model is None:
                 continue
             # Deletion: the backing file is gone (via ContentsManager/filesystem).
-            if not (self._root_dir / path).exists():
+            # Use the model's live path so an in-band move (which updates the
+            # model's tracked path) is not mistaken for a deletion.
+            if not (self._root_dir / model.get_path()).exists():
                 self._free(path, ChatEventAction.DELETED)
                 continue
             # Inactivity: only applies to WS models we own the memory for. A
@@ -293,6 +295,8 @@ class ChatManager(LoggingConfigurable):
     def _free(self, path: str, action: ChatEventAction) -> Optional["BaseChatModel"]:
         model = self._models.pop(path, None)
         self._last_active.pop(path, None)
+        if isinstance(model, WsChatModel):
+            model.dispose()
         room_id = None
         for rid, p in list(self._room_to_path.items()):
             if p == path:
@@ -344,7 +348,11 @@ class ChatManager(LoggingConfigurable):
     def _get_or_create_ws(self, path: str) -> "WsChatModel":
         model = self._models.get(path)
         if model is None:
-            model = WsChatModel(path=path, root_dir=self._root_dir)
+            model = WsChatModel(
+                path=path,
+                root_dir=self._root_dir,
+                event_logger=self._event_logger,
+            )
             model.load_from_file()
             self._models[path] = model
             self._last_active[path] = time.time()

--- a/python/jupyterlab-chat/jupyterlab_chat/events.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/events.py
@@ -403,7 +403,12 @@ class ChatManager(LoggingConfigurable):
         RTC provider is installed."""
         try:
             collaboration = self._settings["jupyter_server_ydoc"]
-            return await collaboration.get_document(room_id=room_id, copy=False)
+            model = await collaboration.get_document(room_id=room_id, copy=False)
+            if model is not None:
+                # Give the document its room id so get_path() can recover the
+                # file id (the room id's last ':'-delimited component).
+                model.room_id = room_id
+            return model
         except Exception as e:  # pragma: no cover - depends on RTC install
             self.log.warning("Could not resolve YChat for room %s: %s", room_id, e)
             return None

--- a/python/jupyterlab-chat/jupyterlab_chat/models.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/models.py
@@ -281,9 +281,6 @@ class BaseChatModel(ABC):
     def get_path(self) -> str:
         """Return the path of the file backing this chat model, relative to
         ``ContentsManager.root_dir``.
-
-        This is a stopgap until ``WsChatModel`` and the collaborative model
-        expose paths uniformly (see jupyterlab/jupyter-chat#522).
         """
         ...
 

--- a/python/jupyterlab-chat/jupyterlab_chat/models.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/models.py
@@ -274,7 +274,8 @@ class BaseChatModel(ABC):
     """
 
     @abstractmethod
-    def get_id(self) -> Optional[str]:
+    def get_id(self) -> str:
+        """Return the stable unique id of this chat. Always a string."""
         ...
 
     @abstractmethod

--- a/python/jupyterlab-chat/jupyterlab_chat/models.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/models.py
@@ -278,6 +278,16 @@ class BaseChatModel(ABC):
         ...
 
     @abstractmethod
+    def get_path(self) -> str:
+        """Return the path of the file backing this chat model, relative to
+        ``ContentsManager.root_dir``.
+
+        This is a stopgap until ``WsChatModel`` and the collaborative model
+        expose paths uniformly (see jupyterlab/jupyter-chat#522).
+        """
+        ...
+
+    @abstractmethod
     def get_message(self, id: str) -> Optional[Message]:
         ...
 

--- a/python/jupyterlab-chat/jupyterlab_chat/tests/test_events.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/tests/test_events.py
@@ -3,9 +3,11 @@
 """Unit tests for jupyterlab_chat.events.ChatManager (WebSocket path)."""
 import asyncio
 import time
+from pathlib import Path
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, cast
 
+import jupyter_server
 from jupyter_events import EventLogger
 
 from jupyterlab_chat.events import ChatManager
@@ -16,8 +18,21 @@ if TYPE_CHECKING:
     from jupyter_server.serverapp import ServerApp
 
 
-def _make_manager(tmp_path, capture):
+def _event_logger() -> EventLogger:
+    """An EventLogger with the ContentsManager schema registered, matching a
+    real server (so freeing a WsChatModel can remove its contents listener)."""
     logger = EventLogger()
+    logger.register_event_schema(
+        Path(jupyter_server.__file__).parent
+        / "event_schemas"
+        / "contents_service"
+        / "v1.yaml"
+    )
+    return logger
+
+
+def _make_manager(tmp_path, capture):
+    logger = _event_logger()
     settings = {"event_logger": logger, "server_root_dir": str(tmp_path)}
     serverapp = cast(
         "ServerApp", SimpleNamespace(web_app=SimpleNamespace(settings=settings))
@@ -190,7 +205,7 @@ def test_client_connected_and_disconnected_events(tmp_path):
     async def run():
         events: list = []
 
-        logger = EventLogger()
+        logger = _event_logger()
         settings = {"event_logger": logger, "server_root_dir": str(tmp_path)}
         serverapp = cast(
             "ServerApp",

--- a/python/jupyterlab-chat/jupyterlab_chat/tests/test_get_path.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/tests/test_get_path.py
@@ -44,3 +44,11 @@ def test_ychat_get_path(jp_serverapp):
     os.rename(root / "sub" / "chat.chat", root / "moved" / "chat.chat")
     fim.move("sub/chat.chat", "moved/chat.chat")
     assert chat.get_path() == "moved/chat.chat"
+
+
+def test_ychat_get_path_falls_back_to_initial_path():
+    # With no resolvable room id / File ID service, get_path() returns the
+    # initial_path recorded when the room was created.
+    chat = YChat()
+    chat.initial_path = "sub/chat.chat"
+    assert chat.get_path() == "sub/chat.chat"

--- a/python/jupyterlab-chat/jupyterlab_chat/tests/test_get_path.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/tests/test_get_path.py
@@ -1,0 +1,37 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+"""Tests for ``BaseChatModel.get_path()`` on both transports."""
+
+from unittest.mock import Mock
+
+from jupyterlab_chat.websocket_model import WsChatModel
+from jupyterlab_chat.ychat import YChat
+
+
+def test_ws_chat_model_get_path(tmp_path):
+    model = WsChatModel(path="sub/chat.chat", root_dir=tmp_path)
+    assert model.get_path() == "sub/chat.chat"
+
+
+def test_ychat_get_path_falls_back_to_shared_state():
+    # No running server (and no File ID service): get_path() returns the
+    # root-relative path recorded in the shared document state.
+    chat = YChat()
+    chat.path = "sub/chat.chat"
+    assert chat.get_path() == "sub/chat.chat"
+
+
+def test_ychat_get_path_prefers_file_id_service(monkeypatch):
+    # When a File ID service is available, the live path is resolved from the
+    # stable file id, so the path follows the file across moves/renames.
+    chat = YChat()
+    chat.path = "old/chat.chat"
+
+    fake_fim = Mock()
+    fake_fim.get_id.return_value = "file-1"
+    fake_fim.get_path.return_value = "new/chat.chat"
+    monkeypatch.setattr(YChat, "_get_file_id_manager", staticmethod(lambda: fake_fim))
+
+    assert chat.get_path() == "new/chat.chat"
+    fake_fim.get_id.assert_called_once_with("old/chat.chat")
+    fake_fim.get_path.assert_called_once_with("file-1")

--- a/python/jupyterlab-chat/jupyterlab_chat/tests/test_get_path.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/tests/test_get_path.py
@@ -2,10 +2,20 @@
 # Distributed under the terms of the Modified BSD License.
 """Tests for ``BaseChatModel.get_path()`` on both transports."""
 
-from unittest.mock import Mock
+from pathlib import Path
+
+import pytest
 
 from jupyterlab_chat.websocket_model import WsChatModel
 from jupyterlab_chat.ychat import YChat
+
+
+@pytest.fixture
+def jp_server_config():
+    # Enable the File ID service, so the server registers a ``file_id_manager``
+    # in its web app settings. This mirrors an RTC deployment, where
+    # jupyter-collaboration pulls in ``jupyter_server_fileid``.
+    return {"ServerApp": {"jpserver_extensions": {"jupyter_server_fileid": True}}}
 
 
 def test_ws_chat_model_get_path(tmp_path):
@@ -13,25 +23,15 @@ def test_ws_chat_model_get_path(tmp_path):
     assert model.get_path() == "sub/chat.chat"
 
 
-def test_ychat_get_path_falls_back_to_shared_state():
-    # No running server (and no File ID service): get_path() returns the
-    # root-relative path recorded in the shared document state.
+def test_ychat_get_path(jp_serverapp):
+    """With a running server whose File ID service is enabled, ``get_path()``
+    returns the chat's path relative to the ContentsManager root."""
+    assert jp_serverapp.web_app.settings.get("file_id_manager") is not None
+
+    root = Path(jp_serverapp.root_dir)
+    (root / "sub").mkdir(parents=True, exist_ok=True)
+    (root / "sub" / "chat.chat").write_text("{}")
+
     chat = YChat()
     chat.path = "sub/chat.chat"
     assert chat.get_path() == "sub/chat.chat"
-
-
-def test_ychat_get_path_prefers_file_id_service(monkeypatch):
-    # When a File ID service is available, the live path is resolved from the
-    # stable file id, so the path follows the file across moves/renames.
-    chat = YChat()
-    chat.path = "old/chat.chat"
-
-    fake_fim = Mock()
-    fake_fim.get_id.return_value = "file-1"
-    fake_fim.get_path.return_value = "new/chat.chat"
-    monkeypatch.setattr(YChat, "_get_file_id_manager", staticmethod(lambda: fake_fim))
-
-    assert chat.get_path() == "new/chat.chat"
-    fake_fim.get_id.assert_called_once_with("old/chat.chat")
-    fake_fim.get_path.assert_called_once_with("file-1")

--- a/python/jupyterlab-chat/jupyterlab_chat/tests/test_get_path.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/tests/test_get_path.py
@@ -2,6 +2,7 @@
 # Distributed under the terms of the Modified BSD License.
 """Tests for ``BaseChatModel.get_path()`` on both transports."""
 
+import os
 from pathlib import Path
 
 import pytest
@@ -25,13 +26,21 @@ def test_ws_chat_model_get_path(tmp_path):
 
 def test_ychat_get_path(jp_serverapp):
     """With a running server whose File ID service is enabled, ``get_path()``
-    returns the chat's path relative to the ContentsManager root."""
-    assert jp_serverapp.web_app.settings.get("file_id_manager") is not None
+    resolves the file id from the room id and returns the file's current path,
+    following it across an in-band move."""
+    fim = jp_serverapp.web_app.settings["file_id_manager"]
 
     root = Path(jp_serverapp.root_dir)
     (root / "sub").mkdir(parents=True, exist_ok=True)
     (root / "sub" / "chat.chat").write_text("{}")
+    file_id = fim.index("sub/chat.chat")
 
     chat = YChat()
-    chat.path = "sub/chat.chat"
+    chat.room_id = f"text:chat:{file_id}"
     assert chat.get_path() == "sub/chat.chat"
+
+    # After an in-band move, get_path() follows the file via its stable id.
+    (root / "moved").mkdir()
+    os.rename(root / "sub" / "chat.chat", root / "moved" / "chat.chat")
+    fim.move("sub/chat.chat", "moved/chat.chat")
+    assert chat.get_path() == "moved/chat.chat"

--- a/python/jupyterlab-chat/jupyterlab_chat/tests/test_ws_move_tracking.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/tests/test_ws_move_tracking.py
@@ -13,19 +13,8 @@ def test_get_id_is_a_stable_str(tmp_path):
     model = WsChatModel(path="chat.chat", root_dir=tmp_path)
     chat_id = model.get_id()
     assert isinstance(chat_id, str) and chat_id
-    # Stable across calls.
+    # Stable across calls (for the lifetime of the model instance).
     assert model.get_id() == chat_id
-
-
-def test_id_persists_across_reload(tmp_path):
-    model = WsChatModel(path="chat.chat", root_dir=tmp_path)
-    model.save()
-    chat_id = model.get_id()
-
-    # A fresh model loading the same file adopts the persisted id.
-    reloaded = WsChatModel(path="chat.chat", root_dir=tmp_path)
-    reloaded.load_from_file()
-    assert reloaded.get_id() == chat_id
 
 
 @pytest.mark.asyncio
@@ -79,4 +68,4 @@ def test_moved_model_saves_to_new_path(tmp_path):
     assert (tmp_path / "moved.chat").exists()
     assert not (tmp_path / "chat.chat").exists()
     saved = json.loads((tmp_path / "moved.chat").read_text())
-    assert saved["metadata"]["id"] == model.get_id()
+    assert saved["messages"] == []

--- a/python/jupyterlab-chat/jupyterlab_chat/tests/test_ws_move_tracking.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/tests/test_ws_move_tracking.py
@@ -1,0 +1,82 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+"""Tests for WsChatModel stable id and in-band move tracking."""
+
+import json
+
+import pytest
+
+from jupyterlab_chat.websocket_model import WsChatModel
+
+
+def test_get_id_is_a_stable_str(tmp_path):
+    model = WsChatModel(path="chat.chat", root_dir=tmp_path)
+    chat_id = model.get_id()
+    assert isinstance(chat_id, str) and chat_id
+    # Stable across calls.
+    assert model.get_id() == chat_id
+
+
+def test_id_persists_across_reload(tmp_path):
+    model = WsChatModel(path="chat.chat", root_dir=tmp_path)
+    model.save()
+    chat_id = model.get_id()
+
+    # A fresh model loading the same file adopts the persisted id.
+    reloaded = WsChatModel(path="chat.chat", root_dir=tmp_path)
+    reloaded.load_from_file()
+    assert reloaded.get_id() == chat_id
+
+
+@pytest.mark.asyncio
+async def test_rename_event_updates_path(tmp_path):
+    model = WsChatModel(path="chat.chat", root_dir=tmp_path)
+    await model._on_contents_event(
+        None,
+        "contents_service/v1",
+        {"action": "rename", "source_path": "chat.chat", "path": "moved.chat"},
+    )
+    assert model.get_path() == "moved.chat"
+
+
+@pytest.mark.asyncio
+async def test_directory_rename_updates_nested_path(tmp_path):
+    model = WsChatModel(path="dir/chat.chat", root_dir=tmp_path)
+    await model._on_contents_event(
+        None,
+        "contents_service/v1",
+        {"action": "rename", "source_path": "dir", "path": "renamed"},
+    )
+    assert model.get_path() == "renamed/chat.chat"
+
+
+@pytest.mark.asyncio
+async def test_unrelated_rename_leaves_path(tmp_path):
+    model = WsChatModel(path="chat.chat", root_dir=tmp_path)
+    await model._on_contents_event(
+        None,
+        "contents_service/v1",
+        {"action": "rename", "source_path": "other.txt", "path": "renamed.txt"},
+    )
+    assert model.get_path() == "chat.chat"
+
+
+@pytest.mark.asyncio
+async def test_non_rename_action_ignored(tmp_path):
+    model = WsChatModel(path="chat.chat", root_dir=tmp_path)
+    await model._on_contents_event(
+        None, "contents_service/v1", {"action": "save", "path": "chat.chat"}
+    )
+    assert model.get_path() == "chat.chat"
+
+
+def test_moved_model_saves_to_new_path(tmp_path):
+    """After a move, save() writes at the new path (and not the old one)."""
+    model = WsChatModel(path="chat.chat", root_dir=tmp_path)
+    model.path = "moved.chat"  # simulate the post-move tracked path
+    model.save()
+
+    assert (tmp_path / "moved.chat").exists()
+    assert not (tmp_path / "chat.chat").exists()
+    saved = json.loads((tmp_path / "moved.chat").read_text())
+    assert saved["metadata"]["id"] == model.get_id()

--- a/python/jupyterlab-chat/jupyterlab_chat/tests/test_ychat.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/tests/test_ychat.py
@@ -53,35 +53,29 @@ def test_create_id_updates_metadata_synchronously():
 
 
 @pytest.mark.asyncio
-async def test_initialize_creates_id_without_a_background_task():
+async def test_initialize_creates_id():
     chat = YChat()
 
-    with patch.object(chat, "create_task", side_effect=AssertionError):
-        chat.dirty = False
+    chat.dirty = False
     await asyncio.sleep(0)
 
-    assert chat.get_id() is not None
-    assert not chat._background_tasks
+    assert chat._ymetadata.get("id") is not None
 
 
 @pytest.mark.asyncio
-async def test_raw_message_timestamp_is_updated_without_a_background_task():
+async def test_raw_message_timestamp_is_updated():
     chat = YChat()
     chat.set_id("test-chat")
     chat.dirty = False
     timestamp = 123.0
 
-    with (
-        patch("jupyterlab_chat.ychat.time.time", return_value=timestamp),
-        patch.object(chat, "create_task", side_effect=AssertionError),
-    ):
+    with patch("jupyterlab_chat.ychat.time.time", return_value=timestamp):
         chat.add_message(create_new_message())
     await asyncio.sleep(0)
 
     message = chat.get_messages()[0]
     assert message.time == timestamp
     assert message.raw_time is False
-    assert not chat._background_tasks
 
 
 def test_user_ignores_mention_name_ctor_arg():

--- a/python/jupyterlab-chat/jupyterlab_chat/websocket_handler.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/websocket_handler.py
@@ -110,6 +110,7 @@ class WSChatHandler(JupyterHandler, websocket.WebSocketHandler):
         self.write_message(json.dumps({
             "type": "connection",
             "client_id": self._client_id,
+            "id": model.get_id(),
             "messages": [model.resolve_message(m) for m in model._messages],
             "users": model._users,
         }))

--- a/python/jupyterlab-chat/jupyterlab_chat/websocket_model.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/websocket_model.py
@@ -59,9 +59,6 @@ class WsChatModel(BaseChatModel):
         self._attachments: Dict[str, dict] = {}
         self._metadata: Dict[str, object] = {}
         self._message_observers: List[MessageObserverCallback] = []
-        # A random id assigned once per model instance. Not persisted to the
-        # chat file: no consumer needs it to be stable across reloads.
-        self._id = uuid.uuid4().hex
 
         # Track in-band moves: a rename via the ContentsManager updates our
         # tracked path, so subsequent saves go to the file's new location. This
@@ -97,6 +94,10 @@ class WsChatModel(BaseChatModel):
             self._metadata = content.get("metadata", {})
         except (FileNotFoundError, json.JSONDecodeError):
             self._metadata = {}
+        # A stable id lives in the chat file's metadata (same as the
+        # collaborative model). Generate one if the file has none yet; it is
+        # persisted on the next save.
+        self._metadata.setdefault("id", uuid.uuid4().hex)
         self._indexes_by_id = {m["id"]: i for i, m in enumerate(self._messages) if "id" in m}
 
     def save(self) -> None:
@@ -150,7 +151,9 @@ class WsChatModel(BaseChatModel):
     # ------------------------------------------------------------------
 
     def get_id(self) -> str:
-        return self._id
+        # The id is stored in the chat file's metadata (same as the
+        # collaborative model). Create one lazily if it does not exist yet.
+        return self._metadata.setdefault("id", uuid.uuid4().hex)  # type: ignore[return-value]
 
     def get_path(self) -> str:
         # The WebSocket model does not use file IDs; its path is tracked

--- a/python/jupyterlab-chat/jupyterlab_chat/websocket_model.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/websocket_model.py
@@ -58,11 +58,11 @@ class WsChatModel(BaseChatModel):
         self._indexes_by_id: dict[str, int] = {}
         self._users: Dict[str, dict] = {}
         self._attachments: Dict[str, dict] = {}
-        # Stable id assigned once. Persisted in the chat file's metadata, so it
-        # survives reloads and in-band moves (the file carries it to the new
-        # path). ``load_from_file`` adopts a persisted id if the file has one.
-        self._metadata: Dict[str, object] = {"id": uuid.uuid4().hex}
+        self._metadata: Dict[str, object] = {}
         self._message_observers: List[MessageObserverCallback] = []
+        # A random id assigned once per model instance. Not persisted to the
+        # chat file: no consumer needs it to be stable across reloads.
+        self._id = uuid.uuid4().hex
 
         # Track in-band moves: a rename via the ContentsManager updates our
         # tracked path, so subsequent saves go to the file's new location. This
@@ -89,7 +89,6 @@ class WsChatModel(BaseChatModel):
 
     def load_from_file(self) -> None:
         full_path = self.root_dir / self.path
-        existing_id = self._metadata.get("id")
         try:
             with open(full_path) as f:
                 content = json.load(f)
@@ -99,10 +98,6 @@ class WsChatModel(BaseChatModel):
             self._metadata = content.get("metadata", {})
         except (FileNotFoundError, json.JSONDecodeError):
             self._metadata = {}
-        # Guarantee a stable id: adopt the file's persisted id if present,
-        # otherwise keep the id assigned at construction.
-        if not self._metadata.get("id"):
-            self._metadata["id"] = existing_id or uuid.uuid4().hex
         self._indexes_by_id = {m["id"]: i for i, m in enumerate(self._messages) if "id" in m}
 
     def save(self) -> None:
@@ -156,7 +151,7 @@ class WsChatModel(BaseChatModel):
     # ------------------------------------------------------------------
 
     def get_id(self) -> str:
-        return self._metadata["id"]  # type: ignore[return-value]
+        return self._id
 
     def get_path(self) -> str:
         # The WebSocket model does not use file IDs; its path is tracked

--- a/python/jupyterlab-chat/jupyterlab_chat/websocket_model.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/websocket_model.py
@@ -125,6 +125,11 @@ class WsChatModel(BaseChatModel):
     def get_id(self) -> Optional[str]:
         return self._metadata.get("id")  # type: ignore[return-value]
 
+    def get_path(self) -> str:
+        # The WebSocket model does not use file IDs; its path is fixed at
+        # construction and is already relative to the ContentsManager root.
+        return self.path
+
     def get_message(self, id: str) -> Optional[Message]:
         idx = self._indexes_by_id.get(id)
         if idx is None:

--- a/python/jupyterlab-chat/jupyterlab_chat/websocket_model.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/websocket_model.py
@@ -7,8 +7,10 @@ import time
 import uuid
 from dataclasses import asdict
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Union
 
+from jupyter_events import EventLogger
+from jupyter_server.services.contents.manager import ContentsManager
 from tornado import websocket
 
 from .models import (
@@ -25,16 +27,12 @@ from .models import (
     message_asdict_factory,
 )
 
-if TYPE_CHECKING:
-    from jupyter_events import EventLogger
-
 _log = logging.getLogger(__name__)
 
-#: Jupyter Server ContentsManager event schema. The manager emits a ``rename``
-#: action (with ``source_path`` and ``path``) on in-band moves/renames.
-CONTENTS_EVENT_SCHEMA_ID = (
-    "https://events.jupyter.org/jupyter_server/contents_service/v1"
-)
+#: Jupyter Server ContentsManager event schema id. The manager emits a
+#: ``rename`` action (with ``source_path`` and ``path``) on in-band
+#: moves/renames.
+CONTENTS_EVENT_SCHEMA_ID = ContentsManager.event_schema_id
 
 
 class WsChatModel(BaseChatModel):
@@ -49,7 +47,7 @@ class WsChatModel(BaseChatModel):
         self,
         path: str,
         root_dir: Path,
-        event_logger: Optional["EventLogger"] = None,
+        event_logger: Optional[EventLogger] = None,
     ):
         self.path = path
         self.root_dir = root_dir

--- a/python/jupyterlab-chat/jupyterlab_chat/websocket_model.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/websocket_model.py
@@ -3,7 +3,7 @@
 
 import json
 import logging
-import posixpath
+import os
 import time
 import uuid
 from dataclasses import asdict
@@ -172,10 +172,10 @@ class WsChatModel(BaseChatModel):
             return
         if self.path == source:
             self._on_path_change(dest)
-        elif posixpath.commonpath((source, self.path)) == source:
+        elif os.path.commonpath((source, self.path)) == source:
             # `self.path` is nested under the renamed directory `source`.
             self._on_path_change(
-                posixpath.join(dest, posixpath.relpath(self.path, source))
+                os.path.join(dest, os.path.relpath(self.path, source))
             )
 
     def _on_path_change(self, new_path: str) -> None:

--- a/python/jupyterlab-chat/jupyterlab_chat/websocket_model.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/websocket_model.py
@@ -3,7 +3,7 @@
 
 import json
 import logging
-import os
+import posixpath
 import time
 import uuid
 from dataclasses import asdict
@@ -172,8 +172,11 @@ class WsChatModel(BaseChatModel):
             return
         if self.path == source:
             self._on_path_change(dest)
-        elif self.path.startswith(f"{source}/"):
-            self._on_path_change(os.path.join(dest, os.path.relpath(self.path, source)))
+        elif posixpath.commonpath((source, self.path)) == source:
+            # `self.path` is nested under the renamed directory `source`.
+            self._on_path_change(
+                posixpath.join(dest, posixpath.relpath(self.path, source))
+            )
 
     def _on_path_change(self, new_path: str) -> None:
         """Point the model at ``new_path`` (the file's new location)."""

--- a/python/jupyterlab-chat/jupyterlab_chat/websocket_model.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/websocket_model.py
@@ -7,7 +7,7 @@ import time
 import uuid
 from dataclasses import asdict
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
 
 from tornado import websocket
 
@@ -25,7 +25,16 @@ from .models import (
     message_asdict_factory,
 )
 
+if TYPE_CHECKING:
+    from jupyter_events import EventLogger
+
 _log = logging.getLogger(__name__)
+
+#: Jupyter Server ContentsManager event schema. The manager emits a ``rename``
+#: action (with ``source_path`` and ``path``) on in-band moves/renames.
+CONTENTS_EVENT_SCHEMA_ID = (
+    "https://events.jupyter.org/jupyter_server/contents_service/v1"
+)
 
 
 class WsChatModel(BaseChatModel):
@@ -36,7 +45,12 @@ class WsChatModel(BaseChatModel):
     to the collaborative (YChat) backend.
     """
 
-    def __init__(self, path: str, root_dir: Path):
+    def __init__(
+        self,
+        path: str,
+        root_dir: Path,
+        event_logger: Optional["EventLogger"] = None,
+    ):
         self.path = path
         self.root_dir = root_dir
         self.handlers: Dict[str, websocket.WebSocketHandler] = {}
@@ -44,8 +58,22 @@ class WsChatModel(BaseChatModel):
         self._indexes_by_id: dict[str, int] = {}
         self._users: Dict[str, dict] = {}
         self._attachments: Dict[str, dict] = {}
-        self._metadata: Dict[str, object] = {}
+        # Stable id assigned once. Persisted in the chat file's metadata, so it
+        # survives reloads and in-band moves (the file carries it to the new
+        # path). ``load_from_file`` adopts a persisted id if the file has one.
+        self._metadata: Dict[str, object] = {"id": uuid.uuid4().hex}
         self._message_observers: List[MessageObserverCallback] = []
+
+        # Track in-band moves: a rename via the ContentsManager updates our
+        # tracked path, so subsequent saves go to the file's new location. This
+        # does not observe out-of-band moves (e.g. `mv` in a terminal), which do
+        # not go through the ContentsManager.
+        self._event_logger = event_logger
+        if event_logger is not None:
+            event_logger.add_listener(
+                schema_id=CONTENTS_EVENT_SCHEMA_ID,
+                listener=self._on_contents_event,
+            )
 
     # ------------------------------------------------------------------
     # Room-level helpers
@@ -61,6 +89,7 @@ class WsChatModel(BaseChatModel):
 
     def load_from_file(self) -> None:
         full_path = self.root_dir / self.path
+        existing_id = self._metadata.get("id")
         try:
             with open(full_path) as f:
                 content = json.load(f)
@@ -69,7 +98,11 @@ class WsChatModel(BaseChatModel):
             self._attachments = content.get("attachments", {})
             self._metadata = content.get("metadata", {})
         except (FileNotFoundError, json.JSONDecodeError):
-            self._metadata = {"id": uuid.uuid4().hex}
+            self._metadata = {}
+        # Guarantee a stable id: adopt the file's persisted id if present,
+        # otherwise keep the id assigned at construction.
+        if not self._metadata.get("id"):
+            self._metadata["id"] = existing_id or uuid.uuid4().hex
         self._indexes_by_id = {m["id"]: i for i, m in enumerate(self._messages) if "id" in m}
 
     def save(self) -> None:
@@ -122,13 +155,59 @@ class WsChatModel(BaseChatModel):
     # BaseChatModel implementation
     # ------------------------------------------------------------------
 
-    def get_id(self) -> Optional[str]:
-        return self._metadata.get("id")  # type: ignore[return-value]
+    def get_id(self) -> str:
+        return self._metadata["id"]  # type: ignore[return-value]
 
     def get_path(self) -> str:
-        # The WebSocket model does not use file IDs; its path is fixed at
-        # construction and is already relative to the ContentsManager root.
+        # The WebSocket model does not use file IDs; its path is tracked
+        # in-process and kept current on in-band moves (see _on_contents_event).
         return self.path
+
+    async def _on_contents_event(self, logger, schema_id: str, data: dict) -> None:
+        """Update ``self.path`` when the backing file is moved in-band.
+
+        Handles both an exact file rename and the rename of an ancestor
+        directory. Only ContentsManager (REST/API) operations emit these events;
+        out-of-band moves are not observed.
+        """
+        if data.get("action") != "rename":
+            return
+        source = data.get("source_path")
+        dest = data.get("path")
+        if not source or not dest:
+            return
+        new_path = self._relocated_path(self.path, source, dest)
+        if new_path is not None and new_path != self.path:
+            _log.info("Chat file moved: '%s' -> '%s'", self.path, new_path)
+            self.path = new_path
+
+    @staticmethod
+    def _relocated_path(current: str, source: str, dest: str) -> Optional[str]:
+        """Return the path ``current`` maps to when ``source`` is renamed to
+        ``dest``, or ``None`` if ``current`` is unaffected.
+
+        Covers an exact file rename (``current == source``) and the rename of an
+        ancestor directory (``current`` nested under ``source``).
+        """
+        if current == source:
+            return dest
+        prefix = source + "/"
+        if current.startswith(prefix):
+            return dest + "/" + current[len(prefix):]
+        return None
+
+    def dispose(self) -> None:
+        """Release resources held by the model. Removes the ContentsManager
+        event listener so it does not outlive the model."""
+        if self._event_logger is not None:
+            try:
+                self._event_logger.remove_listener(
+                    schema_id=CONTENTS_EVENT_SCHEMA_ID,
+                    listener=self._on_contents_event,
+                )
+            except Exception:  # pragma: no cover - defensive
+                pass
+            self._event_logger = None
 
     def get_message(self, id: str) -> Optional[Message]:
         idx = self._indexes_by_id.get(id)

--- a/python/jupyterlab-chat/jupyterlab_chat/websocket_model.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/websocket_model.py
@@ -3,6 +3,7 @@
 
 import json
 import logging
+import os
 import time
 import uuid
 from dataclasses import asdict
@@ -157,11 +158,11 @@ class WsChatModel(BaseChatModel):
         return self.path
 
     async def _on_contents_event(self, logger, schema_id: str, data: dict) -> None:
-        """Update ``self.path`` when the backing file is moved in-band.
+        """Update the tracked path when the backing file is moved in-band.
 
-        Handles both an exact file rename and the rename of an ancestor
-        directory. Only ContentsManager (REST/API) operations emit these events;
-        out-of-band moves are not observed.
+        Calls :meth:`_on_path_change` when the rename affects this file directly
+        or renames one of its ancestor directories. Only ContentsManager
+        (REST/API) operations emit these events; out-of-band moves are not seen.
         """
         if data.get("action") != "rename":
             return
@@ -169,38 +170,24 @@ class WsChatModel(BaseChatModel):
         dest = data.get("path")
         if not source or not dest:
             return
-        new_path = self._relocated_path(self.path, source, dest)
-        if new_path is not None and new_path != self.path:
+        if self.path == source:
+            self._on_path_change(dest)
+        elif self.path.startswith(f"{source}/"):
+            self._on_path_change(os.path.join(dest, os.path.relpath(self.path, source)))
+
+    def _on_path_change(self, new_path: str) -> None:
+        """Point the model at ``new_path`` (the file's new location)."""
+        if new_path != self.path:
             _log.info("Chat file moved: '%s' -> '%s'", self.path, new_path)
             self.path = new_path
 
-    @staticmethod
-    def _relocated_path(current: str, source: str, dest: str) -> Optional[str]:
-        """Return the path ``current`` maps to when ``source`` is renamed to
-        ``dest``, or ``None`` if ``current`` is unaffected.
-
-        Covers an exact file rename (``current == source``) and the rename of an
-        ancestor directory (``current`` nested under ``source``).
-        """
-        if current == source:
-            return dest
-        prefix = source + "/"
-        if current.startswith(prefix):
-            return dest + "/" + current[len(prefix):]
-        return None
-
     def dispose(self) -> None:
-        """Release resources held by the model. Removes the ContentsManager
-        event listener so it does not outlive the model."""
+        """Remove the ContentsManager event listener when the model is freed."""
         if self._event_logger is not None:
-            try:
-                self._event_logger.remove_listener(
-                    schema_id=CONTENTS_EVENT_SCHEMA_ID,
-                    listener=self._on_contents_event,
-                )
-            except Exception:  # pragma: no cover - defensive
-                pass
-            self._event_logger = None
+            self._event_logger.remove_listener(
+                schema_id=CONTENTS_EVENT_SCHEMA_ID,
+                listener=self._on_contents_event,
+            )
 
     def get_message(self, id: str) -> Optional[Message]:
         idx = self._indexes_by_id.get(id)

--- a/python/jupyterlab-chat/jupyterlab_chat/ychat.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/ychat.py
@@ -393,6 +393,50 @@ class YChat(YBaseDoc, BaseChatModel):
         with self._ydoc.transaction():
             self._ymetadata.update({"id": id})
 
+    def get_path(self) -> str:
+        """Return the chat file path relative to ``ContentsManager.root_dir``.
+
+        The collaborative model records its root-relative path in the shared
+        document state. When the File ID service is available it is preferred to
+        resolve the live path, so the path follows the file across moves and
+        renames. The File ID service is always installed when RTC is enabled,
+        but this method does not assume ``jupyter_server_fileid`` is present:
+        without it, the path recorded in the shared state is returned as-is.
+        """
+        path = self.path
+        file_id_manager = self._get_file_id_manager()
+        if file_id_manager is not None and path is not None:
+            file_id = file_id_manager.get_id(path)
+            if file_id:
+                resolved = file_id_manager.get_path(file_id)
+                if resolved:
+                    return resolved
+        if path is None:
+            raise ValueError(
+                "This YChat has no path recorded in its shared document state."
+            )
+        return path
+
+    @staticmethod
+    def _get_file_id_manager() -> Optional[Any]:
+        """Best-effort reference to the server's File ID manager.
+
+        Returns ``None`` when there is no running server or when
+        ``jupyter_server_fileid`` is not installed (the manager is only
+        registered in the server settings by that extension). Never raises.
+        """
+        try:
+            from jupyter_server.serverapp import ServerApp
+
+            if not ServerApp.initialized():
+                return None
+            web_app = getattr(ServerApp.instance(), "web_app", None)
+            if web_app is None:
+                return None
+            return web_app.settings.get("file_id_manager")
+        except Exception:  # pragma: no cover - defensive
+            return None
+
     def get(self) -> str:
         """
         Returns the contents of the document.

--- a/python/jupyterlab-chat/jupyterlab_chat/ychat.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/ychat.py
@@ -380,11 +380,14 @@ class YChat(YBaseDoc, BaseChatModel):
         self.set_id(id)
         return id
 
-    def get_id(self) -> Optional[str]:
+    def get_id(self) -> str:
         """
-        Returns the ID of the document.
+        Returns the ID of the document, creating one if it does not exist yet.
         """
-        return self._ymetadata.get("id", None)
+        existing = self._ymetadata.get("id", None)
+        if existing:
+            return existing
+        return self.create_id()
 
     def set_id(self, id: str) -> None:
         """
@@ -532,7 +535,10 @@ class YChat(YBaseDoc, BaseChatModel):
         """
         if self.dirty:
             return
-        if (self.get_id() is None):
+        # Read the raw metadata rather than get_id(): get_id() lazily creates an
+        # id, and this observer runs inside a read-only transaction where writes
+        # are forbidden. The (deferred) create_id below performs the write.
+        if self._ymetadata.get("id", None) is None:
             self._schedule_callback(self.create_id)
         if self._ystate_subscription is not None:
             self._ystate.unobserve(self._ystate_subscription)

--- a/python/jupyterlab-chat/jupyterlab_chat/ychat.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/ychat.py
@@ -9,7 +9,7 @@ import time
 import asyncio
 from functools import partial
 from jupyter_ydoc.ybasedoc import YBaseDoc
-from typing import Any, Callable, Optional, Set, Union
+from typing import Any, Callable, Optional, Union
 from uuid import uuid4
 from pycrdt import Array, ArrayEvent, Map, MapEvent, Subscription
 
@@ -40,7 +40,6 @@ WRITERS_AWARENESS_KEY = "writers"
 class YChat(YBaseDoc, BaseChatModel):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._background_tasks: Set[asyncio.Task] = set()
         self.dirty = True
         # The RTC room id ("{format}:{type}:{file_id}"), set by whoever resolves
         # this document (e.g. the ChatManager). Used by get_path() to recover
@@ -74,11 +73,6 @@ class YChat(YBaseDoc, BaseChatModel):
         :rtype: str
         """
         return "1.0.0"
-
-    def create_task(self, coro):
-        task = asyncio.create_task(coro)
-        self._background_tasks.add(task)
-        task.add_done_callback(self._background_tasks.discard)
 
     @staticmethod
     def _schedule_callback(callback: Callable[..., Any], *args: Any) -> None:

--- a/python/jupyterlab-chat/jupyterlab_chat/ychat.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/ychat.py
@@ -42,6 +42,10 @@ class YChat(YBaseDoc, BaseChatModel):
         super().__init__(*args, **kwargs)
         self._background_tasks: Set[asyncio.Task] = set()
         self.dirty = True
+        # The RTC room id ("{format}:{type}:{file_id}"), set by whoever resolves
+        # this document (e.g. the ChatManager). Used by get_path() to recover
+        # the file id. `None` when the chat was not resolved through a room.
+        self.room_id: Optional[str] = None
         self._ydoc["users"] = self._yusers = Map()  # type:ignore[var-annotated]
         self._ydoc["messages"] = self._ymessages = Array()  # type:ignore[var-annotated]
         self._ydoc["attachments"] = self._yattachments = Map()  # type:ignore[var-annotated]
@@ -399,21 +403,23 @@ class YChat(YBaseDoc, BaseChatModel):
     def get_path(self) -> str:
         """Return the chat file path relative to ``ContentsManager.root_dir``.
 
-        The collaborative model records its root-relative path in the shared
-        document state. When the File ID service is available it is preferred to
-        resolve the live path, so the path follows the file across moves and
-        renames. The File ID service is always installed when RTC is enabled,
-        but this method does not assume ``jupyter_server_fileid`` is present:
-        without it, the path recorded in the shared state is returned as-is.
+        When this chat's ``room_id`` is known, the file id is its last
+        ``:``-delimited component (room ids have the form
+        ``{format}:{type}:{file_id}``), and the live path is resolved from the
+        File ID service so it follows the file across moves and renames. The
+        File ID service is always installed when RTC is enabled, but this method
+        does not assume ``jupyter_server_fileid`` is present: without a room id
+        or a File ID service, the path recorded in the shared document state is
+        returned as-is.
         """
-        path = self.path
-        file_id_manager = self._get_file_id_manager()
-        if file_id_manager is not None and path is not None:
-            file_id = file_id_manager.get_id(path)
-            if file_id:
+        if self.room_id:
+            file_id = self.room_id.split(":")[-1]
+            file_id_manager = self._get_file_id_manager()
+            if file_id_manager is not None:
                 resolved = file_id_manager.get_path(file_id)
                 if resolved:
                     return resolved
+        path = self.path
         if path is None:
             raise ValueError(
                 "This YChat has no path recorded in its shared document state."

--- a/python/jupyterlab-chat/jupyterlab_chat/ychat.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/ychat.py
@@ -41,10 +41,13 @@ class YChat(YBaseDoc, BaseChatModel):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.dirty = True
-        # The RTC room id ("{format}:{type}:{file_id}"), set by whoever resolves
-        # this document (e.g. the ChatManager). Used by get_path() to recover
-        # the file id. `None` when the chat was not resolved through a room.
+        # Set by whoever resolves this document (e.g. the ChatManager) from the
+        # collaboration room lifecycle event, which carries both fields. The
+        # room id ("{format}:{type}:{file_id}") lets get_path() recover the file
+        # id; initial_path is the path recorded when the room was created and is
+        # used as a fallback. Both are None until the chat is resolved.
         self.room_id: Optional[str] = None
+        self.initial_path: Optional[str] = None
         self._ydoc["users"] = self._yusers = Map()  # type:ignore[var-annotated]
         self._ydoc["messages"] = self._ymessages = Array()  # type:ignore[var-annotated]
         self._ydoc["attachments"] = self._yattachments = Map()  # type:ignore[var-annotated]
@@ -397,14 +400,14 @@ class YChat(YBaseDoc, BaseChatModel):
     def get_path(self) -> str:
         """Return the chat file path relative to ``ContentsManager.root_dir``.
 
-        When this chat's ``room_id`` is known, the file id is its last
-        ``:``-delimited component (room ids have the form
-        ``{format}:{type}:{file_id}``), and the live path is resolved from the
-        File ID service so it follows the file across moves and renames. The
-        File ID service is always installed when RTC is enabled, but this method
-        does not assume ``jupyter_server_fileid`` is present: without a room id
-        or a File ID service, the path recorded in the shared document state is
-        returned as-is.
+        Resolves the live path from the file id encoded in ``room_id`` (its last
+        ``:``-delimited component) via the File ID service, so the path follows
+        the file across moves and renames. Falls back to ``initial_path`` (the
+        path recorded when the room was created) when there is no room id / File
+        ID service, or the id cannot be resolved. Both ``room_id`` and
+        ``initial_path`` are set by the resolver (e.g. the ChatManager) from the
+        collaboration room lifecycle event; this method does not rely on the
+        shared-state ``path``, which not every RTC provider sets.
         """
         if self.room_id:
             file_id = self.room_id.split(":")[-1]
@@ -413,12 +416,12 @@ class YChat(YBaseDoc, BaseChatModel):
                 resolved = file_id_manager.get_path(file_id)
                 if resolved:
                     return resolved
-        path = self.path
-        if path is None:
+        if self.initial_path is None:
             raise ValueError(
-                "This YChat has no path recorded in its shared document state."
+                "This YChat has no path: neither a resolvable room id nor an "
+                "initial_path has been recorded."
             )
-        return path
+        return self.initial_path
 
     @staticmethod
     def _get_file_id_manager() -> Optional[Any]:

--- a/python/jupyterlab-chat/pyproject.toml
+++ b/python/jupyterlab-chat/pyproject.toml
@@ -49,6 +49,7 @@ test = [
     "pytest-asyncio",
     "pytest-cov",
     "pytest-jupyter[server]>=0.6.0",
+    "jupyter_server_fileid>=0.9.0",
 ]
 
 [project.urls]

--- a/python/jupyterlab-chat/pyproject.toml
+++ b/python/jupyterlab-chat/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
 ]
 dependencies = [
     "jupyter_server>=2.0.1,<3",
+    "jupyter_events>=0.6.0",
     "jupyter_ydoc>=3.0.0,<5.0.0",
     "pycrdt>=0.12.48,<0.15.0",
 ]

--- a/ui-tests/tests/chat-file-moved.spec.ts
+++ b/ui-tests/tests/chat-file-moved.spec.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+import { expect, test } from '@jupyterlab/galata';
+
+import { openChat } from './test-utils';
+
+const OLD_PATH = 'chat-file-moved.chat';
+const NEW_PATH = 'chat-file-moved-renamed.chat';
+const MSG1 = 'first message';
+const MSG2 = 'second message';
+
+/**
+ * Read and parse a .chat file from disk via the ContentsManager.
+ */
+const readChat = async (page: any, path: string): Promise<any> => {
+  return page.evaluate(async (p: string) => {
+    const model = await window.jupyterapp.serviceManager.contents.get(p, {
+      content: true,
+      type: 'file',
+      format: 'text'
+    });
+    return JSON.parse(model.content);
+  }, path);
+};
+
+const sendInto = async (panel: any, content: string) => {
+  const input = panel.locator('.jp-chat-input-container').getByRole('combobox');
+  await input.pressSequentially(content);
+  await panel.locator('.jp-chat-input-container .jp-chat-send-button').click();
+};
+
+test.describe('#chatFileMoved', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.filebrowser.contents.uploadContent('{}', 'text', OLD_PATH);
+  });
+
+  test.afterEach(async ({ page }) => {
+    for (const path of [OLD_PATH, NEW_PATH]) {
+      if (await page.filebrowser.contents.fileExists(path)) {
+        await page.filebrowser.contents.deleteFile(path);
+      }
+    }
+  });
+
+  test('should follow an in-band move and keep working', async ({ page }) => {
+    // 1. Send the first message in the new chat.
+    const chatPanel = await openChat(page, OLD_PATH);
+    await sendInto(chatPanel, MSG1);
+    await expect(
+      chatPanel.locator('.jp-chat-messages-container .jp-chat-message')
+    ).toHaveCount(1);
+
+    // 2. It is saved to disk at the current (old) path.
+    await page.waitForCondition(async () => {
+      const content = await readChat(page, OLD_PATH);
+      return content.messages?.length === 1;
+    });
+    const beforeMove = await readChat(page, OLD_PATH);
+    expect(beforeMove.messages[0].body).toBe(MSG1);
+
+    // 3. Move the chat via the ContentsManager (in-band, NOT an out-of-band mv).
+    await page.evaluate(
+      async ({ oldPath, newPath }) => {
+        await window.jupyterapp.serviceManager.contents.rename(
+          oldPath,
+          newPath
+        );
+      },
+      { oldPath: OLD_PATH, newPath: NEW_PATH }
+    );
+
+    // 4. Send another message; the chat still works and shows both messages.
+    const movedPanel = await openChat(page, NEW_PATH);
+    await sendInto(movedPanel, MSG2);
+    await expect(
+      movedPanel.locator('.jp-chat-messages-container .jp-chat-message')
+    ).toHaveCount(2);
+
+    // 5. Nothing is (re)created at the old path: the file is gone.
+    expect(await page.filebrowser.contents.fileExists(OLD_PATH)).toBe(false);
+
+    // 6. Both messages are persisted at the new path.
+    await page.waitForCondition(async () => {
+      const content = await readChat(page, NEW_PATH);
+      return content.messages?.length === 2;
+    });
+    const afterMove = await readChat(page, NEW_PATH);
+    const bodies = afterMove.messages.map((m: any) => m.body);
+    expect(bodies).toContain(MSG1);
+    expect(bodies).toContain(MSG2);
+  });
+});


### PR DESCRIPTION
Fixes #524

## Summary
Adds a required `BaseChatModel.get_path()` that returns the chat file's path relative to `ContentsManager.root_dir`, so consumers can locate the backing file without reaching into transport-specific internals.

`WsChatModel` returns its path directly (it does not use file IDs yet). `YChat` prefers the File ID service so the path follows the file across moves and renames, and falls back to the path recorded in the shared document state.

## Technical details
`get_path()` does not assume `jupyter_server_fileid` is installed: `YChat` looks the manager up from the running server's settings only when it is present (it always is when RTC is enabled), and otherwise returns the shared-state path. This is a stopgap until #522 has `WsChatModel` track paths through file IDs too.

## Testing
Unit tests for both transports, including that `YChat` resolves through the File ID service when one is available.