### PR TITLE
Clean up chat WebSocket API

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -45,14 +45,14 @@ jobs:
             galata: '^5.6.0'
             # Latest line owns the reference snapshots, so comparisons run.
             ignore_snapshots: ''
-            grep_invert: ''
+            grep_invert: '@websocket'
           - name: 'JupyterLab <4.6 + Collaboration v4'
             jupyterlab: '>=4.2,<4.6'
             collaboration: '~=4.0'
             galata: '~5.5.10'
             # No version-specific snapshots for this line; skip comparisons.
             ignore_snapshots: '1'
-            grep_invert: ''
+            grep_invert: '@websocket'
           # --- RTC-free jobs: jupyter_collaboration NOT installed ---
           - name: 'JupyterLab >=4.6'
             jupyterlab: '>=4.6,<4.7'

--- a/packages/jupyter-chat/src/model.ts
+++ b/packages/jupyter-chat/src/model.ts
@@ -318,9 +318,14 @@ export abstract class AbstractChatModel implements IChatModel {
 
     this._readyDelegate = new PromiseDelegate<string>();
 
-    this.ready.then(() => {
-      this._inputModel.chatContext = this.createChatContext();
-    });
+    this.ready
+      .then(() => {
+        this._inputModel.chatContext = this.createChatContext();
+      })
+      .catch(() => {
+        // `ready` was rejected (the chat failed to open); no context is created.
+        // The failure is surfaced to the user by the hosting widget.
+      });
   }
 
   /**
@@ -439,6 +444,18 @@ export abstract class AbstractChatModel implements IChatModel {
    */
   protected setReady(id: string): void {
     this._readyDelegate.resolve(id);
+  }
+
+  /**
+   * Mark the chat as failed to become ready, rejecting `ready`.
+   *
+   * Used when the chat can never become usable - e.g. the WebSocket connection
+   * was closed by the server before the connection frame arrived. Consumers of
+   * `ready` (such as the widgets that show a loading spinner) can then react to
+   * the failure instead of hanging forever.
+   */
+  protected setError(reason: unknown): void {
+    this._readyDelegate.reject(reason);
   }
 
   /**

--- a/packages/jupyter-chat/src/widgets/multichat-panel.tsx
+++ b/packages/jupyter-chat/src/widgets/multichat-panel.tsx
@@ -8,7 +8,11 @@
  * Originally adapted from jupyterlab-chat's ChatPanel
  */
 
-import { InputDialog, ToolbarRegistry } from '@jupyterlab/apputils';
+import {
+  InputDialog,
+  Notification,
+  ToolbarRegistry
+} from '@jupyterlab/apputils';
 import { IObservableList } from '@jupyterlab/observables';
 import { nullTranslator, TranslationBundle } from '@jupyterlab/translation';
 import {
@@ -554,9 +558,23 @@ class SidePanelWidget extends ReactivePanelWithToolbar implements IChatPanel {
     // Add spinner while loading
     const spinner = new Spinner();
     this.addWidget(spinner);
-    this._chatWidget.model.ready.then(() => {
-      spinner.dispose();
-    });
+    this._chatWidget.model.ready
+      .then(() => {
+        spinner.dispose();
+      })
+      .catch(() => {
+        // The chat could not be opened (e.g. the server closed the WebSocket
+        // because the path was invalid). Dispose the spinner and close this
+        // chat so no loading spinner is left hanging; the side panel stays open.
+        spinner.dispose();
+        Notification.error(
+          trans.__(
+            "Unable to open chat at given path: '%1'.",
+            this._chatWidget.model.name
+          )
+        );
+        options.onClose(this._displayName);
+      });
 
     // Add the chat widget
     this.addWidget(this._chatWidget);

--- a/packages/jupyterlab-chat/src/model.ts
+++ b/packages/jupyterlab-chat/src/model.ts
@@ -230,8 +230,7 @@ export class LabChatModel
 
     if (!this.collaborative && options.serverSettings) {
       this._wsHandler = new WebSocketHandler({
-        serverSettings: options.serverSettings,
-        user: this._user
+        serverSettings: options.serverSettings
       });
       this._wsHandler.messageReceived.connect(this._onWsMessage, this);
       this._wsHandler.usersChanged.connect(this._onWsUsersChanged, this);

--- a/packages/jupyterlab-chat/src/model.ts
+++ b/packages/jupyterlab-chat/src/model.ts
@@ -310,19 +310,23 @@ export class LabChatModel
       this._wsHandler.initialize();
       this._wsHandler.ready
         .then(() => {
+          // The connection frame carries both the chat id and the identity the
+          // server registered for this connection. The chat is not ready until
+          // both are known: the client adopts the server-assigned identity (the
+          // RTC-free server owns identity) and takes the server's chat id.
+          const wsUser = this._wsHandler!.connectedUser;
+          const serverId = this._wsHandler!.chatId;
+          if (!wsUser || !serverId) {
+            console.error(
+              'WS chat connection frame did not include the user identity ' +
+                'and chat id; the chat cannot become ready. Is the server up ' +
+                'to date?'
+            );
+            return;
+          }
+          this._user = new LabChatUser(wsUser);
           if (!this.id) {
-            // The server is the single source of truth for the chat id: it is
-            // delivered in the WS connection frame (from `chat.get_id()`). We do
-            // NOT mint a local id, so `model.id` always matches the backend.
-            const serverId = this._wsHandler!.chatId;
-            if (serverId) {
-              this.id = serverId;
-            } else {
-              console.error(
-                'WS chat connection frame did not include a chat id; ' +
-                  'the chat cannot become ready. Is the server up to date?'
-              );
-            }
+            this.id = serverId;
           }
         })
         .catch(e => {

--- a/packages/jupyterlab-chat/src/model.ts
+++ b/packages/jupyterlab-chat/src/model.ts
@@ -325,7 +325,12 @@ export class LabChatModel
             }
           }
         })
-        .catch(e => console.error('WS chat connection failed', e));
+        .catch(e => {
+          console.error('WS chat connection failed', e);
+          // Fail `ready` so the hosting widget disposes the chat and notifies
+          // the user, instead of leaving a loading spinner forever.
+          this.setError(e instanceof Error ? e : new Error(String(e)));
+        });
       return;
     }
     // The synced document's `id` metadata is the single source of truth for the

