### PR TITLE
Load and save content from/to file in jupyterlite

### DIFF
--- a/packages/jupyterlab-chat-extension/src/index.ts
+++ b/packages/jupyterlab-chat-extension/src/index.ts
@@ -1348,7 +1348,10 @@ const chatPanel: JupyterFrontEndPlugin<MultiChatPanel> = {
       );
       const names: { [name: string]: string } = {};
       for (const file of dirContents.content) {
-        if (file.type === 'file' && file.name.endsWith(chatFileExtension)) {
+        if (
+          (file.type === 'file' || file.type === chatFileType.contentType) &&
+          file.name.endsWith(chatFileExtension)
+        ) {
           const nameWithoutExt = file.name.replace(chatFileExtension, '');
           names[nameWithoutExt] = file.path;
         }

--- a/packages/jupyterlab-chat/package.json
+++ b/packages/jupyterlab-chat/package.json
@@ -59,6 +59,7 @@
     "@jupyterlab/ui-components": "^4.5.0",
     "@lumino/commands": "^2.3.3",
     "@lumino/coreutils": "^2.2.2",
+    "@lumino/polling": "^2.1.5",
     "@lumino/signaling": "^2.1.5",
     "@lumino/widgets": "^2.8.0",
     "react": "^18.2.0",

--- a/packages/jupyterlab-chat/src/model.ts
+++ b/packages/jupyterlab-chat/src/model.ts
@@ -19,6 +19,7 @@ import { IChangedArgs } from '@jupyterlab/coreutils';
 import { DocumentRegistry } from '@jupyterlab/docregistry';
 import { ServerConnection, User } from '@jupyterlab/services';
 import { PartialJSONObject, UUID } from '@lumino/coreutils';
+import { Debouncer } from '@lumino/polling';
 import { ISignal, Signal } from '@lumino/signaling';
 
 import { enforceAutosaveEnabled } from './autosave';
@@ -268,7 +269,15 @@ export class LabChatModel
     return this._dirty;
   }
   set dirty(value: boolean) {
+    const old = this._dirty;
     this._dirty = value;
+    if (old !== value) {
+      this._stateChanged.emit({
+        name: 'dirty',
+        oldValue: old,
+        newValue: value
+      });
+    }
   }
 
   get readOnly(): boolean {
@@ -346,11 +355,18 @@ export class LabChatModel
             'WS chat connection failed, falling back to shared model',
             e
           );
-          if (!this._sharedModel.id) {
-            this._sharedModel.id = UUID.uuid4();
-          }
-          const id = this._sharedModel.id;
-          this.setReady(id);
+          // Restore content from disk before wiring the change handler, so the
+          // initial population doesn't itself trigger a save. `ready` is
+          // resolved only after the load completes (see #532).
+          void this._loadContent().then(() => {
+            if (!this._sharedModel.id) {
+              this._sharedModel.id = UUID.uuid4();
+            }
+            const id = this._sharedModel.id;
+            // Any subsequent change must be saved by the frontend (no backend).
+            this._sharedModel.changed.connect(this._onServerLessChange, this);
+            this.setReady(id);
+          });
         });
       return;
     }
@@ -378,6 +394,7 @@ export class LabChatModel
     if (this.isDisposed) {
       return;
     }
+    this._saveDebouncer.dispose();
     this._wsHandler?.dispose();
     this._wsHandler = null;
     super.dispose();
@@ -388,19 +405,20 @@ export class LabChatModel
   }
 
   toString(): string {
-    return JSON.stringify({}, null, 2);
+    return JSON.stringify(this._sharedModel.getSource(), null, 2);
   }
 
