### PR TITLE
Push user and metadata updates to WS chat clients

### DIFF
--- a/packages/jupyterlab-chat/src/model.ts
+++ b/packages/jupyterlab-chat/src/model.ts
@@ -234,6 +234,7 @@ export class LabChatModel
       });
       this._wsHandler.messageReceived.connect(this._onWsMessage, this);
       this._wsHandler.usersChanged.connect(this._onWsUsersChanged, this);
+      this._wsHandler.metadataChanged.connect(this._onWsMetadata, this);
       this._wsHandler.writingChanged.connect(this._onWsWriting, this);
     }
   }
@@ -748,6 +749,15 @@ export class LabChatModel
       if (!this._sharedModel.getUser(user.username)) {
         this._sharedModel.setUser(new LabChatUser(user));
       }
+    }
+  };
+
+  private _onWsMetadata = (
+    _: WebSocketHandler,
+    metadata: Record<string, any>
+  ): void => {
+    for (const [key, value] of Object.entries(metadata)) {
+      this._sharedModel.setMetadata(key, value);
     }
   };
 

--- a/packages/jupyterlab-chat/src/websocket-handler.ts
+++ b/packages/jupyterlab-chat/src/websocket-handler.ts
@@ -9,6 +9,16 @@ import { ServerConnection } from '@jupyterlab/services';
 import { PromiseDelegate, UUID } from '@lumino/coreutils';
 import { ISignal, Signal } from '@lumino/signaling';
 