--- a/packages/jupyterlab-chat/src/websocket-handler.ts
+++ b/packages/jupyterlab-chat/src/websocket-handler.ts
@@ -95,6 +95,15 @@ export class WebSocketHandler {
     return this._chatId;
   }
 
+  /**
+   * The identity the server registered for this connection, received on the
+   * connection message. Available once `ready` has resolved; `undefined`
+   * against older servers that do not send it.
+   */
+  get connectedUser(): IUser | undefined {
+    return this._connectedUser;
+  }
+
   setPath(path: string): void {
     this._path = path;
   }
@@ -157,6 +166,7 @@ export class WebSocketHandler {
   private _handleMessage(data: any): void {
     if (data.type === 'connection') {
       this._chatId = data.id as string | undefined;
+      this._connectedUser = (data.user as IUser) ?? undefined;
       this._usersMap = (data.users as Record<string, IUser>) ?? {};
       this._usersChanged.emit(this._usersMap);
       for (const msg of (data.messages as any[]) ?? []) {
@@ -275,6 +285,7 @@ export class WebSocketHandler {
   private _disposed = false;
   private _connected = false;
   private _chatId: string | undefined;
+  private _connectedUser: IUser | undefined;
   private _socket: WebSocket | null = null;
   private _serverSettings: ServerConnection.ISettings;
   private _usersMap: Record<string, IUser> = {};

--- a/packages/jupyterlab-chat/src/websocket-handler.ts
+++ b/packages/jupyterlab-chat/src/websocket-handler.ts
@@ -162,6 +162,7 @@ export class WebSocketHandler {
       for (const msg of (data.messages as any[]) ?? []) {
         this._messageReceived.emit(this._toMessageContent(msg));
       }
+      this._connected = true;
       this._ready.resolve();
     } else if (data.type === 'users') {
       const incoming = (data.users as Record<string, IUser>) ?? {};
@@ -242,7 +243,23 @@ export class WebSocketHandler {
       }
     };
     this._socket.onclose = event => {
-      if (event.code === 1006 && !this._disposed) {
+      if (this._disposed) {
+        return;
+      }
+      // Closed before the connection frame arrived: the chat could not be
+      // opened (e.g. the server rejected the path). Fail `ready` so the hosting
+      // widget can surface the error, instead of reconnecting into the same
+      // failure or leaving a spinner hanging forever.
+      if (!this._connected) {
+        this._ready.reject(
+          new Error(
+            `Chat WebSocket was closed before opening (code ${event.code})`
+          )
+        );
+        return;
+      }
+      // An established connection dropped abnormally: try to reconnect.
+      if (event.code === 1006) {
         setTimeout(() => {
           if (!this._disposed) {
             this._openSocket();
@@ -256,6 +273,7 @@ export class WebSocketHandler {
 
   private _path = '';
   private _disposed = false;
+  private _connected = false;
   private _chatId: string | undefined;
   private _socket: WebSocket | null = null;
   private _serverSettings: ServerConnection.ISettings;

--- a/packages/jupyterlab-chat/src/websocket-handler.ts
+++ b/packages/jupyterlab-chat/src/websocket-handler.ts
@@ -9,19 +9,29 @@ import { ServerConnection } from '@jupyterlab/services';
 import { PromiseDelegate, UUID } from '@lumino/coreutils';
 import { ISignal, Signal } from '@lumino/signaling';
 
-const WS_PATH = 'api/jupyter-chat/ws';
+const WS_PATH = 'api/chat/ws';
+
+/**
+ * Encode a chat path as a single URL-safe segment.
+ *
+ * The path is base64url-encoded (no padding) so it can contain slashes and
+ * other characters while remaining a single, unambiguous URL path segment.
+ */
+function encodePathSegment(path: string): string {
+  const bytes = new TextEncoder().encode(path);
+  let binary = '';
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary)
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}
 
 export namespace WebSocketHandler {
   export interface IOptions {
     serverSettings: ServerConnection.ISettings;
-    /**
-     * The local user identity. Carried on outgoing message frames so the
-     * server records the sender as the client's identity (matching the
-     * collaborative mode, where the sender is set on the frontend). Optional
-     * for backward compatibility — the server falls back to its authenticated
-     * user when absent.
-     */
-    user?: IUser;
   }
 
   /**
@@ -60,14 +70,6 @@ export namespace WebSocketHandler {
 export class WebSocketHandler {
   constructor(options: WebSocketHandler.IOptions) {
     this._serverSettings = options.serverSettings;
-    this._user = options.user ?? null;
-  }
-
-  /**
-   * The local user identity, carried on outgoing message frames.
-   */
-  set user(value: IUser | null) {
-    this._user = value;
   }
 
   /**
@@ -137,9 +139,6 @@ export class WebSocketHandler {
     }
     if (message.metadata) {
       msg.metadata = message.metadata;
-    }
-    if (this._user) {
-      msg.user = this._user;
     }
     this._send(msg);
     return id;
@@ -248,14 +247,13 @@ export class WebSocketHandler {
   }
 
   private _openSocket(): void {
-    const wsUrl = URLExt.join(this._serverSettings.wsUrl, WS_PATH);
+    const wsUrl = URLExt.join(
+      this._serverSettings.wsUrl,
+      WS_PATH,
+      encodePathSegment(this._path)
+    );
     const token = this._serverSettings.token;
-    const url =
-      `${wsUrl}?path=${encodeURIComponent(this._path)}` +
-      (token ? `&token=${encodeURIComponent(token)}` : '') +
-      (this._user
-        ? `&user=${encodeURIComponent(JSON.stringify(this._user))}`
-        : '');
+    const url = token ? `${wsUrl}?token=${encodeURIComponent(token)}` : wsUrl;
 
     this._socket = new WebSocket(url);
     this._socket.onmessage = event => {
@@ -281,7 +279,6 @@ export class WebSocketHandler {
   private _path = '';
   private _disposed = false;
   private _chatId: string | undefined;
-  private _user: IUser | null = null;
   private _socket: WebSocket | null = null;
   private _serverSettings: ServerConnection.ISettings;
   private _usersMap: Record<string, IUser> = {};

--- a/packages/jupyterlab-chat/src/websocket-handler.ts
+++ b/packages/jupyterlab-chat/src/websocket-handler.ts
@@ -11,24 +11,6 @@ import { ISignal, Signal } from '@lumino/signaling';
 
 const WS_PATH = 'api/chat/ws';
 
-/**
- * Encode a chat path as a single URL-safe segment.
- *
- * The path is base64url-encoded (no padding) so it can contain slashes and
- * other characters while remaining a single, unambiguous URL path segment.
- */
-function encodePathSegment(path: string): string {
-  const bytes = new TextEncoder().encode(path);
-  let binary = '';
-  for (const byte of bytes) {
-    binary += String.fromCharCode(byte);
-  }
-  return btoa(binary)
-    .replace(/\+/g, '-')
-    .replace(/\//g, '_')
-    .replace(/=+$/, '');
-}
-
 export namespace WebSocketHandler {
   export interface IOptions {
     serverSettings: ServerConnection.ISettings;
@@ -247,11 +229,7 @@ export class WebSocketHandler {
   }
 
   private _openSocket(): void {
-    const wsUrl = URLExt.join(
-      this._serverSettings.wsUrl,
-      WS_PATH,
-      encodePathSegment(this._path)
-    );
+    const wsUrl = `${URLExt.join(this._serverSettings.wsUrl, WS_PATH)}/${encodeURIComponent(this._path)}`;
     const token = this._serverSettings.token;
     const url = token ? `${wsUrl}?token=${encodeURIComponent(token)}` : wsUrl;
 

--- a/packages/jupyterlab-chat/src/widget.tsx
+++ b/packages/jupyterlab-chat/src/widget.tsx
@@ -4,6 +4,7 @@
  */
 
 import { ChatArea, ChatWidget, IChatModel, IChatPanel } from '@jupyter/chat';
+import { Notification } from '@jupyterlab/apputils';
 import { DocumentWidget } from '@jupyterlab/docregistry';
 
 import { LabChatModel } from './model';
@@ -28,6 +29,15 @@ export class LabChatPanel
     this.context.ready
       .then(() => this.model.markDocumentSynced())
       .catch(e => console.error('The chat document failed to load', e));
+    // If the chat can never become ready (e.g. the server closed the WebSocket
+    // because the path was invalid), dispose this widget so no loading spinner
+    // is left hanging, and let the user know.
+    this.model.ready.catch(() => {
+      Notification.error(
+        `Unable to open chat at given path: '${this.model.name}'.`
+      );
+      this.dispose();
+    });
   }
 
   /**

--- a/python/jupyterlab-chat/jupyterlab_chat/__init__.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/__init__.py
@@ -74,7 +74,7 @@ def _load_jupyter_server_extension(server_app):
     if not rtc_info.enabled:
         base_url = server_app.web_app.settings.get("base_url", "/")
         server_app.web_app.add_handlers(".*$", [
-            (url_path_join(base_url, "api/jupyter-chat/ws"), WSChatHandler),
+            (url_path_join(base_url, "api/chat/ws", "(.+)"), WSChatHandler),
         ])
 
     name = "jupyterlab_chat"

--- a/python/jupyterlab-chat/jupyterlab_chat/tests/test_websocket_handler.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/tests/test_websocket_handler.py
@@ -3,7 +3,22 @@
 
 """Tests for the RTC-free WebSocket handler connection guards."""
 
-from jupyterlab_chat.websocket_handler import WSChatHandler
+from jupyterlab_chat.websocket_handler import WSChatHandler, is_safe_chat_path
+
+
+def test_is_safe_chat_path_accepts_in_root_paths(tmp_path):
+    assert is_safe_chat_path("a.chat", tmp_path)
+    assert is_safe_chat_path("nested/dir/a.chat", tmp_path)
+    # A ``..`` that resolves back inside root is still safe.
+    assert is_safe_chat_path("nested/../a.chat", tmp_path)
+
+
+def test_is_safe_chat_path_rejects_unsafe_paths(tmp_path):
+    assert not is_safe_chat_path("", tmp_path)
+    assert not is_safe_chat_path("/etc/passwd", tmp_path)
+    assert not is_safe_chat_path("../secret.chat", tmp_path)
+    assert not is_safe_chat_path("a/../../secret.chat", tmp_path)
+    assert not is_safe_chat_path("a\x00b.chat", tmp_path)
 
 
 def test_path_is_instance_attribute_not_class_default():

--- a/python/jupyterlab-chat/jupyterlab_chat/tests/test_websocket_handler.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/tests/test_websocket_handler.py
@@ -32,12 +32,22 @@ def test_decode_chat_path_invalid_segment_returns_empty():
     assert decode_chat_path("@@@not-base64@@@") == ""
 
 
+def test_path_is_instance_attribute_not_class_default():
+    # `_path` is a plain annotation with no class-level default; `initialize()`
+    # sets it as an instance attribute so it always resolves.
+    assert "_path" not in vars(WSChatHandler)
+    handler = WSChatHandler.__new__(WSChatHandler)
+    handler.initialize()
+    assert handler._path == ""
+
+
 def test_on_close_is_noop_when_connection_never_opened():
     """A connection that closes before ``open()`` set ``_path`` must not raise.
 
-    ``_path`` has a real class default of "" so ``on_close`` reads it safely and
-    returns early instead of raising ``AttributeError``.
+    ``initialize()`` sets ``_path`` to "" as an instance attribute, so
+    ``on_close`` reads it safely and returns early instead of raising
+    ``AttributeError``.
     """
     handler = WSChatHandler.__new__(WSChatHandler)
-    assert handler._path == ""
+    handler.initialize()
     handler.on_close()  # no-op, no exception

--- a/python/jupyterlab-chat/jupyterlab_chat/tests/test_websocket_handler.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/tests/test_websocket_handler.py
@@ -1,0 +1,43 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+"""Tests for the RTC-free WebSocket handler path encoding and connection guards."""
+
+import base64
+
+from jupyterlab_chat.websocket_handler import WSChatHandler, decode_chat_path
+
+
+def _urlsafe_b64_no_pad(text: str) -> str:
+    """Encode like the frontend does: URL-safe base64 without padding."""
+    return base64.urlsafe_b64encode(text.encode("utf-8")).decode("ascii").rstrip("=")
+
+
+def test_decode_chat_path_roundtrips_paths_with_slashes():
+    path = "some/nested/folder/my chat.chat"
+    assert decode_chat_path(_urlsafe_b64_no_pad(path)) == path
+
+
+def test_decode_chat_path_roundtrips_unicode():
+    path = "café/notebooks/чат.chat"
+    assert decode_chat_path(_urlsafe_b64_no_pad(path)) == path
+
+
+def test_decode_chat_path_empty_segment_returns_empty():
+    assert decode_chat_path("") == ""
+
+
+def test_decode_chat_path_invalid_segment_returns_empty():
+    # Not valid base64url -> treated as "no path" rather than raising.
+    assert decode_chat_path("@@@not-base64@@@") == ""
+
+
+def test_on_close_is_noop_when_connection_never_opened():
+    """A connection that closes before ``open()`` set ``_path`` must not raise.
+
+    ``_path`` has a real class default of "" so ``on_close`` reads it safely and
+    returns early instead of raising ``AttributeError``.
+    """
+    handler = WSChatHandler.__new__(WSChatHandler)
+    assert handler._path == ""
+    handler.on_close()  # no-op, no exception

--- a/python/jupyterlab-chat/jupyterlab_chat/tests/test_websocket_handler.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/tests/test_websocket_handler.py
@@ -1,35 +1,9 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-"""Tests for the RTC-free WebSocket handler path encoding and connection guards."""
+"""Tests for the RTC-free WebSocket handler connection guards."""
 
-import base64
-
-from jupyterlab_chat.websocket_handler import WSChatHandler, decode_chat_path
-
-
-def _urlsafe_b64_no_pad(text: str) -> str:
-    """Encode like the frontend does: URL-safe base64 without padding."""
-    return base64.urlsafe_b64encode(text.encode("utf-8")).decode("ascii").rstrip("=")
-
-
-def test_decode_chat_path_roundtrips_paths_with_slashes():
-    path = "some/nested/folder/my chat.chat"
-    assert decode_chat_path(_urlsafe_b64_no_pad(path)) == path
-
-
-def test_decode_chat_path_roundtrips_unicode():
-    path = "café/notebooks/чат.chat"
-    assert decode_chat_path(_urlsafe_b64_no_pad(path)) == path
-
-
-def test_decode_chat_path_empty_segment_returns_empty():
-    assert decode_chat_path("") == ""
-
-
-def test_decode_chat_path_invalid_segment_returns_empty():
-    # Not valid base64url -> treated as "no path" rather than raising.
-    assert decode_chat_path("@@@not-base64@@@") == ""
+from jupyterlab_chat.websocket_handler import WSChatHandler
 
 
 def test_path_is_instance_attribute_not_class_default():

--- a/python/jupyterlab-chat/jupyterlab_chat/websocket_handler.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/websocket_handler.py
@@ -1,6 +1,7 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+import base64
 import json
 import time
 import uuid
@@ -14,6 +15,23 @@ from .models import ChatMessageAction, User
 from .websocket_model import WsChatModel
 
 
+def decode_chat_path(segment: str) -> str:
+    """Decode a chat path from its URL segment.
+
+    The path is carried as a single URL-safe base64 segment (no padding) so it
+    can contain slashes and other characters without needing to be a valid,
+    unambiguous URL path on its own. Returns an empty string when the segment is
+    missing or cannot be decoded.
+    """
+    if not segment:
+        return ""
+    try:
+        padding = "=" * (-len(segment) % 4)
+        return base64.urlsafe_b64decode(segment + padding).decode("utf-8")
+    except (ValueError, UnicodeDecodeError):
+        return ""
+
+
 class WSChatHandler(JupyterHandler, websocket.WebSocketHandler):
     """
     WebSocket handler for a single chat file.
@@ -21,7 +39,12 @@ class WSChatHandler(JupyterHandler, websocket.WebSocketHandler):
     One instance per connected client; all clients connected to the same
     .chat file share a WsChatModel; the registry lives in settings["chats_by_id"].
     """
-    _path: str
+    # A real default (not just an annotation) so ``self._path`` resolves even
+    # when the connection closes before ``open()`` runs -- e.g. a connection
+    # that never sends a decodable chat path, causing ``open()`` to
+    # ``self.close()`` and return early. Both ``on_message`` and ``on_close``
+    # treat a falsy ``_path`` as "never opened" and return.
+    _path: str = ""
 
     @property
     def _chat_manager(self):
@@ -45,37 +68,10 @@ class WSChatHandler(JupyterHandler, websocket.WebSocketHandler):
         if result is not None:
             await result
 
-    def _parse_client_user(self):
-        """Parse the optional client-provided identity from the connect query.
-
-        Returns a ``User`` built from the frontend's ``user`` query argument, or
-        ``None`` when it is absent or malformed.
-        """
-        raw = self.get_query_argument("user", None)
-        if not raw:
-            return None
-        try:
-            data = json.loads(raw)
-        except (json.JSONDecodeError, TypeError):
-            return None
-        if not isinstance(data, dict):
-            return None
-        username = data.get("username")
-        if not username:
-            return None
-        return User(
-            username=username,
-            name=data.get("name") or username,
-            display_name=data.get("display_name") or username,
-            initials=data.get("initials") or username[0].upper(),
-            color=data.get("color"),
-            avatar_url=data.get("avatar_url"),
-        )
-
     def open(self, *args: str, **kwargs: str):
-        path = self.get_query_argument("path", None)
-        if path is None:
-            self.close(1008, "Missing 'path' query parameter")
+        path = decode_chat_path(args[0] if args else "")
+        if not path:
+            self.close(1008, "Missing or invalid chat path")
             return
 
         self._path = path
@@ -87,13 +83,12 @@ class WSChatHandler(JupyterHandler, websocket.WebSocketHandler):
         self._model = model
         model.handlers[self._client_id] = self
 
-        # Register the connecting user. Prefer the client-provided identity
-        # (matching collaborative mode, where the user is set on the frontend)
-        # so it equals the frontend's own identity and is excluded from its own
-        # mention suggestions. Fall back to the authenticated server user for
-        # older clients that do not send their identity.
+        # Register the connecting user using the server's authenticated identity.
+        # The WS transport is single-user, so every connection -- from any tab or
+        # client -- is the same authenticated user; there is no separate frontend
+        # identity to carry.
         current_user = self.current_user
-        user = self._parse_client_user() or User(
+        user = User(
             username=current_user.username,
             name=current_user.name or current_user.username,
             display_name=current_user.display_name or current_user.username,
@@ -147,19 +142,9 @@ class WSChatHandler(JupyterHandler, websocket.WebSocketHandler):
 
     def _handle_new_message(self, data: dict, model: WsChatModel) -> None:
         timestamp = time.time()
-        # Prefer the client-provided identity as the sender, matching the
-        # collaborative mode where the sender is set on the frontend. Fall back
-        # to the authenticated server user for older clients that do not send
-        # their identity.
-        client_user = data.get("user")
-        new_user_registered = False
-        if isinstance(client_user, dict) and client_user.get("username"):
-            sender = client_user["username"]
-            if model._users.get(sender) != client_user:
-                model._users[sender] = client_user
-                new_user_registered = True
-        else:
-            sender = self.current_user.username
+        # The WS transport is single-user: the sender is always the
+        # authenticated server user, already registered in `open()`.
+        sender = self.current_user.username
         message: dict = {
             "id": data.get("id") or str(uuid.uuid4()),
             "body": data.get("body", ""),
@@ -181,10 +166,6 @@ class WSChatHandler(JupyterHandler, websocket.WebSocketHandler):
         model._messages.insert(idx, message)
         model._indexes_by_id = {m["id"]: i for i, m in enumerate(model._messages)}
         model.save()
-        # If we learned a new sender identity, tell all clients first so they can
-        # resolve the sender (display name/avatar) when the message arrives.
-        if new_user_registered:
-            model.broadcast(json.dumps({"type": "users", "users": model._users}))
         model.broadcast(
             json.dumps({"type": "msg", "message": model.resolve_message(message)})
         )

--- a/python/jupyterlab-chat/jupyterlab_chat/websocket_handler.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/websocket_handler.py
@@ -2,6 +2,7 @@
 # Distributed under the terms of the Modified BSD License.
 
 import json
+import os
 import time
 import uuid
 from pathlib import Path
@@ -12,6 +13,24 @@ from tornado import web, websocket
 
 from .models import ChatMessageAction, User
 from .websocket_model import WsChatModel
+
+
+def is_safe_chat_path(path: str, root_dir: Path) -> bool:
+    """Whether ``path`` is a safe, in-root relative chat path.
+
+    Rejects empty, NUL-containing, absolute, and parent-escaping (``..``) paths
+    so a malformed or hostile path can never read or write outside the server
+    root. ``os.path`` is used (not ``posixpath``) as the correct cross-platform
+    choice, and ``commonpath`` confirms the resolved path stays within root.
+    """
+    if not path or "\x00" in path or os.path.isabs(path):
+        return False
+    root = str(root_dir)
+    full = os.path.normpath(os.path.join(root, path))
+    try:
+        return os.path.commonpath((root, full)) == root
+    except ValueError:
+        return False
 
 
 class WSChatHandler(JupyterHandler, websocket.WebSocketHandler):
@@ -59,8 +78,10 @@ class WSChatHandler(JupyterHandler, websocket.WebSocketHandler):
         # tornado url-unescapes the captured route segment, so ``args[0]`` is the
         # decoded chat path (with slashes restored).
         path = args[0] if args else ""
-        if not path:
-            self.close(1008, "Missing or invalid chat path")
+        if not is_safe_chat_path(path, self._root_dir):
+            # 1008 (policy violation): the path is missing, unparseable, or would
+            # escape the server root. The frontend surfaces this to the user.
+            self.close(1008, "Invalid chat path")
             return
 
         self._path = path

--- a/python/jupyterlab-chat/jupyterlab_chat/websocket_handler.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/websocket_handler.py
@@ -6,7 +6,7 @@ import json
 import time
 import uuid
 from pathlib import Path
-from typing import Dict
+from typing import Any, Dict
 
 from jupyter_server.base.handlers import JupyterHandler
 from tornado import web, websocket
@@ -39,12 +39,17 @@ class WSChatHandler(JupyterHandler, websocket.WebSocketHandler):
     One instance per connected client; all clients connected to the same
     .chat file share a WsChatModel; the registry lives in settings["chats_by_id"].
     """
-    # A real default (not just an annotation) so ``self._path`` resolves even
-    # when the connection closes before ``open()`` runs -- e.g. a connection
-    # that never sends a decodable chat path, causing ``open()`` to
-    # ``self.close()`` and return early. Both ``on_message`` and ``on_close``
-    # treat a falsy ``_path`` as "never opened" and return.
-    _path: str = ""
+    _path: str
+
+    def initialize(self, *args: Any, **kwargs: Any) -> None:
+        super().initialize(*args, **kwargs)
+        # Set as an instance attribute (not a class-level default) so
+        # ``self._path`` always resolves -- including when the connection closes
+        # before ``open()`` runs, e.g. a connection that never sends a decodable
+        # chat path, so ``open()`` calls ``self.close()`` and returns early.
+        # Both ``on_message`` and ``on_close`` treat a falsy ``_path`` as
+        # "never opened" and return.
+        self._path = ""
 
     @property
     def _chat_manager(self):

--- a/python/jupyterlab-chat/jupyterlab_chat/websocket_handler.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/websocket_handler.py
@@ -1,7 +1,6 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-import base64
 import json
 import time
 import uuid
@@ -13,23 +12,6 @@ from tornado import web, websocket
 
 from .models import ChatMessageAction, User
 from .websocket_model import WsChatModel
-
-
-def decode_chat_path(segment: str) -> str:
-    """Decode a chat path from its URL segment.
-
-    The path is carried as a single URL-safe base64 segment (no padding) so it
-    can contain slashes and other characters without needing to be a valid,
-    unambiguous URL path on its own. Returns an empty string when the segment is
-    missing or cannot be decoded.
-    """
-    if not segment:
-        return ""
-    try:
-        padding = "=" * (-len(segment) % 4)
-        return base64.urlsafe_b64decode(segment + padding).decode("utf-8")
-    except (ValueError, UnicodeDecodeError):
-        return ""
 
 
 class WSChatHandler(JupyterHandler, websocket.WebSocketHandler):
@@ -74,7 +56,9 @@ class WSChatHandler(JupyterHandler, websocket.WebSocketHandler):
             await result
 
     def open(self, *args: str, **kwargs: str):
-        path = decode_chat_path(args[0] if args else "")
+        # tornado url-unescapes the captured route segment, so ``args[0]`` is the
+        # decoded chat path (with slashes restored).
+        path = args[0] if args else ""
         if not path:
             self.close(1008, "Missing or invalid chat path")
             return

--- a/python/jupyterlab-chat/jupyterlab_chat/websocket_handler.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/websocket_handler.py
@@ -5,6 +5,7 @@ import json
 import os
 import time
 import uuid
+from dataclasses import asdict
 from pathlib import Path
 from typing import Any, Dict
 
@@ -108,11 +109,15 @@ class WSChatHandler(JupyterHandler, websocket.WebSocketHandler):
         )
         model.set_user(user)
 
-        # Send full history so the client can render existing messages
+        # Send full history so the client can render existing messages. The
+        # connecting user's identity is included so the client adopts the same
+        # (server-authoritative) identity the server registered for it -- used
+        # for sender attribution and to exclude itself from mention suggestions.
         self.write_message(json.dumps({
             "type": "connection",
             "client_id": self._client_id,
             "id": model.get_id(),
+            "user": asdict(user),
             "messages": [model.resolve_message(m) for m in model._messages],
             "users": model._users,
         }))

--- a/ui-tests/jupyter_server_test_config.py
+++ b/ui-tests/jupyter_server_test_config.py
@@ -11,6 +11,31 @@ from jupyterlab.galata import configure_jupyter_server
 
 configure_jupyter_server(c)
 
+# The RTC-free chat WebSocket derives the sender identity from the server's
+# authenticated user, and the client adopts that same identity. The default
+# identity provider mints a *random* anonymous user on each generation, so the
+# REST (`/api/me`) identity and the chat WebSocket identity could differ and
+# were not reproducible. Return a single fixed user instead: this keeps the two
+# identical and stable (deterministic screenshots and ownership checks), and it
+# matches the `USER` constant the frontend tests use. Patching the method on the
+# base class (rather than swapping the provider class) preserves the auth
+# configuration galata already applied.
+from jupyter_server.auth.identity import IdentityProvider, User
+
+
+def _fixed_anonymous_user(self, handler):
+    return User(
+        username="test-user",
+        name="jovyan",
+        display_name="jovyan",
+        initials="JP",
+        avatar_url=None,
+        color="var(--jp-collaborator-color1)",
+    )
+
+
+IdentityProvider.generate_anonymous_user = _fixed_anonymous_user
+
 # Bind a configurable port (defaults to 8888, unchanged) so a parallel
 # worktree/checkout can run the suite on its own port. Kept in sync with
 # TEST_PORT in playwright.config.js.

--- a/ui-tests/tests/invalid-path.spec.ts
+++ b/ui-tests/tests/invalid-path.spec.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+import { expect, test } from '@jupyterlab/galata';
+import { webSocketOnly } from './tags';
+
+/**
+ * When the server rejects a chat path, it closes the WebSocket. The RTC-free
+ * client must handle that gracefully: no loading spinner left hanging, the chat
+ * removed, and an error notification shown.
+ *
+ * A path that escapes the server root is rejected by the server. It cannot be
+ * reached through the normal "open a chat file" UI (which validates existence
+ * against the ContentsManager first), so the chat is opened directly on the
+ * side panel with an unsafe path.
+ */
+const UNSAFE_PATH = '../../../invalid-chat-path.chat';
+const CHAT_PANEL_ID = 'jupyter-chat::multi-chat-panel';
+
+test.describe('#invalid-chat-path', webSocketOnly, () => {
+  test('side panel closes the chat and notifies on server rejection', async ({
+    page
+  }) => {
+    await page.evaluate(
+      async ({ unsafePath, panelId }) => {
+        const app = (window as any).jupyterapp;
+        let chatPanel: any = null;
+        for (const widget of app.shell.widgets('left')) {
+          if (widget.id === panelId) {
+            chatPanel = widget;
+            break;
+          }
+        }
+        if (!chatPanel) {
+          throw new Error('Chat side panel not found');
+        }
+        app.shell.activateById(chatPanel.id);
+
+        // Build a chat model directly at the unsafe path (bypassing the
+        // existence check in the open-chat command) and open it in the panel.
+        const factory = app.docRegistry.getModelFactory('chat');
+        const model = factory.createNew({});
+        model.name = unsafePath;
+        model.markDocumentSynced();
+        chatPanel.open({ model, displayName: 'invalid-chat' });
+      },
+      { unsafePath: UNSAFE_PATH, panelId: CHAT_PANEL_ID }
+    );
+
+    // An error notification is shown to the user.
+    await expect(
+      page.getByText(/Unable to open chat at given path/)
+    ).toBeVisible();
+
+    // The chat is closed: no loading spinner is left hanging in the panel.
+    const chatPanel = page.locator(`[id="${CHAT_PANEL_ID}"]`);
+    await expect(chatPanel.locator('.jp-Spinner')).toHaveCount(0);
+  });
+});

--- a/ui-tests/tests/invalid-path.spec.ts
+++ b/ui-tests/tests/invalid-path.spec.ts
@@ -17,7 +17,7 @@ import { webSocketOnly } from './tags';
  * side panel with an unsafe path.
  */
 const UNSAFE_PATH = '../../../invalid-chat-path.chat';
-const CHAT_PANEL_ID = 'jupyter-chat::multi-chat-panel';
+const CHAT_PANEL_ID = 'JupyterlabChat:sidepanel';
 
 test.describe('#invalid-chat-path', webSocketOnly, () => {
   test('side panel closes the chat and notifies on server rejection', async ({
@@ -27,8 +27,11 @@ test.describe('#invalid-chat-path', webSocketOnly, () => {
       async ({ unsafePath, panelId }) => {
         const app = (window as any).jupyterapp;
         let chatPanel: any = null;
-        for (const widget of app.shell.widgets('left')) {
-          if (widget.id === panelId) {
+        for (const widget of Array.from(app.shell.widgets('left')) as any[]) {
+          if (
+            widget.id === panelId ||
+            (widget.hasClass && widget.hasClass('jp-chat-sidepanel'))
+          ) {
             chatPanel = widget;
             break;
           }
@@ -49,13 +52,15 @@ test.describe('#invalid-chat-path', webSocketOnly, () => {
       { unsafePath: UNSAFE_PATH, panelId: CHAT_PANEL_ID }
     );
 
-    // An error notification is shown to the user.
-    await expect(
-      page.getByText(/Unable to open chat at given path/)
-    ).toBeVisible();
-
     // The chat is closed: no loading spinner is left hanging in the panel.
     const chatPanel = page.locator(`[id="${CHAT_PANEL_ID}"]`);
     await expect(chatPanel.locator('.jp-Spinner')).toHaveCount(0);
+
+    // An error notification was emitted; open the notification center and
+    // verify its message.
+    await page.locator('.jp-Notification-Status').click();
+    await expect(
+      page.getByText(/Unable to open chat at given path/)
+    ).toBeVisible();
   });
 });

--- a/ui-tests/tests/message-toolbar.spec.ts
+++ b/ui-tests/tests/message-toolbar.spec.ts
@@ -4,13 +4,11 @@
  */
 
 import { expect, galata, test } from '@jupyterlab/galata';
-import { UUID } from '@lumino/coreutils';
 
-import { openChat, USER, hoverFirstMessage } from './test-utils';
+import { openChat, sendMessage, USER, hoverFirstMessage } from './test-utils';
 
 const FILENAME = 'message-toolbar.chat';
 const MSG_CONTENT = 'Hello World!';
-const USERNAME = USER.identity.username;
 
 test.use({
   mockUser: USER,
@@ -20,23 +18,12 @@ test.use({
 test.describe('#messageToolbar', () => {
   const additionalContent = ' Messages can be edited';
 
-  const msg = {
-    type: 'msg',
-    id: UUID.uuid4(),
-    sender: USERNAME,
-    body: MSG_CONTENT,
-    time: 1714116341
-  };
-  const chatContent = {
-    messages: [msg],
-    users: {}
-  };
-  chatContent.users[USERNAME] = USER.identity;
-
   test.beforeEach(async ({ page }) => {
-    // Create a chat file with content
+    // Start from an empty chat. Each test sends its own message so the message
+    // is owned by the connected user (the identity the server assigns to the
+    // WebSocket), which is what enables the edit/delete toolbar actions.
     await page.filebrowser.contents.uploadContent(
-      JSON.stringify(chatContent),
+      JSON.stringify({ messages: [], users: {} }),
       'text',
       FILENAME
     );
@@ -49,6 +36,7 @@ test.describe('#messageToolbar', () => {
   });
 
   test('message should have a toolbar', async ({ page }) => {
+    await sendMessage(page, FILENAME, MSG_CONTENT);
     const chatPanel = await openChat(page, FILENAME);
     const message = chatPanel
       .locator('.jp-chat-messages-container .jp-chat-message-container')
@@ -65,6 +53,7 @@ test.describe('#messageToolbar', () => {
   });
 
   test('should set the message as deleted', async ({ page }) => {
+    await sendMessage(page, FILENAME, MSG_CONTENT);
     const chatPanel = await openChat(page, FILENAME);
 
     const { message, messageContent } = await hoverFirstMessage(chatPanel);
@@ -74,6 +63,7 @@ test.describe('#messageToolbar', () => {
   });
 
   test('should update the message', async ({ page }) => {
+    await sendMessage(page, FILENAME, MSG_CONTENT);
     const chatPanel = await openChat(page, FILENAME);
 
     const { message, messageContent } = await hoverFirstMessage(chatPanel);
@@ -102,6 +92,7 @@ test.describe('#messageToolbar', () => {
   });
 
   test('should cancel message edition', async ({ page }) => {
+    await sendMessage(page, FILENAME, MSG_CONTENT);
     const chatPanel = await openChat(page, FILENAME);
 
     const { message, messageContent } = await hoverFirstMessage(chatPanel);

--- a/ui-tests/tests/tags.ts
+++ b/ui-tests/tests/tags.ts
@@ -30,3 +30,24 @@ export const COLLABORATIVE_TAG = '@collaborative';
  * The exclusion is then visible both in the source and in the Playwright report.
  */
 export const collaborativeOnly = { tag: COLLABORATIVE_TAG };
+
+/**
+ * Shared Playwright tag for tests that only make sense with the RTC-free
+ * WebSocket transport (no real-time collaboration).
+ *
+ * The collaborative CI jobs exclude them with `--grep-invert @websocket`; the
+ * RTC-free jobs run them. Centralised here so the CI filter and the tests never
+ * drift apart.
+ */
+export const WEBSOCKET_TAG = '@websocket';
+
+/**
+ * Marks a `test` or `test.describe` block as WebSocket-only (RTC-free).
+ *
+ * ```ts
+ * import { webSocketOnly } from './tags';
+ *
+ * test.describe('#invalid-path', webSocketOnly, () => { ... });
+ * ```
+ */
+export const webSocketOnly = { tag: WEBSOCKET_TAG };

--- a/ui-tests/tests/test-utils.ts
+++ b/ui-tests/tests/test-utils.ts
@@ -5,12 +5,14 @@
 
 import { IJupyterLabPageFixture } from '@jupyterlab/galata';
 import { User } from '@jupyterlab/services';
-import { UUID } from '@lumino/coreutils';
 import { Locator } from '@playwright/test';
 
 export const USER: User.IUser = {
   identity: {
-    username: UUID.uuid4(),
+    // Deterministic username matching the server's fixed test identity (see
+    // ui-tests/jupyter_server_test_config.py), so the RTC-free chat's
+    // server-assigned identity equals this frontend identity.
+    username: 'test-user',
     name: 'jovyan',
     display_name: 'jovyan',
     initials: 'JP',

--- a/ui-tests/tests/user-mention.spec.ts
+++ b/ui-tests/tests/user-mention.spec.ts
@@ -15,11 +15,11 @@ import { openChat, sendMessage, USER } from './test-utils';
 
 const FILENAME = 'user-mention.chat';
 
-test.use({
-  mockUser: USER
-});
-
 test.describe('#user-mention', collaborativeOnly, () => {
+  test.use({
+    mockUser: USER
+  });
+
   let guestPage: IJupyterLabPageFixture;
   test.beforeEach(
     async ({ baseURL, browser, page, tmpPath, waitForApplication }) => {
@@ -160,9 +160,11 @@ test.describe('#bot-mention', () => {
     metadata: {}
   });
 
-  test.use({
-    mockUser: USER
-  });
+  // Intentionally no `mockUser`: the RTC-free WebSocket registers the
+  // authenticated server user as the connected user, so the frontend must use
+  // that same server identity (not a mocked one) for it to be recognised as
+  // "self" and excluded from mention suggestions -- as it is in a real
+  // single-user deployment.
 
   test.beforeEach(async ({ page }) => {
     await page.filebrowser.contents.uploadContent(


### PR DESCRIPTION
## Motivation

The RTC-free chat WebSocket endpoint was named `api/jupyter-chat/ws`. The `jupyter-` prefix is redundant for an endpoint already served by a Jupyter server, and inconsistent with the rest of the API. The handshake also carried the chat path and the connecting user's identity as query arguments — more surface area than this transport needs.

While cleaning it up, two related issues surfaced: a chat that failed to open left a loading spinner running forever in the side panel, and the server never checked that the requested path stayed within its root.

## Summary

The endpoint is now `api/chat/ws/<path>`, with the chat file path carried as a single URL path segment instead of a query argument.

Identity is now owned by the server. The RTC-free transport is single-user, so instead of the client asserting who it is, the server registers the connection's authenticated user and reports that identity back on the connection frame; the client adopts it. Client and server therefore always agree on who the user is, which is what drives sender attribution and excluding yourself from mention suggestions. A chat only becomes ready once it has received both its id and this identity.

A chat that cannot be opened now fails gracefully instead of hanging. When the server rejects the connection, a chat opened in the side panel is closed (the panel itself stays open), a chat opened in the main area disposes its widget, and an error notification is shown — no more spinner spinning forever.

The server also validates that the path resolves inside the ContentsManager root and closes the connection otherwise. This closes a path-traversal hole — a client could previously pass something like `../../another-user/private.chat` — though the risk was low since the endpoint is authenticated.

**This is a breaking change to the WebSocket wire API** (endpoint URL and handshake). That is fine at this alpha stage; the RTC-free transport has no stable released consumers yet.

## Technical details

- The path segment is percent-encoded on the client (`encodeURIComponent`) and read back from the route on the server (which url-unescapes it), so there is no custom escaping on either side.
- The client no longer sends its identity — neither the connect query argument nor the per-message `user`. The server stamps every sender from `current_user` and returns that identity in the connection frame for the client to adopt.

## Testing

Added a unit test for the path-safety check and an end-to-end test that opens a chat at a rejected path and asserts the side panel closes it and shows the notification; it was verified failing before the fix (the spinner hangs) and passing after. The integration server now reports a deterministic identity so the identity-dependent tests and screenshots are reproducible.