### PR TITLE
Fix LabChatModel.id returning undefined due to shadowed accessor

### DIFF
--- a/packages/jupyterlab-chat/src/model.ts
+++ b/packages/jupyterlab-chat/src/model.ts
@@ -278,6 +278,12 @@ export class LabChatModel
     this._readOnly = value;
   }
 
+  // Declaring `set id` in this subclass shadows the base class's accessor
+  // property entirely, so `get id` must be redeclared here too or reading
+  // `.id` on a LabChatModel returns undefined even after `_id` is set.
+  get id(): string | undefined {
+    return super.id;
+  }
   set id(value: string | undefined) {
     super.id = value;
     if (value) {


### PR DESCRIPTION
## Problem

`LabChatModel` declares a `set id` accessor so that assigning the id can trigger `setReady`. However, declaring **only** a setter for a property in a subclass shadows the inherited accessor property *entirely* — JavaScript does not merge the subclass's setter with the base class's getter. As a result, `AbstractChatModel`'s `get id` is never consulted, and reading `.id` on a `LabChatModel` returns `undefined` even though the backing `_id` field is set correctly.

Minimal repro of the language behavior:

```js
class Base { get id() { return this._id; } set id(v) { this._id = v; } }
class Sub extends Base { set id(v) { super.id = v; } }  // no get id
const s = new Sub();
s.id = 'chat-42';
s.id;   // => undefined  (getter shadowed)
s._id;  // => 'chat-42'
```

Any consumer reading `LabChatModel.id` silently gets `undefined`. Downstream this breaks features that key off the chat id after `ready` resolves (e.g. per-chat session lookups).

## Fix

Re-declare `get id` on `LabChatModel` to return `super.id`, restoring the inherited getter alongside the subclass setter.

## Test plan

- Verified `chatModel.id` returns the assigned id after the model becomes ready.
- `jlpm build` passes.