-  fromString(data: string): void {
-    /** */
+  fromString(_data: string): void {
+    // Content is loaded on demand via _loadContent() in the serverless
+    // (JupyterLite) fallback; in RTC/WS modes the transport owns the data.
   }
 
   toJSON(): PartialJSONObject {
     return JSON.parse(this.toString());
   }
 
-  fromJSON(data: PartialJSONObject): void {
-    // nothing to do
+  fromJSON(_data: PartialJSONObject): void {
+    // nothing to do — see fromString
   }
 
   createChatContext(): IChatContext {
@@ -618,6 +636,55 @@ export class LabChatModel
   private _enforceAutosaveEnabled = () => {
     enforceAutosaveEnabled(this.sharedModel.awareness);
   };
+
+  /**
+   * Triggered when there is no backend and a change occur in the shared model (e.g.
+   * Jupyterlite). It is used to save the chat content from the frontend.
+   */
+  private _onServerLessChange = (): void => {
+    this.dirty = true;
+    void this._saveDebouncer.invoke();
+  };
+
+  /**
+   * Load the chat content when no backend is available (e.g. Jupyterlite).
+   * Should be called once when initializing the chat.
+   */
+  private async _loadContent(): Promise<void> {
+    if (!this.documentManager) {
+      return;
+    }
+    try {
+      const file = await this.documentManager.services.contents.get(this.name, {
+        content: true,
+        format: 'text'
+      });
+      if (typeof file.content === 'string' && file.content) {
+        this._sharedModel.setSource(JSON.parse(file.content));
+      }
+    } catch {
+      // Missing or invalid file — start with an empty chat.
+    }
+  }
+
+  /**
+   * Save the content to a file when no backend is available (e.g. Jupyterlite).
+   */
+  private async _saveContent(): Promise<void> {
+    if (!this.documentManager) {
+      return;
+    }
+    try {
+      await this.documentManager.services.contents.save(this.name, {
+        type: 'file',
+        format: 'text',
+        content: this.toString()
+      });
+      this.dirty = false;
+    } catch (e) {
+      console.error('Failed to save chat file', e);
+    }
+  }
 
   private _onchange = async (_: YChat, changes: IChatChanges) => {
     if (changes.messageListChanges) {
@@ -872,7 +939,13 @@ export class LabChatModel
   private _timeoutWriting: number | null = null;
 
   private _user: IUser;
+
+  // Web socket to use if RTC is not available
   private _wsHandler: WebSocketHandler | null = null;
+
+  // Debouncer used to save file from the frontend if RTC and web socket are not
+  // available (e.g. jupyterlite).
+  private _saveDebouncer = new Debouncer(() => this._saveContent(), 500);
 }
 
 /**

--- a/packages/jupyterlab-chat/src/ychat.ts
+++ b/packages/jupyterlab-chat/src/ychat.ts
@@ -137,9 +137,10 @@ export class YChat extends YDocument<IChatChanges> {
   getSource(): JSONObject {
     const users = this._users.toJSON();
     const messages = this._messages.toJSON();
+    const attachments = this._attachments.toJSON();
     const metadata = this._metadata.toJSON();
 
-    return { users, messages, metadata };
+    return { users, messages, attachments, metadata };
   }
 
   setSource(value: JSONObject): void {
@@ -162,6 +163,11 @@ export class YChat extends YDocument<IChatChanges> {
       const users = value['users'] ?? {};
       Object.entries(users).forEach(([key, val]) =>
         this._users.set(key, val as IUser)
+      );
+
+      const attachments = value['attachments'] ?? {};
+      Object.entries(attachments).forEach(([key, val]) =>
+        this._attachments.set(key, val as IAttachment)
       );
 
       const metadata = value['metadata'] ?? {};

--- a/yarn.lock
+++ b/yarn.lock
@@ -8704,6 +8704,7 @@ __metadata:
     "@jupyterlab/ui-components": ^4.5.0
     "@lumino/commands": ^2.3.3
     "@lumino/coreutils": ^2.2.2
+    "@lumino/polling": ^2.1.5
     "@lumino/signaling": ^2.1.5
     "@lumino/widgets": ^2.8.0
     "@types/jest": ^29.2.0


### PR DESCRIPTION
This PR allows to load and save content from/to file in a jupyterlite environment (no RTC, no web server).

Follow up #529 

It can be tested from the readthedoc deployment https://jupyter-chat--533.org.readthedocs.build/en/533/lite/lab/index.html

### CHANGES

If RTC and web socket are not available, the content is loaded from the frontend contents manager, and saved when the shared model changed.
It also fix the `YChat` set source, that wasn't used before the PR.