### PR TITLE
Adopt synced document id under RTC instead of minting a new one

### DIFF
--- a/packages/jupyterlab-chat/src/model.ts
+++ b/packages/jupyterlab-chat/src/model.ts
@@ -329,9 +329,20 @@ export class LabChatModel
         .catch(e => console.error('WS chat connection failed', e));
       return;
     }
-    if (!this._sharedModel.id) {
-      // Assigning the shared ID emits a metadata change, which sets the model
-      // ID - and therefore resolves `ready` - through `_onchange`.
+    // The synced document's `id` metadata is the single source of truth for the
+    // chat id under RTC: the server writes it (the same value `chat.get_id()`
+    // returns) and it reaches us through the shared document. When it is already
+    // present at sync time, adopt it and resolve `ready` with it - the initial
+    // sync populates it without emitting an `_onchange` metadata delta, so
+    // nothing else would set the model id and `ready` would never resolve.
+    if (this._sharedModel.id) {
+      this.id = this._sharedModel.id;
+    } else {
+      // Brand-new document with no id yet: assigning the shared id emits a
+      // metadata change that sets the model id - and therefore resolves `ready`
+      // - through `_onchange`. A server-authored id that arrives later is
+      // likewise adopted through `_onchange`. We do NOT mint an id that would
+      // diverge from the server's, since the server reads back this value.
       this._sharedModel.id = UUID.uuid4();
     }
   }


### PR DESCRIPTION
## Problem

Under RTC (collaborative provider), `LabChatModel.markDocumentSynced()` only acted when the shared model had **no** id yet — it minted a `UUID.uuid4()`, and that write resolved `ready` indirectly via the `_onchange` metadata-delta handler.

But when the document syncs and the server-authored `id` metadata is **already present** (the server writes it via `chat.get_id()`), the method did nothing with it. The initial document sync populates the metadata without emitting an `_onchange` `id` delta, so the model id was never set and `ready` never resolved. The chat stayed unready and its `id` was never available.

This breaks any consumer that keys work on the chat id after `ready` — e.g. per-chat persona events / awareness — since the frontend and server would otherwise also disagree on the id when the frontend mints its own.

Symptom: a slow-loading chat under Jupyter Collaboration never leaves its loading state (the toolbar's persona picker/placeholder never appears), while the same chat works fine over the WebSocket transport.

## Fix

Treat the synced document's `id` metadata as the single source of truth (matching the server's `chat.get_id()`): when it is present at sync time, adopt it and resolve `ready` with it. Only mint an id when the document genuinely has none yet; a server-authored id that arrives later is still adopted through `_onchange`. This also avoids minting an id that would diverge from the server's.

## Test plan

- `jlpm build` passes.
- Under RTC, a chat whose document already carries a server id becomes ready with that exact id (no divergent locally-minted UUID).