+import {
+  CLIENT,
+  IClientChatWsMessage,
+  IClientEditMessage,
+  IClientSendMessage,
+  IServerChatWsMessage,
+  IWireMessage,
+  SERVER
+} from './ws-messages';
+
 const WS_PATH = 'api/chat/ws';
 
 export namespace WebSocketHandler {
@@ -72,6 +82,14 @@ export class WebSocketHandler {
   }
 
   /**
+   * Emitted whenever chat metadata changes -- on every 'metadata' update pushed
+   * by the server. The payload is the map of new/updated metadata entries.
+   */
+  get metadataChanged(): ISignal<this, Record<string, any>> {
+    return this._metadataChanged;
+  }
+
+  /**
    * Emitted whenever a writing status is pushed by the server (e.g. an AI agent).
    */
   get writingChanged(): ISignal<this, WebSocketHandler.IWriting> {
@@ -114,8 +132,9 @@ export class WebSocketHandler {
 
   sendMessage(message: INewMessage): string {
     const id = UUID.uuid4();
-    const msg: Record<string, unknown> = {
-      type: 'msg',
+    const msg: IClientSendMessage = {
+      type: CLIENT,
+      action: 'send',
       id,
       body: message.body ?? ''
     };
@@ -136,9 +155,9 @@ export class WebSocketHandler {
   }
 
   updateMessage(id: string, message: IMessageContent): void {
-    const msg: Record<string, unknown> = {
-      type: 'msg',
-      is_update: true,
+    const msg: IClientEditMessage = {
+      type: CLIENT,
+      action: 'edit',
       id,
       body: message.body,
       edited: true
@@ -153,7 +172,13 @@ export class WebSocketHandler {
   }
 
   deleteMessage(id: string): void {
-    this._send({ type: 'msg', is_update: true, id, body: '', deleted: true });
+    this._send({
+      type: CLIENT,
+      action: 'edit',
+      id,
+      body: '',
+      deleted: true
+    });
   }
 
   dispose(): void {
@@ -163,40 +188,56 @@ export class WebSocketHandler {
     Signal.clearData(this);
   }
 
-  private _handleMessage(data: any): void {
-    if (data.type === 'connection') {
-      this._chatId = data.id as string | undefined;
-      this._connectedUser = (data.user as IUser) ?? undefined;
-      this._usersMap = (data.users as Record<string, IUser>) ?? {};
-      this._usersChanged.emit(this._usersMap);
-      for (const msg of (data.messages as any[]) ?? []) {
-        this._messageReceived.emit(this._toMessageContent(msg));
+  private _handleMessage(data: IServerChatWsMessage): void {
+    if (data.type !== SERVER) {
+      return;
+    }
+    switch (data.action) {
+      case 'connection': {
+        this._chatId = data.id;
+        this._connectedUser = data.user ?? undefined;
+        this._usersMap = data.users ?? {};
+        this._usersChanged.emit(this._usersMap);
+        for (const msg of data.messages ?? []) {
+          this._messageReceived.emit(this._toMessageContent(msg));
+        }
+        this._connected = true;
+        this._ready.resolve();
+        break;
       }
-      this._connected = true;
-      this._ready.resolve();
-    } else if (data.type === 'users') {
-      const incoming = (data.users as Record<string, IUser>) ?? {};
-      this._usersMap = { ...this._usersMap, ...incoming };
-      this._usersChanged.emit(incoming);
-    } else if (data.type === 'msg' && data.message) {
-      this._messageReceived.emit(this._toMessageContent(data.message));
-    } else if (data.type === 'writing') {
-      const user: IUser = data.user ?? {
-        username: data.sender,
-        name: data.sender,
-        display_name: data.sender
-      };
-      this._writingChanged.emit({
-        user,
-        state: !!data.state,
-        messageID: data.messageID,
-        typingIndicator: data.typingIndicator
-      });
+      case 'users': {
+        const incoming = data.users ?? {};
+        this._usersMap = { ...this._usersMap, ...incoming };
+        this._usersChanged.emit(incoming);
+        break;
+      }
+      case 'metadata': {
+        this._metadataChanged.emit(data.metadata ?? {});
+        break;
+      }
+      case 'message': {
+        this._messageReceived.emit(this._toMessageContent(data.message));
+        break;
+      }
+      case 'writing': {
+        const user: IUser = data.user ?? {
+          username: '',
+          name: '',
+          display_name: ''
+        };
+        this._writingChanged.emit({
+          user,
+          state: !!data.state,
+          messageID: data.messageID,
+          typingIndicator: data.typingIndicator
+        });
+        break;
+      }
     }
   }
 
-  private _toMessageContent(msg: any): IMessageContent {
-    const username = msg.sender as string;
+  private _toMessageContent(msg: IWireMessage): IMessageContent {
+    const username = msg.sender;
     const sender: IUser = this._usersMap[username] ?? {
       username,
       name: username,
@@ -235,7 +276,7 @@ export class WebSocketHandler {
     return content;
   }
 
-  private _send(data: Record<string, unknown>): void {
+  private _send(data: IClientChatWsMessage): void {
     this._socket?.send(JSON.stringify(data));
   }
 
@@ -247,7 +288,9 @@ export class WebSocketHandler {
     this._socket = new WebSocket(url);
     this._socket.onmessage = event => {
       try {
-        this._handleMessage(JSON.parse(event.data as string));
+        this._handleMessage(
+          JSON.parse(event.data as string) as IServerChatWsMessage
+        );
       } catch (e) {
         console.error('WS chat: invalid JSON received', e);
       }
@@ -292,5 +335,6 @@ export class WebSocketHandler {
   private _ready = new PromiseDelegate<void>();
   private _messageReceived = new Signal<this, IMessageContent>(this);
   private _usersChanged = new Signal<this, Record<string, IUser>>(this);
+  private _metadataChanged = new Signal<this, Record<string, any>>(this);
   private _writingChanged = new Signal<this, WebSocketHandler.IWriting>(this);
 }

--- a/packages/jupyterlab-chat/src/ws-messages.ts
+++ b/packages/jupyterlab-chat/src/ws-messages.ts
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+import { IUser } from '@jupyter/chat';
+
+/**
+ * Typed schema for the per-chat `/api/chat/ws` WebSocket protocol.
+ *
+ * Every frame is discriminated by two fields:
+ * - `type`: the *direction* -- `'client'` (web client -> server) or `'server'`
+ *   (server -> web client).
+ * - `action`: the specific message within a direction.
+ *
+ * ```
+ * ChatWsMessage       = ClientChatWsMessage | ServerChatWsMessage
+ * ClientChatWsMessage = IClientSendMessage | IClientEditMessage
+ * ServerChatWsMessage = IServerConnectionMessage | IServerMessageMessage
+ *                     | IServerUsersMessage | IServerMetadataMessage
+ *                     | IServerWritingMessage
+ * ```
+ *
+ * This mirrors the backend definition in
+ * `python/jupyterlab-chat/jupyterlab_chat/ws_messages.py`; the two must stay in
+ * sync.
+ */
+
+/** Direction discriminator values (the `type` field). */
+export const CLIENT = 'client';
+export const SERVER = 'server';
+
+/** A raw message object as it travels on the wire (pre-resolution). */
+export interface IWireMessage {
+  id: string;
+  sender: string;
+  body?: string;
+  time?: number;
+  type?: string;
+  raw_time?: boolean;
+  edited?: boolean;
+  deleted?: boolean;
+  metadata?: Record<string, any>;
+  mime_model?: any;
+  attachments?: any[];
+  mentions?: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Client -> server
+// ---------------------------------------------------------------------------
+export interface IClientSendMessage {
+  type: typeof CLIENT;
+  action: 'send';
+  id: string;
+  body: string;
+  mentions?: string[];
+  metadata?: Record<string, any>;
+  attachments?: any[];
+  mime_model?: any;
+}
+
+export interface IClientEditMessage {
+  type: typeof CLIENT;
+  action: 'edit';
+  id: string;
+  body?: string;
+  deleted?: boolean;
+  edited?: boolean;
+  mentions?: string[];
+  metadata?: Record<string, any>;
+  attachments?: any[];
+}
+
+export type IClientChatWsMessage = IClientSendMessage | IClientEditMessage;
+
+// ---------------------------------------------------------------------------
+// Server -> client
+// ---------------------------------------------------------------------------
+export interface IServerConnectionMessage {
+  type: typeof SERVER;
+  action: 'connection';
+  client_id: string;
+  id: string;
+  user: IUser;
+  messages: IWireMessage[];
+  users: Record<string, IUser>;
+}
+
+export interface IServerMessageMessage {
+  type: typeof SERVER;
+  action: 'message';
+  message: IWireMessage;
+}
+
+export interface IServerUsersMessage {
+  type: typeof SERVER;
+  action: 'users';
+  users: Record<string, IUser>;
+}
+
+export interface IServerMetadataMessage {
+  type: typeof SERVER;
+  action: 'metadata';
+  metadata: Record<string, any>;
+}
+
+export interface IServerWritingMessage {
+  type: typeof SERVER;
+  action: 'writing';
+  user: IUser;
+  state: boolean;
+  messageID?: string;
+  typingIndicator?: string;
+}
+
+export type IServerChatWsMessage =
+  | IServerConnectionMessage
+  | IServerMessageMessage
+  | IServerUsersMessage
+  | IServerMetadataMessage
+  | IServerWritingMessage;
+
+export type IChatWsMessage = IClientChatWsMessage | IServerChatWsMessage;

--- a/packages/jupyterlab-chat/src/ychat.ts
+++ b/packages/jupyterlab-chat/src/ychat.ts
@@ -189,6 +189,17 @@ export class YChat extends YDocument<IChatChanges> {
     });
   }
 
+  /**
+   * Set (or update) a chat-level metadata entry. Used by the RTC-free transport
+   * to apply `metadata` updates pushed by the server; the metadata observer then
+   * emits the change to consumers.
+   */
+  setMetadata(key: string, value: IMetadata): void {
+    this.transact(() => {
+      this._metadata.set(key, value);
+    });
+  }
+
   getMessage(index: number): IYmessage | undefined {
     return this._messages.get(index).toJSON() as IYmessage;
   }

--- a/python/jupyterlab-chat/jupyterlab_chat/tests/test_writing.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/tests/test_writing.py
@@ -34,7 +34,8 @@ def test_broadcast_writing_status_frame(tmp_path):
 
     assert len(handler.messages) == 1
     frame = json.loads(handler.messages[0])
-    assert frame["type"] == "writing"
+    assert frame["type"] == "server"
+    assert frame["action"] == "writing"
     assert frame["state"] is True
     assert frame["typingIndicator"] == "is running ripgrep"
     assert frame["user"]["username"] == "bot"
@@ -65,6 +66,8 @@ def test_broadcast_writing_status_stop(tmp_path):
     model.broadcast_writing_status(User(username="bot"), None)
 
     frame = json.loads(handler.messages[0])
+    assert frame["type"] == "server"
+    assert frame["action"] == "writing"
     assert frame["state"] is False
     assert frame["user"]["username"] == "bot"
     assert "typingIndicator" not in frame

--- a/python/jupyterlab-chat/jupyterlab_chat/tests/test_ws_messages.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/tests/test_ws_messages.py
@@ -1,0 +1,59 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+"""Tests for the typed ``/api/chat/ws`` message schema."""
+import json
+
+from jupyterlab_chat.ws_messages import (
+    ClientEditMessage,
+    ClientSendMessage,
+    ServerUsersMessage,
+    ServerWritingMessage,
+    parse_client_message,
+    to_wire,
+)
+
+
+def test_to_wire_sets_discriminators_and_drops_none():
+    frame = json.loads(to_wire(ServerUsersMessage(users={"a": {"username": "a"}})))
+    assert frame == {"type": "server", "action": "users", "users": {"a": {"username": "a"}}}
+
+
+def test_to_wire_omits_none_optionals():
+    frame = json.loads(
+        to_wire(ServerWritingMessage(user={"username": "bot"}, state=False))
+    )
+    # ``messageID``/``typingIndicator`` default to None and must be absent.
+    assert frame == {
+        "type": "server",
+        "action": "writing",
+        "user": {"username": "bot"},
+        "state": False,
+    }
+
+
+def test_parse_client_send():
+    msg = parse_client_message(
+        {"type": "client", "action": "send", "id": "m1", "body": "hi"}
+    )
+    assert isinstance(msg, ClientSendMessage)
+    assert msg.id == "m1" and msg.body == "hi" and msg.mentions == []
+
+
+def test_parse_client_edit():
+    msg = parse_client_message(
+        {"type": "client", "action": "edit", "id": "m1", "deleted": True, "body": ""}
+    )
+    assert isinstance(msg, ClientEditMessage)
+    assert msg.deleted is True and msg.body == ""
+
+
+def test_parse_rejects_non_client_and_malformed():
+    # Server-directed frames are not accepted from clients.
+    assert parse_client_message({"type": "server", "action": "users"}) is None
+    # Unknown action.
+    assert parse_client_message({"type": "client", "action": "nope", "id": "x"}) is None
+    # Missing/empty id.
+    assert parse_client_message({"type": "client", "action": "send"}) is None
+    assert parse_client_message({"type": "client", "action": "send", "id": ""}) is None
+    # Not a dict.
+    assert parse_client_message("garbage") is None

--- a/python/jupyterlab-chat/jupyterlab_chat/tests/test_ws_user_updates.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/tests/test_ws_user_updates.py
@@ -1,0 +1,83 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+"""Tests for dynamic user/metadata propagation on the RTC-free WebSocket model.
+
+Reproduces the reported bug: an AI persona registers itself on the live model
+(``model.set_user``) *after* web clients have already connected, so without a
+broadcast the connected clients never learn the persona's name/avatar. The same
+gap exists for ``set_metadata``.
+
+A connected client is, on the server, exactly an entry in ``model.handlers``
+whose ``write_message`` writes to that client's socket; a recording fake handler
+is therefore a faithful stand-in (same pattern as ``test_writing.py``).
+"""
+import json
+
+from jupyterlab_chat.models import User
+from jupyterlab_chat.websocket_model import WsChatModel
+
+
+class _FakeHandler:
+    """Captures frames written to a connected client."""
+
+    def __init__(self):
+        self.messages = []
+
+    def write_message(self, message):
+        self.messages.append(message)
+
+
+def _model_with_client(tmp_path):
+    model = WsChatModel(path="chat.chat", root_dir=tmp_path)
+    handler = _FakeHandler()
+    model.handlers["client-1"] = handler  # type: ignore[assignment]
+    return model, handler
+
+
+def _frames_of(handler, action):
+    return [
+        json.loads(m)
+        for m in handler.messages
+        if json.loads(m).get("type") == "server" and json.loads(m).get("action") == action
+    ]
+
+
+def test_set_user_broadcasts_to_connected_clients(tmp_path):
+    """Adding a user after a client connects pushes a ``users`` update to it."""
+    model, handler = _model_with_client(tmp_path)
+    persona = User(
+        username="jovian-bot",
+        name="Jovian",
+        display_name="Jovian",
+        avatar_url="/avatar/jovian.png",
+        bot=True,
+    )
+
+    model.set_user(persona)
+
+    frames = _frames_of(handler, "users")
+    assert len(frames) == 1
+    users = frames[0]["users"]
+    assert "jovian-bot" in users
+    assert users["jovian-bot"]["display_name"] == "Jovian"
+    assert users["jovian-bot"]["avatar_url"] == "/avatar/jovian.png"
+    assert users["jovian-bot"]["bot"] is True
+
+
+def test_set_metadata_broadcasts_to_connected_clients(tmp_path):
+    """Setting chat metadata after a client connects pushes a ``metadata`` update."""
+    model, handler = _model_with_client(tmp_path)
+
+    model.set_metadata("banner", {"text": "hello"})
+
+    frames = _frames_of(handler, "metadata")
+    assert len(frames) == 1
+    assert frames[0]["metadata"]["banner"] == {"text": "hello"}
+
+
+def test_set_user_does_not_persist_or_require_clients(tmp_path):
+    """set_user works with no connected clients and does not write the file."""
+    model = WsChatModel(path="chat.chat", root_dir=tmp_path)
+    model.set_user(User(username="solo"))
+    assert "solo" in model._users
+    assert not (tmp_path / "chat.chat").exists()

--- a/python/jupyterlab-chat/jupyterlab_chat/websocket_handler.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/websocket_handler.py
@@ -14,6 +14,14 @@ from tornado import web, websocket
 
 from .models import ChatMessageAction, User
 from .websocket_model import WsChatModel
+from .ws_messages import (
+    ClientEditMessage,
+    ClientSendMessage,
+    ServerConnectionMessage,
+    ServerMessageMessage,
+    parse_client_message,
+    to_wire,
+)
 
 
 def is_safe_chat_path(path: str, root_dir: Path) -> bool:
@@ -92,7 +100,6 @@ class WSChatHandler(JupyterHandler, websocket.WebSocketHandler):
         # (once, when the model is first created).
         model = self._chat_manager.ws_open(path)
         self._model = model
-        model.handlers[self._client_id] = self
 
         # Register the connecting user using the server's authenticated identity.
         # The WS transport is single-user, so every connection -- from any tab or
@@ -107,29 +114,28 @@ class WSChatHandler(JupyterHandler, websocket.WebSocketHandler):
             color=getattr(current_user, "color", None),
             avatar_url=getattr(current_user, "avatar_url", None),
         )
+        # ``set_user`` broadcasts a ``users`` update to every connected client.
+        # Doing this *before* registering our own handler means already-connected
+        # clients learn about us, while we do not receive a redundant delta ahead
+        # of our own connection frame (which already carries the full users map).
         model.set_user(user)
+        model.handlers[self._client_id] = self
 
         # Send full history so the client can render existing messages. The
         # connecting user's identity is included so the client adopts the same
         # (server-authoritative) identity the server registered for it -- used
         # for sender attribution and to exclude itself from mention suggestions.
-        self.write_message(json.dumps({
-            "type": "connection",
-            "client_id": self._client_id,
-            "id": model.get_id(),
-            "user": asdict(user),
-            "messages": [model.resolve_message(m) for m in model._messages],
-            "users": model._users,
-        }))
-
-        # Notify existing clients about the updated users map
-        users_update = json.dumps({"type": "users", "users": model._users})
-        for client_id, handler in list(model.handlers.items()):
-            if client_id != self._client_id:
-                try:
-                    handler.write_message(users_update)
-                except websocket.WebSocketClosedError:
-                    pass
+        self.write_message(
+            to_wire(
+                ServerConnectionMessage(
+                    client_id=self._client_id,
+                    id=model.get_id(),
+                    user=asdict(user),
+                    messages=[model.resolve_message(m) for m in model._messages],
+                    users=model._users,
+                )
+            )
+        )
 
         self.log.info("WS chat client %s connected to model '%s'", self._client_id, path)
         self._chat_manager.on_client_connect(path, self._client_id, model.get_id())
@@ -141,8 +147,7 @@ class WSChatHandler(JupyterHandler, websocket.WebSocketHandler):
             self.log.error("Invalid JSON received on WS chat connection")
             return
 
-        path = self._path
-        if not path:
+        if not self._path:
             return
 
         model = getattr(self, "_model", None)
@@ -150,29 +155,39 @@ class WSChatHandler(JupyterHandler, websocket.WebSocketHandler):
             return
         self._chat_manager.ws_activity(model.get_id())
 
-        if data.get("is_update"):
-            self._handle_update_message(data, model)
-        else:
-            self._handle_new_message(data, model)
+        message = parse_client_message(data)
+        if message is None:
+            self.log.error(
+                "Ignoring malformed or unsupported chat WS frame: %r", data
+            )
+            return
 
-    def _handle_new_message(self, data: dict, model: WsChatModel) -> None:
+        if isinstance(message, ClientSendMessage):
+            self._handle_new_message(message, model)
+        else:
+            self._handle_update_message(message, model)
+
+    def _handle_new_message(self, msg: ClientSendMessage, model: WsChatModel) -> None:
         timestamp = time.time()
         # The WS transport is single-user: the sender is always the
         # authenticated server user, already registered in `open()`.
         sender = self.current_user.username
         message: dict = {
-            "id": data.get("id") or str(uuid.uuid4()),
-            "body": data.get("body", ""),
+            "id": msg.id,
+            "body": msg.body,
             "time": timestamp,
             "sender": sender,
             "type": "msg",
             "raw_time": False,
         }
-        for key in ("mentions", "metadata", "mime_model"):
-            if key in data:
-                message[key] = data[key]
-        if "attachments" in data:
-            message["attachments"] = self._store_attachments(data["attachments"], model)
+        if msg.mentions:
+            message["mentions"] = msg.mentions
+        if msg.metadata is not None:
+            message["metadata"] = msg.metadata
+        if msg.mime_model is not None:
+            message["mime_model"] = msg.mime_model
+        if msg.attachments is not None:
+            message["attachments"] = self._store_attachments(msg.attachments, model)
 
         idx = next(
             (i for i, m in enumerate(model._messages) if m.get("time", 0) > timestamp),
@@ -182,7 +197,7 @@ class WSChatHandler(JupyterHandler, websocket.WebSocketHandler):
         model._indexes_by_id = {m["id"]: i for i, m in enumerate(model._messages)}
         model.save()
         model.broadcast(
-            json.dumps({"type": "msg", "message": model.resolve_message(message)})
+            to_wire(ServerMessageMessage(message=model.resolve_message(message)))
         )
         received = model.get_message(message["id"])
         if received is not None:
@@ -190,24 +205,28 @@ class WSChatHandler(JupyterHandler, websocket.WebSocketHandler):
                 ChatMessageAction.CLIENT_MSG_RECEIVED, received
             )
 
-    def _handle_update_message(self, data: dict, model: WsChatModel) -> None:
-        msg_id = data.get("id")
-        if not msg_id:
-            return
-        idx = model._indexes_by_id.get(msg_id)
+    def _handle_update_message(self, msg: ClientEditMessage, model: WsChatModel) -> None:
+        idx = model._indexes_by_id.get(msg.id)
         if idx is None:
             return
-        msg = model._messages[idx]
-        for key in ("body", "deleted", "edited", "mentions", "metadata"):
-            if key in data:
-                msg[key] = data[key]
-        if "attachments" in data:
-            msg["attachments"] = self._store_attachments(data["attachments"], model)
+        stored = model._messages[idx]
+        if msg.body is not None:
+            stored["body"] = msg.body
+        if msg.deleted is not None:
+            stored["deleted"] = msg.deleted
+        if msg.edited is not None:
+            stored["edited"] = msg.edited
+        if msg.mentions is not None:
+            stored["mentions"] = msg.mentions
+        if msg.metadata is not None:
+            stored["metadata"] = msg.metadata
+        if msg.attachments is not None:
+            stored["attachments"] = self._store_attachments(msg.attachments, model)
         model.save()
         model.broadcast(
-            json.dumps({"type": "msg", "message": model.resolve_message(msg)})
+            to_wire(ServerMessageMessage(message=model.resolve_message(stored)))
         )
-        edited = model.get_message(msg_id)
+        edited = model.get_message(msg.id)
         if edited is not None:
             model._emit_message_event(
                 ChatMessageAction.CLIENT_MSG_EDITED, edited

--- a/python/jupyterlab-chat/jupyterlab_chat/websocket_model.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/websocket_model.py
@@ -14,6 +14,13 @@ from jupyter_events import EventLogger
 from jupyter_server.services.contents.manager import ContentsManager
 from tornado import websocket
 
+from .ws_messages import (
+    ServerMessageMessage,
+    ServerMetadataMessage,
+    ServerUsersMessage,
+    ServerWritingMessage,
+    to_wire,
+)
 from .models import (
     BaseChatModel,
     ChatMessageAction,
@@ -121,17 +128,18 @@ class WsChatModel(BaseChatModel):
         recipients can display the writer (and tell bots from humans via
         ``user.bot``) without having seen a message from them.
         """
-        payload: dict = {
-            "type": "writing",
-            "user": asdict(user),
-            "state": status is not None,
-        }
-        if status:
-            for key in ("messageID", "typingIndicator"):
-                value = status.get(key)
-                if value is not None:
-                    payload[key] = value
-        self.broadcast(json.dumps(payload))
+        active = status is not None
+        status = status or {}
+        self.broadcast(
+            to_wire(
+                ServerWritingMessage(
+                    user=asdict(user),
+                    state=active,
+                    messageID=status.get("messageID"),
+                    typingIndicator=status.get("typingIndicator"),
+                )
+            )
+        )
 
     def resolve_message(self, message: dict) -> dict:
         """Return a copy of a message with attachment IDs replaced by full objects."""
@@ -244,7 +252,7 @@ class WsChatModel(BaseChatModel):
         self._indexes_by_id = {m["id"]: i for i, m in enumerate(self._messages)}
         self.save()
         self.broadcast(
-            json.dumps({"type": "msg", "message": self.resolve_message(msg_dict)})
+            to_wire(ServerMessageMessage(message=self.resolve_message(msg_dict)))
         )
         self._emit_message_event(ChatMessageAction.SERVER_MSG_SENT, message)
         return msg_id
@@ -270,7 +278,7 @@ class WsChatModel(BaseChatModel):
                 msg_dict[key] = value
         self.save()
         self.broadcast(
-            json.dumps({"type": "msg", "message": self.resolve_message(msg_dict)})
+            to_wire(ServerMessageMessage(message=self.resolve_message(msg_dict)))
         )
         updated = self.get_message(update.id)
         if updated is not None:
@@ -295,10 +303,17 @@ class WsChatModel(BaseChatModel):
         return att_id
 
     def set_user(self, user: User) -> None:
-        self._users[user.username] = asdict(user)
+        user_dict = asdict(user)
+        self._users[user.username] = user_dict
+        # Push the change to connected clients. Personas register themselves via
+        # this method *after* clients have connected, so without this broadcast a
+        # newly added user (e.g. an AI agent's name/avatar) would never appear.
+        self.broadcast(to_wire(ServerUsersMessage(users={user.username: user_dict})))
 
     def set_metadata(self, name: str, metadata: Any) -> None:
         self._metadata[name] = metadata
+        # Push the change to connected clients (same rationale as set_user).
+        self.broadcast(to_wire(ServerMetadataMessage(metadata={name: metadata})))
 
     # ------------------------------------------------------------------
     # Message observers

--- a/python/jupyterlab-chat/jupyterlab_chat/ws_messages.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/ws_messages.py
@@ -1,0 +1,190 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+"""Typed schema for the per-chat ``/api/chat/ws`` WebSocket protocol.
+
+Every frame exchanged on the connection is one of the dataclasses defined here,
+discriminated by two fields:
+
+* ``type`` -- the *direction*: ``"client"`` (web client -> server) or
+  ``"server"`` (server -> web client).
+* ``action`` -- the specific message within a direction.
+
+::
+
+    ChatWsMessage    = ClientChatWsMessage | ServerChatWsMessage
+
+    ClientChatWsMessage = ClientSendMessage      # action="send"
+                        | ClientEditMessage      # action="edit"
+
+    ServerChatWsMessage = ServerConnectionMessage  # action="connection"
+                        | ServerMessageMessage     # action="message"
+                        | ServerUsersMessage       # action="users"
+                        | ServerMetadataMessage    # action="metadata"
+                        | ServerWritingMessage     # action="writing"
+
+The frontend mirrors this union in ``packages/jupyterlab-chat/src/ws-messages.ts``;
+the two definitions must stay in sync.
+
+Server frames are constructed as dataclasses and serialized with :func:`to_wire`
+(which drops ``None`` fields so optional keys are simply absent on the wire).
+Client frames are validated and narrowed by :func:`parse_client_message`.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from typing import Any, Dict, List, Literal, Optional, Union
+
+#: Direction discriminator values (the ``type`` field).
+CLIENT: Literal["client"] = "client"
+SERVER: Literal["server"] = "server"
+
+
+# ---------------------------------------------------------------------------
+# Client -> server
+# ---------------------------------------------------------------------------
+@dataclass
+class ClientSendMessage:
+    """A web client asks the server to append a new message."""
+
+    id: str
+    body: str = ""
+    mentions: List[str] = field(default_factory=list)
+    metadata: Optional[Dict[str, Any]] = None
+    attachments: Optional[List[dict]] = None
+    mime_model: Optional[dict] = None
+    type: Literal["client"] = CLIENT
+    action: Literal["send"] = "send"
+
+
+@dataclass
+class ClientEditMessage:
+    """A web client asks the server to edit (or delete) an existing message."""
+
+    id: str
+    body: Optional[str] = None
+    deleted: Optional[bool] = None
+    edited: Optional[bool] = None
+    mentions: Optional[List[str]] = None
+    metadata: Optional[Dict[str, Any]] = None
+    attachments: Optional[List[dict]] = None
+    type: Literal["client"] = CLIENT
+    action: Literal["edit"] = "edit"
+
+
+ClientChatWsMessage = Union[ClientSendMessage, ClientEditMessage]
+
+
+# ---------------------------------------------------------------------------
+# Server -> client
+# ---------------------------------------------------------------------------
+@dataclass
+class ServerConnectionMessage:
+    """First frame sent to a client: its id, the chat id, its (server-owned)
+    identity, the full message history, and the current users map."""
+
+    client_id: str
+    id: str
+    user: Dict[str, Any]
+    messages: List[dict]
+    users: Dict[str, dict]
+    type: Literal["server"] = SERVER
+    action: Literal["connection"] = "connection"
+
+
+@dataclass
+class ServerMessageMessage:
+    """A new or updated message (already attachment-resolved)."""
+
+    message: Dict[str, Any]
+    type: Literal["server"] = SERVER
+    action: Literal["message"] = "message"
+
+
+@dataclass
+class ServerUsersMessage:
+    """An add/update to the users map. Clients merge it into their local map."""
+
+    users: Dict[str, dict]
+    type: Literal["server"] = SERVER
+    action: Literal["users"] = "users"
+
+
+@dataclass
+class ServerMetadataMessage:
+    """An add/update to the chat metadata map. Clients merge it in."""
+
+    metadata: Dict[str, Any]
+    type: Literal["server"] = SERVER
+    action: Literal["metadata"] = "metadata"
+
+
+@dataclass
+class ServerWritingMessage:
+    """An ephemeral writing/typing status pushed by the server (e.g. an AI
+    persona). Not persisted to the ``.chat`` file."""
+
+    user: Dict[str, Any]
+    state: bool
+    messageID: Optional[str] = None
+    typingIndicator: Optional[str] = None
+    type: Literal["server"] = SERVER
+    action: Literal["writing"] = "writing"
+
+
+ServerChatWsMessage = Union[
+    ServerConnectionMessage,
+    ServerMessageMessage,
+    ServerUsersMessage,
+    ServerMetadataMessage,
+    ServerWritingMessage,
+]
+
+ChatWsMessage = Union[ClientChatWsMessage, ServerChatWsMessage]
+
+
+# ---------------------------------------------------------------------------
+# Serialization / parsing
+# ---------------------------------------------------------------------------
+def to_wire(message: ServerChatWsMessage) -> str:
+    """Serialize a server message to a JSON string, omitting ``None`` fields so
+    optional keys are simply absent on the wire."""
+    payload = {k: v for k, v in asdict(message).items() if v is not None}
+    return json.dumps(payload)
+
+
+def parse_client_message(data: Any) -> Optional[ClientChatWsMessage]:
+    """Validate and narrow a decoded client frame.
+
+    Returns the typed message, or ``None`` if ``data`` is not a well-formed
+    client frame (the caller logs and ignores it).
+    """
+    if not isinstance(data, dict) or data.get("type") != CLIENT:
+        return None
+    msg_id = data.get("id")
+    if not isinstance(msg_id, str) or not msg_id:
+        return None
+
+    action = data.get("action")
+    if action == "send":
+        return ClientSendMessage(
+            id=msg_id,
+            body=data.get("body", "") or "",
+            mentions=list(data.get("mentions") or []),
+            metadata=data.get("metadata"),
+            attachments=data.get("attachments"),
+            mime_model=data.get("mime_model"),
+        )
+    if action == "edit":
+        return ClientEditMessage(
+            id=msg_id,
+            body=data.get("body"),
+            deleted=data.get("deleted"),
+            edited=data.get("edited"),
+            mentions=data.get("mentions"),
+            metadata=data.get("metadata"),
+            attachments=data.get("attachments"),
+        )
+    return None

--- a/ui-tests/chat_test_extension.py
+++ b/ui-tests/chat_test_extension.py
@@ -1,0 +1,62 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+"""Test-only server extension for the UI tests.
+
+Exposes ``POST /chat-test/add-user`` so an E2E test can add a user to a *live*
+chat the way an AI persona does -- ``chat.set_user()`` on the server, after web
+clients have already connected -- and then assert the clients' user list updates.
+
+It is transport-agnostic: it resolves the live model from the ``ChatManager`` by
+path, which is a ``WsChatModel`` under the RTC-free WebSocket transport and a
+``YChat`` under real-time collaboration. In both cases ``set_user`` propagates to
+connected clients (a WS broadcast, or a shared-document write).
+
+!! Never enable this in production: it lets any authenticated caller inject
+arbitrary users into a chat.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+
+import tornado
+from jupyter_server.base.handlers import JupyterHandler
+from jupyter_server.utils import url_path_join
+
+from jupyterlab_chat.models import User
+
+
+class AddUserHandler(JupyterHandler):
+    @tornado.web.authenticated
+    async def post(self) -> None:
+        body = json.loads(self.request.body or b"{}")
+        path = body["path"]
+        fields = body["user"]
+
+        manager = self.settings["chat_manager"]
+        # The chat may not be live yet (RTC rooms initialize asynchronously after
+        # the client opens the document), so retry briefly.
+        model = None
+        for _ in range(100):
+            model = await manager.create(path)
+            if model is not None:
+                break
+            await asyncio.sleep(0.1)
+        if model is None:
+            raise tornado.web.HTTPError(404, f"chat not live: {path}")
+
+        model.set_user(User(**fields))
+        self.finish(json.dumps({"ok": True}))
+
+
+def _jupyter_server_extension_points():
+    return [{"module": "chat_test_extension"}]
+
+
+def _load_jupyter_server_extension(server_app) -> None:
+    web_app = server_app.web_app
+    base_url = web_app.settings["base_url"]
+    route = url_path_join(base_url, "chat-test", "add-user")
+    web_app.add_handlers(".*$", [(route, AddUserHandler)])
+    server_app.log.info("Registered chat_test_extension (test-only add-user endpoint)")

--- a/ui-tests/jupyter_server_test_config.py
+++ b/ui-tests/jupyter_server_test_config.py
@@ -45,6 +45,15 @@ c.ServerApp.port = int(os.environ.get("TEST_PORT", "8888"))
 
 c.FileContentsManager.delete_to_trash = False
 
+# Enable the test-only server extension that exposes POST /chat-test/add-user
+# (see chat_test_extension.py), used by user-updates.spec.ts to add a user to a
+# live chat via chat.set_user() and verify the client's user list updates. This
+# config file's directory is not importable by default, so put it on sys.path.
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+c.ServerApp.jpserver_extensions = {"chat_test_extension": True}
+
 # Each UI test runs in its own temporary directory, but all documents handled by
 # the server otherwise share the same SQLite YStore. Use one temporary file per
 # document so parallel tests do not contend for a database lock.

--- a/ui-tests/tests/user-updates.spec.ts
+++ b/ui-tests/tests/user-updates.spec.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+import { expect, IJupyterLabPageFixture, test } from '@jupyterlab/galata';
+
+import { openChat, USER } from './test-utils';
+
+const FILENAME = 'user-updates.chat';
+
+// A non-bot user added to the chat *after* the client connects -- the shape an
+// AI persona registers once it is initialized. `display_name` has no spaces so
+// the mention name is exactly `@seconduser` in every JupyterLab version.
+const ADDED_USER = {
+  username: 'seconduser',
+  name: 'seconduser',
+  display_name: 'seconduser',
+  initials: 'S'
+};
+
+/**
+ * Add a user to a live chat via the test-only server endpoint, which calls
+ * `chat.set_user()` server-side. Transport-agnostic (works with and without RTC).
+ */
+async function addUser(
+  page: IJupyterLabPageFixture,
+  path: string,
+  user: Record<string, unknown>
+): Promise<void> {
+  const status = await page.evaluate(
+    async ({ path, user }) => {
+      const settings = (window.jupyterapp as any).serviceManager.serverSettings;
+      const url = settings.baseUrl + 'chat-test/add-user';
+      const headers: Record<string, string> = {
+        'Content-Type': 'application/json'
+      };
+      if (settings.token) {
+        headers['Authorization'] = 'token ' + settings.token;
+      }
+      const response = await fetch(url, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ path, user })
+      });
+      return response.status;
+    },
+    { path, user }
+  );
+  expect(status).toBe(200);
+}
+
+// Not tagged @collaborative or @websocket: this runs in every CI leg. The user
+// list must update live whether chat is backed by the RTC-free WebSocket or by
+// real-time collaboration.
+test.describe('#user-updates', () => {
+  test.use({ mockUser: USER });
+
+  test.beforeEach(async ({ page }) => {
+    await page.filebrowser.contents.uploadContent('{}', 'text', FILENAME);
+  });
+
+  test.afterEach(async ({ page }) => {
+    if (await page.filebrowser.contents.fileExists(FILENAME)) {
+      await page.filebrowser.contents.deleteFile(FILENAME);
+    }
+  });
+
+  test('a user added after the client connects appears in the user list', async ({
+    page
+  }) => {
+    const chatPanel = await openChat(page, FILENAME);
+    const input = chatPanel
+      .locator('.jp-chat-input-container')
+      .getByRole('combobox');
+    const chatCommandName = page.locator('.jp-chat-command-name');
+    const addedMention = chatCommandName.filter({ hasText: '@seconduser' });
+
+    // Baseline: the user is not known before it is added.
+    await input.fill('');
+    await input.press('@');
+    await expect(addedMention).toHaveCount(0);
+
+    // Add the user server-side, after the client is already connected.
+    await addUser(page, FILENAME, ADDED_USER);
+
+    // The client's user list updates live: the new user becomes mentionable.
+    // Re-open the completer on each attempt so it re-queries the (async-updated)
+    // user list until the update has propagated.
+    await expect(async () => {
+      await input.fill('');
+      await input.press('@');
+      await expect(addedMention).toHaveCount(1, { timeout: 1000 });
+    }).toPass({ timeout: 15000 });
+  });
+});


### PR DESCRIPTION
## Motivation

In RTC-free (WebSocket) chats, a user added to a chat after clients have already connected never shows up for those clients. This bites AI personas in particular: a persona registers itself with `set_user()` once it is initialized, which happens after the web client connects, so the persona's name and avatar never reach the client. Chat metadata set after connect has the same problem.

The underlying reason is that the WS protocol was untyped dicts on both ends, and the only place that ever broadcast the users map was the connection handshake. `set_user`/`set_metadata` mutated server state silently.

## Summary

`set_user` and `set_metadata` now push an update to every connected client, so personas (and any later-added user or metadata) appear live.

The `/api/chat/ws` protocol is now a typed, discriminated schema instead of free-form dicts. Every frame carries `type` (`client` or `server`, the direction) and `action` (the specific message). The backend defines it in a dedicated `ws_messages` module and the frontend mirrors it in `ws-messages.ts`; both the handler and the model construct and parse frames through the schema, and malformed client frames are rejected rather than half-handled.

This changes the wire format, so the server and the labextension must be upgraded together.

## Technical details

- The schema lives in its own module rather than inside `websocket_handler.py`, because the handler imports the model and both need the schema — defining it in the handler would be circular.
- `open()` now calls `set_user` before registering its own handler, so already-connected clients get the new user via the normal broadcast and the connecting client still gets the full users map in its connection frame (the ad-hoc users broadcast in `open()` is gone).
- Frontend gains a `metadataChanged` signal on the WS handler and a `setMetadata` on the shared model to apply metadata updates.

## Testing

Added Python tests that assert `set_user`/`set_metadata` broadcast to connected clients (the reported bug, red before the fix), plus schema round-trip/parse tests. Existing writing-status tests updated to the new frame shape. Frontend types checked via the build; jest suite green.