### PR TITLE
Make `chat_id` a reliable identifier for every chat

### DIFF
--- a/docs/jupyter-chat-example/src/index.ts
+++ b/docs/jupyter-chat-example/src/index.ts
@@ -52,7 +52,8 @@ class ChatContext extends AbstractChatContext {
 class MyChatModel extends AbstractChatModel {
   constructor(options: IChatModel.IOptions) {
     super(options);
-    this.setReady();
+    // This example model has no backend; give it a stable client-side id.
+    this.setReady(UUID.uuid4());
   }
 
   sendMessage(newMessage: INewMessage): string | null {

--- a/packages/jupyter-chat/src/model.ts
+++ b/packages/jupyter-chat/src/model.ts
@@ -1011,9 +1011,11 @@ export namespace IChatModel {
  */
 export interface IChatContext {
   /**
-   * The unique id of the chat, when known.
+   * The chat's stable id. Always available: a chat context is only created once
+   * the model is `ready`, at which point the id is guaranteed to be set (and to
+   * match the backend's `chat.get_id()`).
    */
-  readonly id?: string;
+  readonly id: string;
   /**
    * The name of the chat.
    */
@@ -1046,8 +1048,17 @@ export abstract class AbstractChatContext implements IChatContext {
     this._model = options.model;
   }
 
-  get id(): string | undefined {
-    return this._model.id;
+  get id(): string {
+    // A chat context is only created once the model is ready (see the
+    // AbstractChatModel constructor), so the model's id is guaranteed set here.
+    const id = this._model.id;
+    if (id === undefined) {
+      throw new Error(
+        'IChatContext.id was read before the model was ready; ' +
+          'a chat context must only be created after `model.ready`.'
+      );
+    }
+    return id;
   }
 
   get name(): string {

--- a/packages/jupyter-chat/src/model.ts
+++ b/packages/jupyter-chat/src/model.ts
@@ -54,9 +54,11 @@ export interface IChatModel extends IDisposable {
   unreadMessages: number[];
 
   /**
-   * The promise resolving when the model is ready.
+   * A promise that resolves, once the model is ready, with the chat's stable
+   * id. The id matches the backend's `chat.get_id()` and is guaranteed to be
+   * available (and never change) from this point on.
    */
-  readonly ready: Promise<void>;
+  readonly ready: Promise<string>;
 
   /**
    * The awareness channel of the underlying shared document, when the chat is
@@ -314,7 +316,7 @@ export abstract class AbstractChatModel implements IChatModel {
     this._selectionWatcher = options.selectionWatcher ?? null;
     this._documentManager = options.documentManager ?? null;
 
-    this._readyDelegate = new PromiseDelegate<void>();
+    this._readyDelegate = new PromiseDelegate<string>();
 
     this.ready.then(() => {
       this._inputModel.chatContext = this.createChatContext();
@@ -422,17 +424,21 @@ export abstract class AbstractChatModel implements IChatModel {
   }
 
   /**
-   * Promise that resolves when the model is ready.
+   * Promise that resolves, when the model is ready, with the chat's stable id.
    */
-  get ready(): Promise<void> {
+  get ready(): Promise<string> {
     return this._readyDelegate.promise;
   }
 
   /**
-   * Set the model as ready.
+   * Mark the model as ready, resolving `ready` with the chat's stable id.
+   *
+   * The id must match the backend's `chat.get_id()`; callers pass the
+   * server-authoritative id (WebSocket connection frame, or the synchronized
+   * shared-document metadata under RTC).
    */
-  protected setReady(): void {
-    this._readyDelegate.resolve();
+  protected setReady(id: string): void {
+    this._readyDelegate.resolve(id);
   }
 
   /**
@@ -881,7 +887,7 @@ export abstract class AbstractChatModel implements IChatModel {
   private _name: string = '';
   private _config: IConfig;
   protected _trans: TranslationBundle;
-  private _readyDelegate = new PromiseDelegate<void>();
+  private _readyDelegate = new PromiseDelegate<string>();
   private _inputModel: IInputModel;
   private _disposed = new Signal<IChatModel, void>(this);
   private _isDisposed = false;

--- a/packages/jupyterlab-chat/src/model.ts
+++ b/packages/jupyterlab-chat/src/model.ts
@@ -281,7 +281,7 @@ export class LabChatModel
   set id(value: string | undefined) {
     super.id = value;
     if (value) {
-      this.setReady();
+      this.setReady(value);
     }
   }
 
@@ -306,9 +306,18 @@ export class LabChatModel
       this._wsHandler.ready
         .then(() => {
           if (!this.id) {
-            // Prefer the server-assigned id (from the connection frame); fall
-            // back to a local id only for older servers that do not send one.
-            this.id = this._wsHandler!.chatId ?? UUID.uuid4();
+            // The server is the single source of truth for the chat id: it is
+            // delivered in the WS connection frame (from `chat.get_id()`). We do
+            // NOT mint a local id, so `model.id` always matches the backend.
+            const serverId = this._wsHandler!.chatId;
+            if (serverId) {
+              this.id = serverId;
+            } else {
+              console.error(
+                'WS chat connection frame did not include a chat id; ' +
+                  'the chat cannot become ready. Is the server up to date?'
+              );
+            }
           }
         })
         .catch(e => console.error('WS chat connection failed', e));

--- a/python/jupyterlab-chat/jupyterlab_chat/__init__.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/__init__.py
@@ -63,7 +63,7 @@ def _load_jupyter_server_extension(server_app):
 
     # Create the transport-agnostic chat manager (event bus + model registry +
     # memory management). Under RTC it forwards jupyter_collaboration room events;
-    # under WebSocket it backs the WS handler (owns ``ws_chat_models``).
+    # under WebSocket it backs the WS handler (owns ``chats_by_id``).
     from .chat_manager import ChatManager
 
     chat_manager = ChatManager(server_app, rtc_enabled=rtc_info.enabled)

--- a/python/jupyterlab-chat/jupyterlab_chat/__init__.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/__init__.py
@@ -64,7 +64,7 @@ def _load_jupyter_server_extension(server_app):
     # Create the transport-agnostic chat manager (event bus + model registry +
     # memory management). Under RTC it forwards jupyter_collaboration room events;
     # under WebSocket it backs the WS handler (owns ``ws_chat_models``).
-    from .events import ChatManager
+    from .chat_manager import ChatManager
 
     chat_manager = ChatManager(server_app, rtc_enabled=rtc_info.enabled)
     server_app.web_app.settings["chat_manager"] = chat_manager

--- a/python/jupyterlab-chat/jupyterlab_chat/chat_manager.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/chat_manager.py
@@ -160,15 +160,14 @@ class ChatManager(LoggingConfigurable):
     # ------------------------------------------------------------------
     # Responsibility 2 -- model access
     # ------------------------------------------------------------------
-    def get(self, query: str) -> Optional["BaseChatModel"]:
-        """Return the live model for a path (or a room id, when RTC is available).
+    def get(self, path: str) -> Optional["BaseChatModel"]:
+        """Return the live model for a chat ``path``, or ``None`` if not live.
 
         Synchronous: an open chat is always already cached (we cache before
-        emitting ``opened``). Returns ``None`` if the chat is not currently live.
+        emitting ``opened``). ``path`` is the canonical key stamped on every
+        lifecycle event; a room id is an RTC transport detail and is never a
+        valid key here.
         """
-        path = self._resolve_path(query)
-        if path is None:
-            return None
         return self._models.get(path)
 
     async def create(self, path: str) -> Optional["BaseChatModel"]:
@@ -183,18 +182,6 @@ class ChatManager(LoggingConfigurable):
         if self._rtc_enabled:
             return await self._resolve_ychat_by_path(path)
         return self._get_or_create_ws(path)
-
-    def _resolve_path(self, query: str) -> Optional[str]:
-        if query in self._models:
-            return query
-        if query in self._room_to_path:
-            return self._room_to_path[query]
-        # A room id ("{fmt}:{type}:{id}") is only meaningful under RTC, and only
-        # resolvable if we have seen its ``opened`` event. We do not depend on a
-        # fileIdManager here; an unknown room id resolves to None.
-        if _looks_like_room_id(query):
-            return None
-        return query  # treat as a path
 
     # ------------------------------------------------------------------
     # Responsibility 3 -- memory management
@@ -367,9 +354,3 @@ class ChatManager(LoggingConfigurable):
         if model is not None:
             self._models[path] = model
         return model
-
-
-def _looks_like_room_id(query: str) -> bool:
-    """Heuristic: RTC room ids have the form ``{file_format}:{file_type}:{file_id}``.
-    A ``.chat`` path never contains ':' on the platforms we support."""
-    return query.count(":") >= 2

--- a/python/jupyterlab-chat/jupyterlab_chat/chat_manager.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/chat_manager.py
@@ -72,13 +72,13 @@ class ChatManager(LoggingConfigurable):
 
         # Live chat models keyed by their stable chat id (``chat.get_id()``) --
         # the only stable identifier of a chat (paths change on rename; room ids
-        # exist only under RTC). ``_last_active`` is keyed the same way.
-        self._models: dict[str, "BaseChatModel"] = {}
-        self._last_active: dict[str, float] = {}
+        # exist only under RTC). ``_last_activity_by_id`` is keyed the same way.
+        self._chats_by_id: dict[str, "BaseChatModel"] = {}
+        self._last_activity_by_id: dict[str, float] = {}
 
-        # Exposed for server-side consumers under the legacy ``ws_chat_models``
-        # settings key. Same dict object as ``_models`` -- now keyed by chat id.
-        self._settings["ws_chat_models"] = self._models
+        # Exposed for server-side consumers under the ``chats_by_id`` settings key
+        # (same dict object as ``_chats_by_id``), keyed by the stable chat id.
+        self._settings["chats_by_id"] = self._chats_by_id
 
         self._register_schema()
         if rtc_enabled:
@@ -173,7 +173,7 @@ class ChatManager(LoggingConfigurable):
         event, so consumers already have it. (Paths change on rename and room ids
         exist only under RTC, so neither is a reliable key.)
         """
-        return self._models.get(chat_id)
+        return self._chats_by_id.get(chat_id)
 
     async def create(self, path: str) -> Optional["BaseChatModel"]:
         """Async get-or-create by ``path`` (the WS connection parameter).
@@ -193,7 +193,7 @@ class ChatManager(LoggingConfigurable):
         the handful of live chats). Uses ``get_path()`` so a renamed chat is
         matched by its current path, never a stale key."""
         return next(
-            (m for m in self._models.values() if m.get_path() == path), None
+            (m for m in self._chats_by_id.values() if m.get_path() == path), None
         )
 
     # ------------------------------------------------------------------
@@ -201,8 +201,8 @@ class ChatManager(LoggingConfigurable):
     # ------------------------------------------------------------------
     def _poll(self) -> None:
         now = time.time()
-        for chat_id in list(self._models.keys()):
-            model = self._models.get(chat_id)
+        for chat_id in list(self._chats_by_id.keys()):
+            model = self._chats_by_id.get(chat_id)
             if model is None:
                 continue
             # Deletion: the backing file is gone (via ContentsManager/filesystem).
@@ -215,13 +215,13 @@ class ChatManager(LoggingConfigurable):
             # connected client keeps the chat alive.
             if isinstance(model, WsChatModel):
                 if model.handlers:
-                    self._last_active[chat_id] = now
-                elif now - self._last_active.get(chat_id, now) > self.inactivity_timeout_s:
+                    self._last_activity_by_id[chat_id] = now
+                elif now - self._last_activity_by_id.get(chat_id, now) > self.inactivity_timeout_s:
                     self._free(chat_id, ChatEventAction.CLOSED)
 
     def _free(self, chat_id: str, action: ChatEventAction) -> Optional["BaseChatModel"]:
-        model = self._models.pop(chat_id, None)
-        self._last_active.pop(chat_id, None)
+        model = self._chats_by_id.pop(chat_id, None)
+        self._last_activity_by_id.pop(chat_id, None)
         if model is None:
             return None
         if isinstance(model, WsChatModel):
@@ -245,11 +245,11 @@ class ChatManager(LoggingConfigurable):
         (on first creation) emit ``opened``. Returns the model; the caller reads
         ``model.get_id()`` for the stable chat id."""
         model = self._get_or_create_ws(path)
-        self._last_active[model.get_id()] = time.time()
+        self._last_activity_by_id[model.get_id()] = time.time()
         return model
 
     def ws_activity(self, chat_id: str) -> None:
-        self._last_active[chat_id] = time.time()
+        self._last_activity_by_id[chat_id] = time.time()
 
     def ws_client_gone(self, chat_id: str) -> None:
         # The last client for this chat has disconnected. Free the model now
@@ -258,7 +258,7 @@ class ChatManager(LoggingConfigurable):
         # the writer stops. Freeing here -- rather than reloading from disk on the
         # next open -- is what keeps a reopened chat consistent without having to
         # handle out-of-band file changes.
-        self._last_active[chat_id] = time.time()
+        self._last_activity_by_id[chat_id] = time.time()
         if not self._has_active_writers(chat_id):
             self._free(chat_id, ChatEventAction.CLOSED)
 
@@ -289,8 +289,8 @@ class ChatManager(LoggingConfigurable):
         )
         model.load_from_file()
         chat_id = model.get_id()
-        self._models[chat_id] = model
-        self._last_active[chat_id] = time.time()
+        self._chats_by_id[chat_id] = model
+        self._last_activity_by_id[chat_id] = time.time()
         self._emit_event(
             ChatEvent(
                 path=path,
@@ -336,8 +336,8 @@ class ChatManager(LoggingConfigurable):
                 )
                 return
             chat_id = model.get_id()
-            self._models[chat_id] = model
-            self._last_active[chat_id] = time.time()
+            self._chats_by_id[chat_id] = model
+            self._last_activity_by_id[chat_id] = time.time()
             self._emit_event(
                 ChatEvent(
                     path=path,

--- a/python/jupyterlab-chat/jupyterlab_chat/chat_manager.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/chat_manager.py
@@ -71,7 +71,6 @@ class ChatManager(LoggingConfigurable):
         self._rtc_enabled = rtc_enabled
 
         self._models: dict[str, "BaseChatModel"] = {}
-        self._room_to_path: dict[str, str] = {}
         self._last_active: dict[str, float] = {}
 
         # Single source of truth for the WS handler (supersedes the ad-hoc
@@ -185,16 +184,18 @@ class ChatManager(LoggingConfigurable):
         return self._models.get(path)
 
     async def create(self, path: str) -> Optional["BaseChatModel"]:
-        """Async get-or-create. Resolves+caches if already open, otherwise
-        instantiates the model (WS: ``WsChatModel`` + ``load_from_file``; RTC:
-        resolve the ``YChat``). Creating an empty chat when the file is missing
-        is expected behavior for WS.
+        """Async get-or-create.
+
+        WS: get-or-create a ``WsChatModel`` (loading from disk; creating an empty
+        chat when the file is missing is expected). RTC: an ``opened`` room event
+        creates and caches the ``YChat``, so this only returns an already-live
+        model and does not create one on demand.
         """
         model = self._models.get(path)
         if model is not None:
             return model
         if self._rtc_enabled:
-            return await self._resolve_ychat_by_path(path)
+            return None
         return self._get_or_create_ws(path)
 
     # ------------------------------------------------------------------
@@ -223,9 +224,6 @@ class ChatManager(LoggingConfigurable):
     def _free(self, path: str, action: ChatEventAction) -> Optional["BaseChatModel"]:
         model = self._models.pop(path, None)
         self._last_active.pop(path, None)
-        for rid, p in list(self._room_to_path.items()):
-            if p == path:
-                del self._room_to_path[rid]
         if model is None:
             return None
         # Capture the stable chat id before disposing: close/delete events fire
@@ -322,12 +320,11 @@ class ChatManager(LoggingConfigurable):
         if len(parts) < 2 or parts[1] != "chat" or not path:
             return
         if action == "initialize":
-            self._room_to_path[room] = path
             self._last_active[path] = time.time()
             # Resolve the YChat: `get_document` loads the file content into the
             # doc before returning, so `get_id()` reads the persisted metadata id
             # (never mints a premature one that could conflict with disk).
-            model = await self._resolve_ychat(room)
+            model = await self._resolve_ychat(room, initial_path=path)
             if model is None:
                 # No usable chat without a resolved model; do not emit an
                 # `opened` event that could not carry a chat_id.
@@ -347,7 +344,7 @@ class ChatManager(LoggingConfigurable):
         elif action == "clean":
             self._free(path, ChatEventAction.CLOSED)
 
-    async def _resolve_ychat(self, room_id: str):
+    async def _resolve_ychat(self, room_id: str, initial_path: str):
         """Resolve the ``YChat`` for a room via jupyter_collaboration. Mirrors
         jupyter-ai-router's approach; guarded because the APIs only exist when an
         RTC provider is installed."""
@@ -356,23 +353,11 @@ class ChatManager(LoggingConfigurable):
             model = await collaboration.get_document(room_id=room_id, copy=False)
             if model is not None:
                 # Record the room id (so get_path() can recover the file id) and
-                # the initial path, both taken from the room lifecycle event
-                # (self._room_to_path is populated from that event's `path`).
+                # the initial path, both taken from the room lifecycle event.
                 # `room_id` is an RTC transport detail kept internal to YChat.
                 model.room_id = room_id
-                model.initial_path = self._room_to_path.get(room_id)
+                model.initial_path = initial_path
             return model
         except Exception as e:  # pragma: no cover - depends on RTC install
             self.log.warning("Could not resolve YChat for room %s: %s", room_id, e)
             return None
-
-    async def _resolve_ychat_by_path(self, path: str):
-        room_id = next(
-            (rid for rid, p in self._room_to_path.items() if p == path), None
-        )
-        if room_id is None:
-            return None
-        model = await self._resolve_ychat(room_id)
-        if model is not None:
-            self._models[path] = model
-        return model

--- a/python/jupyterlab-chat/jupyterlab_chat/chat_manager.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/chat_manager.py
@@ -136,23 +136,37 @@ class ChatManager(LoggingConfigurable):
         return model.get_id() if model is not None else None
 
     def on_client_connect(self, path: str, client_id: str) -> None:
-        """Callback invoked upon WebSocket client connection. Emits an event."""
+        """Callback invoked upon WebSocket client connection. Emits an event.
+
+        A live model is guaranteed here (the handler calls ``ws_open`` first), so
+        the event always carries a ``chat_id``; the guard is purely defensive.
+        """
+        chat_id = self._chat_id_for(path)
+        if chat_id is None:
+            return
         self._emit_event(
             ChatEvent(
                 path=path,
                 action=ChatEventAction.CLIENT_CONNECTED,
-                chat_id=self._chat_id_for(path),
+                chat_id=chat_id,
                 client_id=client_id,
             )
         )
 
     def on_client_disconnect(self, path: str, client_id: str) -> None:
-        """Callback invoked upon WebSocket client disconnection. Emits an event."""
+        """Callback invoked upon WebSocket client disconnection. Emits an event.
+
+        Fires before the model is freed, so the model is still live and the event
+        always carries a ``chat_id``; the guard is purely defensive.
+        """
+        chat_id = self._chat_id_for(path)
+        if chat_id is None:
+            return
         self._emit_event(
             ChatEvent(
                 path=path,
                 action=ChatEventAction.CLIENT_DISCONNECTED,
-                chat_id=self._chat_id_for(path),
+                chat_id=chat_id,
                 client_id=client_id,
             )
         )
@@ -209,16 +223,17 @@ class ChatManager(LoggingConfigurable):
     def _free(self, path: str, action: ChatEventAction) -> Optional["BaseChatModel"]:
         model = self._models.pop(path, None)
         self._last_active.pop(path, None)
-        # Capture the stable chat id before disposing: close/delete events fire
-        # after the model is freed, so this is the last chance to read it.
-        chat_id = model.get_id() if model is not None else None
-        if isinstance(model, WsChatModel):
-            model.dispose()
         for rid, p in list(self._room_to_path.items()):
             if p == path:
                 del self._room_to_path[rid]
-        if model is not None:
-            self._emit_event(ChatEvent(path=path, action=action, chat_id=chat_id))
+        if model is None:
+            return None
+        # Capture the stable chat id before disposing: close/delete events fire
+        # after the model is freed, so this is the last chance to read it.
+        chat_id = model.get_id()
+        if isinstance(model, WsChatModel):
+            model.dispose()
+        self._emit_event(ChatEvent(path=path, action=action, chat_id=chat_id))
         return model
 
     def stop(self) -> None:
@@ -313,13 +328,20 @@ class ChatManager(LoggingConfigurable):
             # doc before returning, so `get_id()` reads the persisted metadata id
             # (never mints a premature one that could conflict with disk).
             model = await self._resolve_ychat(room)
-            chat_id = None
-            if model is not None:
-                self._models[path] = model
-                chat_id = model.get_id()
+            if model is None:
+                # No usable chat without a resolved model; do not emit an
+                # `opened` event that could not carry a chat_id.
+                self.log.warning(
+                    "Could not resolve YChat for room %s; skipping opened event",
+                    room,
+                )
+                return
+            self._models[path] = model
             self._emit_event(
                 ChatEvent(
-                    path=path, action=ChatEventAction.OPENED, chat_id=chat_id
+                    path=path,
+                    action=ChatEventAction.OPENED,
+                    chat_id=model.get_id(),
                 )
             )
         elif action == "clean":

--- a/python/jupyterlab-chat/jupyterlab_chat/chat_manager.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/chat_manager.py
@@ -1,0 +1,375 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+"""
+Transport-agnostic chat lifecycle: model access and memory management.
+
+``ChatManager`` gives server-side consumers (e.g. jupyter-ai-router, personas) a
+single way to (1) observe chat lifecycle events, (2) retrieve a chat model by path
+(or room id under RTC), and (3) rely on chat models being freed once inactive,
+regardless of whether the backend is collaborative (``YChat``) or WebSocket-only
+(``WsChatModel``).
+
+The lifecycle event bus is delivered via Jupyter Events (schema in ``events.py``).
+Every event carries the chat's stable id (``chat.get_id()``) as ``chat_id`` -- the
+transport-neutral source of truth for correlating a chat across events and
+transports. ``room_id`` is an RTC transport detail that stays internal to this
+manager and to ``YChat`` (for path resolution); it is never emitted.
+
+Under RTC, jupyter collaboration's room events are forwarded/parsed into the
+generic schema; under WebSocket, the handler notifies the manager directly.
+"""
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING, Callable, Optional
+
+from tornado.ioloop import PeriodicCallback
+from traitlets import Float
+from traitlets.config import LoggingConfigurable
+
+from .events import (
+    CHAT_ROOM_EVENT_SCHEMA,
+    CHAT_ROOM_EVENT_SCHEMA_ID,
+    JUPYTER_COLLABORATION_EVENTS_URI,
+    ChatEvent,
+    ChatEventAction,
+)
+from .websocket_model import WsChatModel
+
+if TYPE_CHECKING:
+    from jupyter_server.serverapp import ServerApp
+
+    from .models import BaseChatModel
+
+
+class ChatManager(LoggingConfigurable):
+    """
+    Owns the set of live chat models and emits lifecycle events for them.
+
+    Responsibilities:
+      1. Event bus  -- ``observe_chats`` / emits ``opened|closed|deleted`` via Jupyter Events.
+      2. Model access -- ``get`` (sync) / ``create`` (async get-or-create).
+      3. Memory management -- frees a model after ``inactivity_timeout_s`` with no
+         connected clients, or when its backing file is gone.
+
+    Every emitted event carries the chat's stable ``chat_id`` (``model.get_id()``).
+    """
+
+    inactivity_timeout_s = Float(
+        300.0, config=True, help="Free a chat model after this many seconds with no connected clients."
+    )
+    poll_interval_s = Float(
+        60.0, config=True, help="How often to poll for inactive/deleted chats."
+    )
+
+    def __init__(self, serverapp: "ServerApp", rtc_enabled: bool = False, start_poller: bool = True, **kwargs):
+        super().__init__(**kwargs)
+        self._serverapp = serverapp
+        self._settings = serverapp.web_app.settings
+        self._event_logger = self._settings.get("event_logger")
+        self._rtc_enabled = rtc_enabled
+
+        self._models: dict[str, "BaseChatModel"] = {}
+        self._room_to_path: dict[str, str] = {}
+        self._last_active: dict[str, float] = {}
+
+        # Single source of truth for the WS handler (supersedes the ad-hoc
+        # ``ws_chat_models`` dict; kept under the same key for compatibility).
+        self._settings["ws_chat_models"] = self._models
+
+        self._register_schema()
+        if rtc_enabled:
+            self._wire_rtc_forwarding()
+
+        self._poller = PeriodicCallback(self._poll, self.poll_interval_s * 1000)
+        if start_poller:
+            self._poller.start()
+
+    @property
+    def _root_dir(self) -> Path:
+        return Path(self._settings.get("server_root_dir", ".")).expanduser().resolve()
+
+    # ------------------------------------------------------------------
+    # Responsibility 1 -- event bus
+    # ------------------------------------------------------------------
+    def _register_schema(self) -> None:
+        if self._event_logger is None:
+            self.log.warning("No event_logger in settings; chat events disabled.")
+            return
+        try:
+            self._event_logger.register_event_schema(CHAT_ROOM_EVENT_SCHEMA)
+        except Exception as e:  # pragma: no cover - defensive
+            self.log.warning("Failed to register chat room event schema: %s", e)
+
+    def observe_chats(self, callback: Callable) -> None:
+        """Subscribe to chat events (wraps ``EventLogger.add_listener``).
+
+        ``callback`` is ``async def (logger, schema_id, data)`` where ``data``
+        matches :class:`ChatEvent`. The stream carries both room-level actions
+        (``opened``/``closed``/``deleted``) and per-client actions
+        (``client_connected``/``client_disconnected``, which carry ``client_id``);
+        consumers filter by ``action``. Every event carries ``chat_id`` -- the
+        stable, transport-neutral chat id -- which consumers should use to
+        correlate a chat. Use the client actions to (re)publish per-client state,
+        such as a catch-up snapshot, when a new consumer joins an already-live chat.
+        """
+        if self._event_logger is None:
+            return
+        self._event_logger.add_listener(
+            schema_id=CHAT_ROOM_EVENT_SCHEMA_ID, listener=callback
+        )
+
+    def _emit_event(self, event: ChatEvent) -> None:
+        if self._event_logger is None:
+            return
+        try:
+            self._event_logger.emit(
+                schema_id=CHAT_ROOM_EVENT_SCHEMA_ID, data=event.to_data()
+            )
+        except Exception as e:  # pragma: no cover - defensive
+            self.log.warning("Failed to emit chat event %s: %s", event, e)
+
+    def _chat_id_for(self, path: str) -> Optional[str]:
+        """The stable chat id for a live chat, or ``None`` if not currently live."""
+        model = self._models.get(path)
+        return model.get_id() if model is not None else None
+
+    def on_client_connect(self, path: str, client_id: str) -> None:
+        """Callback invoked upon WebSocket client connection. Emits an event."""
+        self._emit_event(
+            ChatEvent(
+                path=path,
+                action=ChatEventAction.CLIENT_CONNECTED,
+                chat_id=self._chat_id_for(path),
+                client_id=client_id,
+            )
+        )
+
+    def on_client_disconnect(self, path: str, client_id: str) -> None:
+        """Callback invoked upon WebSocket client disconnection. Emits an event."""
+        self._emit_event(
+            ChatEvent(
+                path=path,
+                action=ChatEventAction.CLIENT_DISCONNECTED,
+                chat_id=self._chat_id_for(path),
+                client_id=client_id,
+            )
+        )
+
+    # ------------------------------------------------------------------
+    # Responsibility 2 -- model access
+    # ------------------------------------------------------------------
+    def get(self, query: str) -> Optional["BaseChatModel"]:
+        """Return the live model for a path (or a room id, when RTC is available).
+
+        Synchronous: an open chat is always already cached (we cache before
+        emitting ``opened``). Returns ``None`` if the chat is not currently live.
+        """
+        path = self._resolve_path(query)
+        if path is None:
+            return None
+        return self._models.get(path)
+
+    async def create(self, path: str) -> Optional["BaseChatModel"]:
+        """Async get-or-create. Resolves+caches if already open, otherwise
+        instantiates the model (WS: ``WsChatModel`` + ``load_from_file``; RTC:
+        resolve the ``YChat``). Creating an empty chat when the file is missing
+        is expected behavior for WS.
+        """
+        model = self._models.get(path)
+        if model is not None:
+            return model
+        if self._rtc_enabled:
+            return await self._resolve_ychat_by_path(path)
+        return self._get_or_create_ws(path)
+
+    def _resolve_path(self, query: str) -> Optional[str]:
+        if query in self._models:
+            return query
+        if query in self._room_to_path:
+            return self._room_to_path[query]
+        # A room id ("{fmt}:{type}:{id}") is only meaningful under RTC, and only
+        # resolvable if we have seen its ``opened`` event. We do not depend on a
+        # fileIdManager here; an unknown room id resolves to None.
+        if _looks_like_room_id(query):
+            return None
+        return query  # treat as a path
+
+    # ------------------------------------------------------------------
+    # Responsibility 3 -- memory management
+    # ------------------------------------------------------------------
+    def _poll(self) -> None:
+        now = time.time()
+        for path in list(self._models.keys()):
+            model = self._models.get(path)
+            if model is None:
+                continue
+            # Deletion: the backing file is gone (via ContentsManager/filesystem).
+            # Use the model's live path so an in-band move (which updates the
+            # model's tracked path) is not mistaken for a deletion.
+            if not (self._root_dir / model.get_path()).exists():
+                self._free(path, ChatEventAction.DELETED)
+                continue
+            # Inactivity: only applies to WS models we own the memory for. A
+            # connected client keeps the chat alive.
+            if isinstance(model, WsChatModel):
+                if model.handlers:
+                    self._last_active[path] = now
+                elif now - self._last_active.get(path, now) > self.inactivity_timeout_s:
+                    self._free(path, ChatEventAction.CLOSED)
+
+    def _free(self, path: str, action: ChatEventAction) -> Optional["BaseChatModel"]:
+        model = self._models.pop(path, None)
+        self._last_active.pop(path, None)
+        # Capture the stable chat id before disposing: close/delete events fire
+        # after the model is freed, so this is the last chance to read it.
+        chat_id = model.get_id() if model is not None else None
+        if isinstance(model, WsChatModel):
+            model.dispose()
+        for rid, p in list(self._room_to_path.items()):
+            if p == path:
+                del self._room_to_path[rid]
+        if model is not None:
+            self._emit_event(ChatEvent(path=path, action=action, chat_id=chat_id))
+        return model
+
+    def stop(self) -> None:
+        if getattr(self, "_poller", None) is not None:
+            self._poller.stop()
+
+    # ------------------------------------------------------------------
+    # WebSocket transport hooks (called by WSChatHandler)
+    # ------------------------------------------------------------------
+    def ws_open(self, path: str) -> "WsChatModel":
+        """First/any client connecting to ``path``: get-or-create the model and
+        (on first creation) emit ``opened``."""
+        model = self._get_or_create_ws(path)
+        self._last_active[path] = time.time()
+        return model
+
+    def ws_activity(self, path: str) -> None:
+        self._last_active[path] = time.time()
+
+    def ws_client_gone(self, path: str) -> None:
+        # The last client for this chat has disconnected. Free the model now
+        # unless a server-side writer (e.g. an AI persona still producing a
+        # reply) is keeping it alive, in which case the poller reclaims it once
+        # the writer stops. Freeing here -- rather than reloading from disk on the
+        # next open -- is what keeps a reopened chat consistent without having to
+        # handle out-of-band file changes.
+        self._last_active[path] = time.time()
+        if not self._has_active_writers(path):
+            self._free(path, ChatEventAction.CLOSED)
+
+    def _has_active_writers(self, path: str) -> bool:
+        """Whether a server-side writer is keeping this chat alive.
+
+        A "writer" is an AI persona (or other server-side producer) that is still
+        working on a reply and would be orphaned if the model were freed. The
+        server-side writing API is not on this branch yet (see
+        jupyterlab/jupyter-chat#497); until it lands there are no server-side
+        writers, so a chat is freed as soon as its last client disconnects.
+        """
+        return False
+
+    def _get_or_create_ws(self, path: str) -> "WsChatModel":
+        model = self._models.get(path)
+        if model is None:
+            model = WsChatModel(
+                path=path,
+                root_dir=self._root_dir,
+                event_logger=self._event_logger,
+            )
+            model.load_from_file()
+            self._models[path] = model
+            self._last_active[path] = time.time()
+            self._emit_event(
+                ChatEvent(
+                    path=path,
+                    action=ChatEventAction.OPENED,
+                    chat_id=model.get_id(),
+                )
+            )
+        # A cached model is the live in-memory session: reuse it verbatim. We do
+        # not reload from disk (out-of-band file changes are unsupported) so that
+        # any attached server-side state, such as AI personas, is preserved when a
+        # client reconnects.
+        return model  # type: ignore[return-value]
+
+    # ------------------------------------------------------------------
+    # RTC forwarding (best-effort; not exercised without jupyter_collaboration)
+    # ------------------------------------------------------------------
+    def _wire_rtc_forwarding(self) -> None:
+        if self._event_logger is None:
+            return
+        try:
+            self._event_logger.add_listener(
+                schema_id=JUPYTER_COLLABORATION_EVENTS_URI,
+                listener=self._on_rtc_room_event,
+            )
+        except Exception as e:  # pragma: no cover - depends on RTC install
+            self.log.warning("Could not attach RTC room-event forwarder: %s", e)
+
+    async def _on_rtc_room_event(self, logger, schema_id: str, data: dict) -> None:
+        room = data.get("room", "") or ""
+        path = data.get("path")
+        action = data.get("action")
+        parts = room.split(":")
+        # Chat rooms only: {file_format}:{file_type}:{file_id} with file_type == "chat".
+        if len(parts) < 2 or parts[1] != "chat" or not path:
+            return
+        if action == "initialize":
+            self._room_to_path[room] = path
+            self._last_active[path] = time.time()
+            # Resolve the YChat: `get_document` loads the file content into the
+            # doc before returning, so `get_id()` reads the persisted metadata id
+            # (never mints a premature one that could conflict with disk).
+            model = await self._resolve_ychat(room)
+            chat_id = None
+            if model is not None:
+                self._models[path] = model
+                chat_id = model.get_id()
+            self._emit_event(
+                ChatEvent(
+                    path=path, action=ChatEventAction.OPENED, chat_id=chat_id
+                )
+            )
+        elif action == "clean":
+            self._free(path, ChatEventAction.CLOSED)
+
+    async def _resolve_ychat(self, room_id: str):
+        """Resolve the ``YChat`` for a room via jupyter_collaboration. Mirrors
+        jupyter-ai-router's approach; guarded because the APIs only exist when an
+        RTC provider is installed."""
+        try:
+            collaboration = self._settings["jupyter_server_ydoc"]
+            model = await collaboration.get_document(room_id=room_id, copy=False)
+            if model is not None:
+                # Record the room id (so get_path() can recover the file id) and
+                # the initial path, both taken from the room lifecycle event
+                # (self._room_to_path is populated from that event's `path`).
+                # `room_id` is an RTC transport detail kept internal to YChat.
+                model.room_id = room_id
+                model.initial_path = self._room_to_path.get(room_id)
+            return model
+        except Exception as e:  # pragma: no cover - depends on RTC install
+            self.log.warning("Could not resolve YChat for room %s: %s", room_id, e)
+            return None
+
+    async def _resolve_ychat_by_path(self, path: str):
+        room_id = next(
+            (rid for rid, p in self._room_to_path.items() if p == path), None
+        )
+        if room_id is None:
+            return None
+        model = await self._resolve_ychat(room_id)
+        if model is not None:
+            self._models[path] = model
+        return model
+
+
+def _looks_like_room_id(query: str) -> bool:
+    """Heuristic: RTC room ids have the form ``{file_format}:{file_type}:{file_id}``.
+    A ``.chat`` path never contains ':' on the platforms we support."""
+    return query.count(":") >= 2

--- a/python/jupyterlab-chat/jupyterlab_chat/chat_manager.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/chat_manager.py
@@ -129,20 +129,12 @@ class ChatManager(LoggingConfigurable):
         except Exception as e:  # pragma: no cover - defensive
             self.log.warning("Failed to emit chat event %s: %s", event, e)
 
-    def _chat_id_for(self, path: str) -> Optional[str]:
-        """The stable chat id for a live chat, or ``None`` if not currently live."""
-        model = self._models.get(path)
-        return model.get_id() if model is not None else None
-
-    def on_client_connect(self, path: str, client_id: str) -> None:
+    def on_client_connect(self, path: str, client_id: str, chat_id: str) -> None:
         """Callback invoked upon WebSocket client connection. Emits an event.
 
-        A live model is guaranteed here (the handler calls ``ws_open`` first), so
-        the event always carries a ``chat_id``; the guard is purely defensive.
+        ``chat_id`` is supplied by the caller (the WS handler, which already holds
+        the model), so the event always carries the chat's stable id.
         """
-        chat_id = self._chat_id_for(path)
-        if chat_id is None:
-            return
         self._emit_event(
             ChatEvent(
                 path=path,
@@ -152,15 +144,12 @@ class ChatManager(LoggingConfigurable):
             )
         )
 
-    def on_client_disconnect(self, path: str, client_id: str) -> None:
+    def on_client_disconnect(self, path: str, client_id: str, chat_id: str) -> None:
         """Callback invoked upon WebSocket client disconnection. Emits an event.
 
-        Fires before the model is freed, so the model is still live and the event
-        always carries a ``chat_id``; the guard is purely defensive.
+        ``chat_id`` is supplied by the caller (the WS handler still holds the live
+        model at disconnect time), so the event always carries the chat's id.
         """
-        chat_id = self._chat_id_for(path)
-        if chat_id is None:
-            return
         self._emit_event(
             ChatEvent(
                 path=path,

--- a/python/jupyterlab-chat/jupyterlab_chat/chat_manager.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/chat_manager.py
@@ -70,11 +70,14 @@ class ChatManager(LoggingConfigurable):
         self._event_logger = self._settings.get("event_logger")
         self._rtc_enabled = rtc_enabled
 
+        # Live chat models keyed by their stable chat id (``chat.get_id()``) --
+        # the only stable identifier of a chat (paths change on rename; room ids
+        # exist only under RTC). ``_last_active`` is keyed the same way.
         self._models: dict[str, "BaseChatModel"] = {}
         self._last_active: dict[str, float] = {}
 
-        # Single source of truth for the WS handler (supersedes the ad-hoc
-        # ``ws_chat_models`` dict; kept under the same key for compatibility).
+        # Exposed for server-side consumers under the legacy ``ws_chat_models``
+        # settings key. Same dict object as ``_models`` -- now keyed by chat id.
         self._settings["ws_chat_models"] = self._models
 
         self._register_schema()
@@ -162,65 +165,72 @@ class ChatManager(LoggingConfigurable):
     # ------------------------------------------------------------------
     # Responsibility 2 -- model access
     # ------------------------------------------------------------------
-    def get(self, path: str) -> Optional["BaseChatModel"]:
-        """Return the live model for a chat ``path``, or ``None`` if not live.
+    def get(self, chat_id: str) -> Optional["BaseChatModel"]:
+        """Return the live model for a stable ``chat_id`` (``chat.get_id()``), or
+        ``None`` if that chat is not currently live.
 
-        Synchronous: an open chat is always already cached (we cache before
-        emitting ``opened``). ``path`` is the canonical key stamped on every
-        lifecycle event; a room id is an RTC transport detail and is never a
-        valid key here.
+        The chat id is the only stable key; it is stamped on every lifecycle
+        event, so consumers already have it. (Paths change on rename and room ids
+        exist only under RTC, so neither is a reliable key.)
         """
-        return self._models.get(path)
+        return self._models.get(chat_id)
 
     async def create(self, path: str) -> Optional["BaseChatModel"]:
-        """Async get-or-create.
+        """Async get-or-create by ``path`` (the WS connection parameter).
 
         WS: get-or-create a ``WsChatModel`` (loading from disk; creating an empty
         chat when the file is missing is expected). RTC: an ``opened`` room event
-        creates and caches the ``YChat``, so this only returns an already-live
-        model and does not create one on demand.
+        creates and caches the ``YChat``, so this returns an already-live model
+        and does not create one on demand.
         """
-        model = self._models.get(path)
-        if model is not None:
-            return model
         if self._rtc_enabled:
-            return None
+            existing = self._model_for_path(path)
+            return existing
         return self._get_or_create_ws(path)
+
+    def _model_for_path(self, path: str) -> Optional["BaseChatModel"]:
+        """Find the live model whose current path is ``path`` (linear scan over
+        the handful of live chats). Uses ``get_path()`` so a renamed chat is
+        matched by its current path, never a stale key."""
+        return next(
+            (m for m in self._models.values() if m.get_path() == path), None
+        )
 
     # ------------------------------------------------------------------
     # Responsibility 3 -- memory management
     # ------------------------------------------------------------------
     def _poll(self) -> None:
         now = time.time()
-        for path in list(self._models.keys()):
-            model = self._models.get(path)
+        for chat_id in list(self._models.keys()):
+            model = self._models.get(chat_id)
             if model is None:
                 continue
             # Deletion: the backing file is gone (via ContentsManager/filesystem).
             # Use the model's live path so an in-band move (which updates the
             # model's tracked path) is not mistaken for a deletion.
             if not (self._root_dir / model.get_path()).exists():
-                self._free(path, ChatEventAction.DELETED)
+                self._free(chat_id, ChatEventAction.DELETED)
                 continue
             # Inactivity: only applies to WS models we own the memory for. A
             # connected client keeps the chat alive.
             if isinstance(model, WsChatModel):
                 if model.handlers:
-                    self._last_active[path] = now
-                elif now - self._last_active.get(path, now) > self.inactivity_timeout_s:
-                    self._free(path, ChatEventAction.CLOSED)
+                    self._last_active[chat_id] = now
+                elif now - self._last_active.get(chat_id, now) > self.inactivity_timeout_s:
+                    self._free(chat_id, ChatEventAction.CLOSED)
 
-    def _free(self, path: str, action: ChatEventAction) -> Optional["BaseChatModel"]:
-        model = self._models.pop(path, None)
-        self._last_active.pop(path, None)
+    def _free(self, chat_id: str, action: ChatEventAction) -> Optional["BaseChatModel"]:
+        model = self._models.pop(chat_id, None)
+        self._last_active.pop(chat_id, None)
         if model is None:
             return None
-        # Capture the stable chat id before disposing: close/delete events fire
-        # after the model is freed, so this is the last chance to read it.
-        chat_id = model.get_id()
         if isinstance(model, WsChatModel):
             model.dispose()
-        self._emit_event(ChatEvent(path=path, action=action, chat_id=chat_id))
+        # The event carries the model's current path (for display/discovery) and
+        # its stable chat id (the key we just freed).
+        self._emit_event(
+            ChatEvent(path=model.get_path(), action=action, chat_id=chat_id)
+        )
         return model
 
     def stop(self) -> None:
@@ -232,26 +242,27 @@ class ChatManager(LoggingConfigurable):
     # ------------------------------------------------------------------
     def ws_open(self, path: str) -> "WsChatModel":
         """First/any client connecting to ``path``: get-or-create the model and
-        (on first creation) emit ``opened``."""
+        (on first creation) emit ``opened``. Returns the model; the caller reads
+        ``model.get_id()`` for the stable chat id."""
         model = self._get_or_create_ws(path)
-        self._last_active[path] = time.time()
+        self._last_active[model.get_id()] = time.time()
         return model
 
-    def ws_activity(self, path: str) -> None:
-        self._last_active[path] = time.time()
+    def ws_activity(self, chat_id: str) -> None:
+        self._last_active[chat_id] = time.time()
 
-    def ws_client_gone(self, path: str) -> None:
+    def ws_client_gone(self, chat_id: str) -> None:
         # The last client for this chat has disconnected. Free the model now
         # unless a server-side writer (e.g. an AI persona still producing a
         # reply) is keeping it alive, in which case the poller reclaims it once
         # the writer stops. Freeing here -- rather than reloading from disk on the
         # next open -- is what keeps a reopened chat consistent without having to
         # handle out-of-band file changes.
-        self._last_active[path] = time.time()
-        if not self._has_active_writers(path):
-            self._free(path, ChatEventAction.CLOSED)
+        self._last_active[chat_id] = time.time()
+        if not self._has_active_writers(chat_id):
+            self._free(chat_id, ChatEventAction.CLOSED)
 
-    def _has_active_writers(self, path: str) -> bool:
+    def _has_active_writers(self, chat_id: str) -> bool:
         """Whether a server-side writer is keeping this chat alive.
 
         A "writer" is an AI persona (or other server-side producer) that is still
@@ -263,28 +274,31 @@ class ChatManager(LoggingConfigurable):
         return False
 
     def _get_or_create_ws(self, path: str) -> "WsChatModel":
-        model = self._models.get(path)
-        if model is None:
-            model = WsChatModel(
+        # Reuse the live model for this path if one exists (matched by current
+        # path, so a renamed chat is still found). A cached model is the live
+        # in-memory session: reuse it verbatim -- we do not reload from disk
+        # (out-of-band file changes are unsupported) so attached server-side
+        # state, such as AI personas, is preserved across reconnects.
+        existing = self._model_for_path(path)
+        if isinstance(existing, WsChatModel):
+            return existing
+        model = WsChatModel(
+            path=path,
+            root_dir=self._root_dir,
+            event_logger=self._event_logger,
+        )
+        model.load_from_file()
+        chat_id = model.get_id()
+        self._models[chat_id] = model
+        self._last_active[chat_id] = time.time()
+        self._emit_event(
+            ChatEvent(
                 path=path,
-                root_dir=self._root_dir,
-                event_logger=self._event_logger,
+                action=ChatEventAction.OPENED,
+                chat_id=chat_id,
             )
-            model.load_from_file()
-            self._models[path] = model
-            self._last_active[path] = time.time()
-            self._emit_event(
-                ChatEvent(
-                    path=path,
-                    action=ChatEventAction.OPENED,
-                    chat_id=model.get_id(),
-                )
-            )
-        # A cached model is the live in-memory session: reuse it verbatim. We do
-        # not reload from disk (out-of-band file changes are unsupported) so that
-        # any attached server-side state, such as AI personas, is preserved when a
-        # client reconnects.
-        return model  # type: ignore[return-value]
+        )
+        return model
 
     # ------------------------------------------------------------------
     # RTC forwarding (best-effort; not exercised without jupyter_collaboration)
@@ -309,7 +323,6 @@ class ChatManager(LoggingConfigurable):
         if len(parts) < 2 or parts[1] != "chat" or not path:
             return
         if action == "initialize":
-            self._last_active[path] = time.time()
             # Resolve the YChat: `get_document` loads the file content into the
             # doc before returning, so `get_id()` reads the persisted metadata id
             # (never mints a premature one that could conflict with disk).
@@ -322,16 +335,20 @@ class ChatManager(LoggingConfigurable):
                     room,
                 )
                 return
-            self._models[path] = model
+            chat_id = model.get_id()
+            self._models[chat_id] = model
+            self._last_active[chat_id] = time.time()
             self._emit_event(
                 ChatEvent(
                     path=path,
                     action=ChatEventAction.OPENED,
-                    chat_id=model.get_id(),
+                    chat_id=chat_id,
                 )
             )
         elif action == "clean":
-            self._free(path, ChatEventAction.CLOSED)
+            model = self._model_for_path(path)
+            if model is not None:
+                self._free(model.get_id(), ChatEventAction.CLOSED)
 
     async def _resolve_ychat(self, room_id: str, initial_path: str):
         """Resolve the ``YChat`` for a room via jupyter_collaboration. Mirrors

--- a/python/jupyterlab-chat/jupyterlab_chat/events.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/events.py
@@ -1,40 +1,25 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 """
-Transport-agnostic chat lifecycle: event bus, model access, and memory management.
+Chat lifecycle event schema (transport-agnostic).
 
-``ChatManager`` gives server-side consumers (e.g. jupyter-ai-router, personas) a
-single way to (1) observe chat lifecycle events, (2) retrieve a chat model by path
-(or room id under RTC), and (3) rely on chat models being freed once inactive,
-regardless of whether the backend is collaborative (``YChat``) or WebSocket-only
-(``WsChatModel``).
+Defines the Jupyter Events schema and the :class:`ChatEvent` dataclass emitted by
+:class:`~jupyterlab_chat.chat_manager.ChatManager`. Every event carries the chat's
+stable id (``chat_id`` = ``chat.get_id()``) -- the transport-neutral source of
+truth for correlating a chat across events and transports. The RTC ``room_id`` is
+never part of this schema: it is an RTC transport detail internal to the
+ChatManager and to ``YChat`` (used only to recover the file id for path
+resolution).
 
-The lifecycle event bus is delivered via Jupyter Events. Under RTC, jupyter
-collaboration's room events are forwarded/parsed into the generic schema below;
-under WebSocket, the handler notifies the manager directly.
-
-Out of scope for now (see tmp/chat-manager-design.md non-goals): message-level
-events, ``reset``/``overwrite`` (hand-edited files), and a dedicated deletion
-signal (deletion is detected by the inactivity poller checking the backing file).
+Under RTC, jupyter collaboration's room events are forwarded/parsed into this
+schema by the ChatManager; under WebSocket, the handler notifies the manager
+directly.
 """
 from __future__ import annotations
 
-import time
 from dataclasses import dataclass
 from enum import Enum
-from pathlib import Path
-from typing import TYPE_CHECKING, Callable, Optional
-
-from tornado.ioloop import PeriodicCallback
-from traitlets import Float
-from traitlets.config import LoggingConfigurable
-
-from .websocket_model import WsChatModel
-
-if TYPE_CHECKING:
-    from jupyter_server.serverapp import ServerApp
-
-    from .models import BaseChatModel
+from typing import Optional
 
 #: Jupyter Events schema id for the generic (transport-agnostic) chat lifecycle bus.
 CHAT_ROOM_EVENT_SCHEMA_ID = "https://schema.jupyter.org/jupyterlab_chat/room/v1"
@@ -57,7 +42,7 @@ CHAT_ROOM_EVENT_SCHEMA = {
     "properties": {
         "path": {
             "type": "string",
-            "description": "Server-root-relative path of the .chat file (canonical id).",
+            "description": "Server-root-relative path of the .chat file.",
         },
         "action": {
             "enum": [
@@ -74,13 +59,16 @@ CHAT_ROOM_EVENT_SCHEMA = {
                 "carry 'client_id'."
             ),
         },
+        "chat_id": {
+            "type": "string",
+            "description": (
+                "Stable, transport-neutral chat id (chat.get_id()); the source of "
+                "truth for correlating a chat across events and transports."
+            ),
+        },
         "client_id": {
             "type": "string",
             "description": "Per-connection id; present only for the client_* actions.",
-        },
-        "room_id": {
-            "type": "string",
-            "description": "RTC room id ({format}:{type}:{file_id}); absent in WebSocket mode.",
         },
     },
     "additionalProperties": False,
@@ -106,328 +94,16 @@ class ChatEvent:
 
     path: str
     action: ChatEventAction
-    room_id: Optional[str] = None
+    #: Stable, transport-neutral chat id (``chat.get_id()``). Populated on every
+    #: event; ``None`` only in the rare case the model could not be resolved.
+    chat_id: Optional[str] = None
     #: Set only for the ``client_connected``/``client_disconnected`` actions.
     client_id: Optional[str] = None
 
     def to_data(self) -> dict:
         data: dict = {"path": self.path, "action": self.action.value}
-        if self.room_id is not None:
-            data["room_id"] = self.room_id
+        if self.chat_id is not None:
+            data["chat_id"] = self.chat_id
         if self.client_id is not None:
             data["client_id"] = self.client_id
         return data
-
-
-class ChatManager(LoggingConfigurable):
-    """
-    Owns the set of live chat models and emits lifecycle events for them.
-
-    Responsibilities:
-      1. Event bus  -- ``observe_chats`` / emits ``opened|closed|deleted`` via Jupyter Events.
-      2. Model access -- ``get`` (sync) / ``create`` (async get-or-create).
-      3. Memory management -- frees a model after ``inactivity_timeout_s`` with no
-         connected clients, or when its backing file is gone.
-    """
-
-    inactivity_timeout_s = Float(
-        300.0, config=True, help="Free a chat model after this many seconds with no connected clients."
-    )
-    poll_interval_s = Float(
-        60.0, config=True, help="How often to poll for inactive/deleted chats."
-    )
-
-    def __init__(self, serverapp: "ServerApp", rtc_enabled: bool = False, start_poller: bool = True, **kwargs):
-        super().__init__(**kwargs)
-        self._serverapp = serverapp
-        self._settings = serverapp.web_app.settings
-        self._event_logger = self._settings.get("event_logger")
-        self._rtc_enabled = rtc_enabled
-
-        self._models: dict[str, "BaseChatModel"] = {}
-        self._room_to_path: dict[str, str] = {}
-        self._last_active: dict[str, float] = {}
-
-        # Single source of truth for the WS handler (supersedes the ad-hoc
-        # ``ws_chat_models`` dict; kept under the same key for compatibility).
-        self._settings["ws_chat_models"] = self._models
-
-        self._register_schema()
-        if rtc_enabled:
-            self._wire_rtc_forwarding()
-
-        self._poller = PeriodicCallback(self._poll, self.poll_interval_s * 1000)
-        if start_poller:
-            self._poller.start()
-
-    @property
-    def _root_dir(self) -> Path:
-        return Path(self._settings.get("server_root_dir", ".")).expanduser().resolve()
-
-    # ------------------------------------------------------------------
-    # Responsibility 1 -- event bus
-    # ------------------------------------------------------------------
-    def _register_schema(self) -> None:
-        if self._event_logger is None:
-            self.log.warning("No event_logger in settings; chat events disabled.")
-            return
-        try:
-            self._event_logger.register_event_schema(CHAT_ROOM_EVENT_SCHEMA)
-        except Exception as e:  # pragma: no cover - defensive
-            self.log.warning("Failed to register chat room event schema: %s", e)
-
-    def observe_chats(self, callback: Callable) -> None:
-        """Subscribe to chat events (wraps ``EventLogger.add_listener``).
-
-        ``callback`` is ``async def (logger, schema_id, data)`` where ``data``
-        matches :class:`ChatEvent`. The stream carries both room-level actions
-        (``opened``/``closed``/``deleted``) and per-client actions
-        (``client_connected``/``client_disconnected``, which carry ``client_id``);
-        consumers filter by ``action``. Use the client actions to (re)publish
-        per-client state, such as a catch-up snapshot, when a new consumer joins
-        an already-live chat.
-        """
-        if self._event_logger is None:
-            return
-        self._event_logger.add_listener(
-            schema_id=CHAT_ROOM_EVENT_SCHEMA_ID, listener=callback
-        )
-
-    def _emit_event(self, event: ChatEvent) -> None:
-        if self._event_logger is None:
-            return
-        try:
-            self._event_logger.emit(
-                schema_id=CHAT_ROOM_EVENT_SCHEMA_ID, data=event.to_data()
-            )
-        except Exception as e:  # pragma: no cover - defensive
-            self.log.warning("Failed to emit chat event %s: %s", event, e)
-
-    def _room_id_for(self, path: str) -> Optional[str]:
-        return next(
-            (rid for rid, p in self._room_to_path.items() if p == path), None
-        )
-
-    def on_client_connect(self, path: str, client_id: str) -> None:
-        """Callback invoked upon WebSocket client connection. Emits an event."""
-        self._emit_event(
-            ChatEvent(
-                path=path,
-                action=ChatEventAction.CLIENT_CONNECTED,
-                room_id=self._room_id_for(path),
-                client_id=client_id,
-            )
-        )
-
-    def on_client_disconnect(self, path: str, client_id: str) -> None:
-        """Callback invoked upon WebSocket client disconnection. Emits an event."""
-        self._emit_event(
-            ChatEvent(
-                path=path,
-                action=ChatEventAction.CLIENT_DISCONNECTED,
-                room_id=self._room_id_for(path),
-                client_id=client_id,
-            )
-        )
-
-    # ------------------------------------------------------------------
-    # Responsibility 2 -- model access
-    # ------------------------------------------------------------------
-    def get(self, query: str) -> Optional["BaseChatModel"]:
-        """Return the live model for a path (or a room id, when RTC is available).
-
-        Synchronous: an open chat is always already cached (we cache before
-        emitting ``opened``). Returns ``None`` if the chat is not currently live.
-        """
-        path = self._resolve_path(query)
-        if path is None:
-            return None
-        return self._models.get(path)
-
-    async def create(self, path: str) -> Optional["BaseChatModel"]:
-        """Async get-or-create. Resolves+caches if already open, otherwise
-        instantiates the model (WS: ``WsChatModel`` + ``load_from_file``; RTC:
-        resolve the ``YChat``). Creating an empty chat when the file is missing
-        is expected behavior for WS.
-        """
-        model = self._models.get(path)
-        if model is not None:
-            return model
-        if self._rtc_enabled:
-            return await self._resolve_ychat_by_path(path)
-        return self._get_or_create_ws(path)
-
-    def _resolve_path(self, query: str) -> Optional[str]:
-        if query in self._models:
-            return query
-        if query in self._room_to_path:
-            return self._room_to_path[query]
-        # A room id ("{fmt}:{type}:{id}") is only meaningful under RTC, and only
-        # resolvable if we have seen its ``opened`` event. We do not depend on a
-        # fileIdManager here; an unknown room id resolves to None.
-        if _looks_like_room_id(query):
-            return None
-        return query  # treat as a path
-
-    # ------------------------------------------------------------------
-    # Responsibility 3 -- memory management
-    # ------------------------------------------------------------------
-    def _poll(self) -> None:
-        now = time.time()
-        for path in list(self._models.keys()):
-            model = self._models.get(path)
-            if model is None:
-                continue
-            # Deletion: the backing file is gone (via ContentsManager/filesystem).
-            # Use the model's live path so an in-band move (which updates the
-            # model's tracked path) is not mistaken for a deletion.
-            if not (self._root_dir / model.get_path()).exists():
-                self._free(path, ChatEventAction.DELETED)
-                continue
-            # Inactivity: only applies to WS models we own the memory for. A
-            # connected client keeps the chat alive.
-            if isinstance(model, WsChatModel):
-                if model.handlers:
-                    self._last_active[path] = now
-                elif now - self._last_active.get(path, now) > self.inactivity_timeout_s:
-                    self._free(path, ChatEventAction.CLOSED)
-
-    def _free(self, path: str, action: ChatEventAction) -> Optional["BaseChatModel"]:
-        model = self._models.pop(path, None)
-        self._last_active.pop(path, None)
-        if isinstance(model, WsChatModel):
-            model.dispose()
-        room_id = None
-        for rid, p in list(self._room_to_path.items()):
-            if p == path:
-                room_id = rid
-                del self._room_to_path[rid]
-        if model is not None:
-            self._emit_event(ChatEvent(path=path, action=action, room_id=room_id))
-        return model
-
-    def stop(self) -> None:
-        if getattr(self, "_poller", None) is not None:
-            self._poller.stop()
-
-    # ------------------------------------------------------------------
-    # WebSocket transport hooks (called by WSChatHandler)
-    # ------------------------------------------------------------------
-    def ws_open(self, path: str) -> "WsChatModel":
-        """First/any client connecting to ``path``: get-or-create the model and
-        (on first creation) emit ``opened``."""
-        model = self._get_or_create_ws(path)
-        self._last_active[path] = time.time()
-        return model
-
-    def ws_activity(self, path: str) -> None:
-        self._last_active[path] = time.time()
-
-    def ws_client_gone(self, path: str) -> None:
-        # The last client for this chat has disconnected. Free the model now
-        # unless a server-side writer (e.g. an AI persona still producing a
-        # reply) is keeping it alive, in which case the poller reclaims it once
-        # the writer stops. Freeing here -- rather than reloading from disk on the
-        # next open -- is what keeps a reopened chat consistent without having to
-        # handle out-of-band file changes.
-        self._last_active[path] = time.time()
-        if not self._has_active_writers(path):
-            self._free(path, ChatEventAction.CLOSED)
-
-    def _has_active_writers(self, path: str) -> bool:
-        """Whether a server-side writer is keeping this chat alive.
-
-        A "writer" is an AI persona (or other server-side producer) that is still
-        working on a reply and would be orphaned if the model were freed. The
-        server-side writing API is not on this branch yet (see
-        jupyterlab/jupyter-chat#497); until it lands there are no server-side
-        writers, so a chat is freed as soon as its last client disconnects.
-        """
-        return False
-
-    def _get_or_create_ws(self, path: str) -> "WsChatModel":
-        model = self._models.get(path)
-        if model is None:
-            model = WsChatModel(
-                path=path,
-                root_dir=self._root_dir,
-                event_logger=self._event_logger,
-            )
-            model.load_from_file()
-            self._models[path] = model
-            self._last_active[path] = time.time()
-            self._emit_event(ChatEvent(path=path, action=ChatEventAction.OPENED))
-        # A cached model is the live in-memory session: reuse it verbatim. We do
-        # not reload from disk (out-of-band file changes are unsupported) so that
-        # any attached server-side state, such as AI personas, is preserved when a
-        # client reconnects.
-        return model  # type: ignore[return-value]
-
-    # ------------------------------------------------------------------
-    # RTC forwarding (best-effort; not exercised without jupyter_collaboration)
-    # ------------------------------------------------------------------
-    def _wire_rtc_forwarding(self) -> None:
-        if self._event_logger is None:
-            return
-        try:
-            self._event_logger.add_listener(
-                schema_id=JUPYTER_COLLABORATION_EVENTS_URI,
-                listener=self._on_rtc_room_event,
-            )
-        except Exception as e:  # pragma: no cover - depends on RTC install
-            self.log.warning("Could not attach RTC room-event forwarder: %s", e)
-
-    async def _on_rtc_room_event(self, logger, schema_id: str, data: dict) -> None:
-        room = data.get("room", "") or ""
-        path = data.get("path")
-        action = data.get("action")
-        parts = room.split(":")
-        # Chat rooms only: {file_format}:{file_type}:{file_id} with file_type == "chat".
-        if len(parts) < 2 or parts[1] != "chat" or not path:
-            return
-        if action == "initialize":
-            self._room_to_path[room] = path
-            self._last_active[path] = time.time()
-            model = await self._resolve_ychat(room)
-            if model is not None:
-                self._models[path] = model
-            self._emit_event(
-                ChatEvent(path=path, action=ChatEventAction.OPENED, room_id=room)
-            )
-        elif action == "clean":
-            self._free(path, ChatEventAction.CLOSED)
-
-    async def _resolve_ychat(self, room_id: str):
-        """Resolve the ``YChat`` for a room via jupyter_collaboration. Mirrors
-        jupyter-ai-router's approach; guarded because the APIs only exist when an
-        RTC provider is installed."""
-        try:
-            collaboration = self._settings["jupyter_server_ydoc"]
-            model = await collaboration.get_document(room_id=room_id, copy=False)
-            if model is not None:
-                # Record the room id (so get_path() can recover the file id) and
-                # the initial path, both taken from the room lifecycle event
-                # (self._room_to_path is populated from that event's `path`).
-                model.room_id = room_id
-                model.initial_path = self._room_to_path.get(room_id)
-            return model
-        except Exception as e:  # pragma: no cover - depends on RTC install
-            self.log.warning("Could not resolve YChat for room %s: %s", room_id, e)
-            return None
-
-    async def _resolve_ychat_by_path(self, path: str):
-        room_id = next(
-            (rid for rid, p in self._room_to_path.items() if p == path), None
-        )
-        if room_id is None:
-            return None
-        model = await self._resolve_ychat(room_id)
-        if model is not None:
-            self._models[path] = model
-        return model
-
-
-def _looks_like_room_id(query: str) -> bool:
-    """Heuristic: RTC room ids have the form ``{file_format}:{file_type}:{file_id}``.
-    A ``.chat`` path never contains ':' on the platforms we support."""
-    return query.count(":") >= 2

--- a/python/jupyterlab-chat/jupyterlab_chat/events.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/events.py
@@ -38,7 +38,7 @@ CHAT_ROOM_EVENT_SCHEMA = {
     "personal-data": True,
     "description": "Transport-agnostic chat room lifecycle and per-client connection events emitted by jupyterlab_chat.",
     "type": "object",
-    "required": ["path", "action"],
+    "required": ["path", "action", "chat_id"],
     "properties": {
         "path": {
             "type": "string",
@@ -63,7 +63,8 @@ CHAT_ROOM_EVENT_SCHEMA = {
             "type": "string",
             "description": (
                 "Stable, transport-neutral chat id (chat.get_id()); the source of "
-                "truth for correlating a chat across events and transports."
+                "truth for correlating a chat across events and transports. Always "
+                "present on every event."
             ),
         },
         "client_id": {
@@ -94,16 +95,19 @@ class ChatEvent:
 
     path: str
     action: ChatEventAction
-    #: Stable, transport-neutral chat id (``chat.get_id()``). Populated on every
-    #: event; ``None`` only in the rare case the model could not be resolved.
-    chat_id: Optional[str] = None
+    #: Stable, transport-neutral chat id (``chat.get_id()``). Always present: the
+    #: ChatManager only emits an event once it has resolved the chat's model, so
+    #: consumers can rely on ``chat_id`` being set on every event.
+    chat_id: str
     #: Set only for the ``client_connected``/``client_disconnected`` actions.
     client_id: Optional[str] = None
 
     def to_data(self) -> dict:
-        data: dict = {"path": self.path, "action": self.action.value}
-        if self.chat_id is not None:
-            data["chat_id"] = self.chat_id
+        data: dict = {
+            "path": self.path,
+            "action": self.action.value,
+            "chat_id": self.chat_id,
+        }
         if self.client_id is not None:
             data["client_id"] = self.client_id
         return data

--- a/python/jupyterlab-chat/jupyterlab_chat/tests/test_events.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/tests/test_events.py
@@ -1,6 +1,6 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
-"""Unit tests for jupyterlab_chat.events.ChatManager (WebSocket path)."""
+"""Unit tests for jupyterlab_chat.chat_manager.ChatManager (WebSocket path)."""
 import asyncio
 import time
 from pathlib import Path
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, cast
 import jupyter_server
 from jupyter_events import EventLogger
 
-from jupyterlab_chat.events import ChatManager
+from jupyterlab_chat.chat_manager import ChatManager
 from jupyterlab_chat.models import NewMessage
 from jupyterlab_chat.websocket_model import WsChatModel
 
@@ -51,6 +51,14 @@ async def _drain():
     await asyncio.sleep(0.1)
 
 
+def _find(capture, path, action):
+    """Return the captured event matching path+action, or None."""
+    for e in capture:
+        if e.get("path") == path and e.get("action") == action:
+            return e
+    return None
+
+
 def test_ws_open_emits_opened_once_and_get(tmp_path):
     async def run():
         capture: list = []
@@ -60,7 +68,9 @@ def test_ws_open_emits_opened_once_and_get(tmp_path):
         model = mgr.ws_open("a.chat")
         assert isinstance(model, WsChatModel)
         await _drain()
-        assert {"path": "a.chat", "action": "opened"} in capture
+        opened = _find(capture, "a.chat", "opened")
+        assert opened is not None
+        assert opened["chat_id"] == model.get_id()
 
         # model access
         assert mgr.get("a.chat") is model
@@ -107,7 +117,9 @@ def test_inactivity_frees_model(tmp_path):
         await _drain()
 
         assert mgr.get("c.chat") is None  # garbage-collected
-        assert {"path": "c.chat", "action": "closed"} in capture
+        closed = _find(capture, "c.chat", "closed")
+        assert closed is not None
+        assert closed["chat_id"] == model.get_id()
         mgr.stop()
 
     asyncio.run(run())
@@ -134,7 +146,7 @@ def test_deletion_frees_model(tmp_path):
         mgr = _make_manager(tmp_path, capture)
         chat = tmp_path / "e.chat"
         chat.write_text("{}")
-        mgr.ws_open("e.chat")
+        model = mgr.ws_open("e.chat")
 
         chat.unlink()  # deleted via filesystem/ContentsManager
         capture.clear()
@@ -142,7 +154,9 @@ def test_deletion_frees_model(tmp_path):
         await _drain()
 
         assert mgr.get("e.chat") is None
-        assert {"path": "e.chat", "action": "deleted"} in capture
+        deleted = _find(capture, "e.chat", "deleted")
+        assert deleted is not None
+        assert deleted["chat_id"] == model.get_id()
         mgr.stop()
 
     asyncio.run(run())
@@ -169,7 +183,9 @@ def test_last_client_gone_frees_model(tmp_path):
         mgr.ws_client_gone("r.chat")
         await _drain()
         assert mgr.get("r.chat") is None
-        assert {"path": "r.chat", "action": "closed"} in capture
+        closed = _find(capture, "r.chat", "closed")
+        assert closed is not None
+        assert closed["chat_id"] == m1.get_id()
 
         # Reopening builds a fresh model, not the stale in-memory instance.
         m2 = mgr.ws_open("r.chat")

--- a/python/jupyterlab-chat/jupyterlab_chat/tests/test_events.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/tests/test_events.py
@@ -241,9 +241,9 @@ def test_client_connected_and_disconnected_events(tmp_path):
         model = mgr.ws_open("a.chat")
         chat_id = model.get_id()
 
-        mgr.on_client_connect("a.chat", "client-1")
-        mgr.on_client_connect("a.chat", "client-2")
-        mgr.on_client_disconnect("a.chat", "client-1")
+        mgr.on_client_connect("a.chat", "client-1", chat_id)
+        mgr.on_client_connect("a.chat", "client-2", chat_id)
+        mgr.on_client_disconnect("a.chat", "client-1", chat_id)
         await _drain()
 
         assert events == [

--- a/python/jupyterlab-chat/jupyterlab_chat/tests/test_events.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/tests/test_events.py
@@ -110,7 +110,7 @@ def test_inactivity_frees_model(tmp_path):
         model = mgr.ws_open("c.chat")
         assert not model.handlers  # no connected clients
 
-        mgr._last_active[model.get_id()] = time.time() - 10_000  # stale
+        mgr._last_activity_by_id[model.get_id()] = time.time() - 10_000  # stale
         capture.clear()
         mgr._poll()
         await _drain()
@@ -130,7 +130,7 @@ def test_connected_client_keeps_model_alive(tmp_path):
         (tmp_path / "d.chat").write_text("{}")
         model = mgr.ws_open("d.chat")
         model.handlers["client-1"] = object()  # simulate a connected client
-        mgr._last_active[model.get_id()] = time.time() - 10_000
+        mgr._last_activity_by_id[model.get_id()] = time.time() - 10_000
 
         mgr._poll()
         assert mgr.get(model.get_id()) is model  # kept because a client is connected

--- a/python/jupyterlab-chat/jupyterlab_chat/tests/test_events.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/tests/test_events.py
@@ -235,15 +235,21 @@ def test_client_connected_and_disconnected_events(tmp_path):
 
         mgr.observe_chats(on_event)
 
+        # A live model must exist for client events to carry its chat_id (in
+        # production the WS handler calls ws_open before on_client_connect).
+        (tmp_path / "a.chat").write_text("{}")
+        model = mgr.ws_open("a.chat")
+        chat_id = model.get_id()
+
         mgr.on_client_connect("a.chat", "client-1")
         mgr.on_client_connect("a.chat", "client-2")
         mgr.on_client_disconnect("a.chat", "client-1")
         await _drain()
 
         assert events == [
-            {"path": "a.chat", "action": "client_connected", "client_id": "client-1"},
-            {"path": "a.chat", "action": "client_connected", "client_id": "client-2"},
-            {"path": "a.chat", "action": "client_disconnected", "client_id": "client-1"},
+            {"path": "a.chat", "action": "client_connected", "chat_id": chat_id, "client_id": "client-1"},
+            {"path": "a.chat", "action": "client_connected", "chat_id": chat_id, "client_id": "client-2"},
+            {"path": "a.chat", "action": "client_disconnected", "chat_id": chat_id, "client_id": "client-1"},
         ]
 
     asyncio.run(run())

--- a/python/jupyterlab-chat/jupyterlab_chat/tests/test_events.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/tests/test_events.py
@@ -75,7 +75,7 @@ def test_ws_open_emits_opened_once_and_get(tmp_path):
         # model access
         assert mgr.get("a.chat") is model
         assert mgr.get("missing.chat") is None
-        assert mgr.get("text:chat:xyz") is None  # room id resolves to None w/o RTC
+        assert mgr.get("text:chat:xyz") is None  # unknown key (path) is not live
 
         # second connection to same path: no duplicate `opened`
         capture.clear()

--- a/python/jupyterlab-chat/jupyterlab_chat/tests/test_events.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/tests/test_events.py
@@ -72,10 +72,9 @@ def test_ws_open_emits_opened_once_and_get(tmp_path):
         assert opened is not None
         assert opened["chat_id"] == model.get_id()
 
-        # model access
-        assert mgr.get("a.chat") is model
-        assert mgr.get("missing.chat") is None
-        assert mgr.get("text:chat:xyz") is None  # unknown key (path) is not live
+        # model access (keyed by the stable chat id)
+        assert mgr.get(model.get_id()) is model
+        assert mgr.get("no-such-id") is None
 
         # second connection to same path: no duplicate `opened`
         capture.clear()
@@ -111,12 +110,12 @@ def test_inactivity_frees_model(tmp_path):
         model = mgr.ws_open("c.chat")
         assert not model.handlers  # no connected clients
 
-        mgr._last_active["c.chat"] = time.time() - 10_000  # stale
+        mgr._last_active[model.get_id()] = time.time() - 10_000  # stale
         capture.clear()
         mgr._poll()
         await _drain()
 
-        assert mgr.get("c.chat") is None  # garbage-collected
+        assert mgr.get(model.get_id()) is None  # garbage-collected
         closed = _find(capture, "c.chat", "closed")
         assert closed is not None
         assert closed["chat_id"] == model.get_id()
@@ -131,10 +130,10 @@ def test_connected_client_keeps_model_alive(tmp_path):
         (tmp_path / "d.chat").write_text("{}")
         model = mgr.ws_open("d.chat")
         model.handlers["client-1"] = object()  # simulate a connected client
-        mgr._last_active["d.chat"] = time.time() - 10_000
+        mgr._last_active[model.get_id()] = time.time() - 10_000
 
         mgr._poll()
-        assert mgr.get("d.chat") is model  # kept because a client is connected
+        assert mgr.get(model.get_id()) is model  # kept because a client is connected
         mgr.stop()
 
     asyncio.run(run())
@@ -153,7 +152,7 @@ def test_deletion_frees_model(tmp_path):
         mgr._poll()
         await _drain()
 
-        assert mgr.get("e.chat") is None
+        assert mgr.get(model.get_id()) is None
         deleted = _find(capture, "e.chat", "deleted")
         assert deleted is not None
         assert deleted["chat_id"] == model.get_id()
@@ -180,9 +179,9 @@ def test_last_client_gone_frees_model(tmp_path):
         # Last client disconnects with no active writer -> model is freed.
         m1.handlers.clear()
         capture.clear()
-        mgr.ws_client_gone("r.chat")
+        mgr.ws_client_gone(m1.get_id())
         await _drain()
-        assert mgr.get("r.chat") is None
+        assert mgr.get(m1.get_id()) is None
         closed = _find(capture, "r.chat", "closed")
         assert closed is not None
         assert closed["chat_id"] == m1.get_id()

--- a/python/jupyterlab-chat/jupyterlab_chat/websocket_handler.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/websocket_handler.py
@@ -19,7 +19,7 @@ class WSChatHandler(JupyterHandler, websocket.WebSocketHandler):
     WebSocket handler for a single chat file.
 
     One instance per connected client; all clients connected to the same
-    .chat file share a WsChatModel stored in settings["ws_chat_models"].
+    .chat file share a WsChatModel; the registry lives in settings["chats_by_id"].
     """
     _path: str
 

--- a/python/jupyterlab-chat/jupyterlab_chat/websocket_handler.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/websocket_handler.py
@@ -125,7 +125,7 @@ class WSChatHandler(JupyterHandler, websocket.WebSocketHandler):
                     pass
 
         self.log.info("WS chat client %s connected to model '%s'", self._client_id, path)
-        self._chat_manager.on_client_connect(path, self._client_id)
+        self._chat_manager.on_client_connect(path, self._client_id, model.get_id())
 
     async def on_message(self, raw: str | bytes) -> None:
         try:
@@ -245,7 +245,7 @@ class WSChatHandler(JupyterHandler, websocket.WebSocketHandler):
         model = self._chat_models.get(path)
         if model and client_id:
             model.handlers.pop(client_id, None)
-            self._chat_manager.on_client_disconnect(path, client_id)
+            self._chat_manager.on_client_disconnect(path, client_id, model.get_id())
             if not model.handlers:
                 # Don't free immediately: the manager reclaims the model after a
                 # grace period of inactivity unless a client reconnects.

--- a/python/jupyterlab-chat/jupyterlab_chat/websocket_handler.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/websocket_handler.py
@@ -24,10 +24,6 @@ class WSChatHandler(JupyterHandler, websocket.WebSocketHandler):
     _path: str
 
     @property
-    def _chat_models(self) -> Dict[str, WsChatModel]:
-        return self.settings["ws_chat_models"]
-
-    @property
     def _chat_manager(self):
         return self.settings["chat_manager"]
 
@@ -88,6 +84,7 @@ class WSChatHandler(JupyterHandler, websocket.WebSocketHandler):
         # The manager owns get-or-create and emits the `opened` lifecycle event
         # (once, when the model is first created).
         model = self._chat_manager.ws_open(path)
+        self._model = model
         model.handlers[self._client_id] = self
 
         # Register the connecting user. Prefer the client-provided identity
@@ -138,10 +135,10 @@ class WSChatHandler(JupyterHandler, websocket.WebSocketHandler):
         if not path:
             return
 
-        model = self._chat_models.get(path)
+        model = getattr(self, "_model", None)
         if model is None:
             return
-        self._chat_manager.ws_activity(path)
+        self._chat_manager.ws_activity(model.get_id())
 
         if data.get("is_update"):
             self._handle_update_message(data, model)
@@ -242,12 +239,14 @@ class WSChatHandler(JupyterHandler, websocket.WebSocketHandler):
             return
 
         client_id = getattr(self, "_client_id", None)
-        model = self._chat_models.get(path)
+        model = getattr(self, "_model", None)
         if model and client_id:
             model.handlers.pop(client_id, None)
-            self._chat_manager.on_client_disconnect(path, client_id, model.get_id())
+            self._chat_manager.on_client_disconnect(
+                model.get_path(), client_id, model.get_id()
+            )
             if not model.handlers:
                 # Don't free immediately: the manager reclaims the model after a
                 # grace period of inactivity unless a client reconnects.
-                self._chat_manager.ws_client_gone(path)
+                self._chat_manager.ws_client_gone(model.get_id())
         self.log.info("WS chat client %s disconnected", client_id)


### PR DESCRIPTION
## Summary
Makes the chat's stable id (`chat.get_id()`) the transport-neutral source of truth for chat lifecycle events, and guarantees the frontend `model.id` matches the backend.

## Changes
- **Split `events.py`**: the schema/`ChatEvent` dataclass stay in `events.py`; the `ChatManager` moves to a new `chat_manager.py` (the old placement was confusing). Import path has been changed (`from jupyterlab_chat.chat_manager import ChatManager`).

- **`chat_id`, not `room_id`, in the event**: `CHAT_ROOM_EVENT_SCHEMA`/`ChatEvent` now carry `chat_id` (`chat.get_id()`) and drop `room_id`. `room_id` remains internal to the ChatManager's RTC resolution and to `YChat` (recovering the file id for `get_path()`); it is never emitted. `chat_id` is captured before a model is freed, so `closed`/`deleted` events still carry it, and the RTC `opened` event reads it only after `get_document()` has loaded content (so it never mints a premature id that could conflict with disk).

- **Frontend `ready` carries the id**: `IChatModel.ready` is now `Promise<string>` resolving with the chat id, so `const id = await model.ready` is the guaranteed, backend-matching id. The WebSocket path no longer mints a local `UUID` fallback: the id is exactly the server's `chat.get_id()` delivered in the connection frame. Under RTC the id continues to come from the synchronized shared-document metadata (same value the backend persists).

