### PR TITLE
Drop the re-broadcast required for writing status in WS chat

### DIFF
--- a/packages/jupyter-chat/src/__tests__/writers.spec.ts
+++ b/packages/jupyter-chat/src/__tests__/writers.spec.ts
@@ -47,20 +47,18 @@ describe('writers state', () => {
     expect(changes.length).toBe(count);
   });
 
-  it('auto-clears a writer after the timeout unless refreshed', () => {
+  it('keeps a writer until it is explicitly cleared (no auto-expiry)', () => {
     jest.useFakeTimers();
     try {
-      model.setWritingStatus(userA, undefined, 2000);
+      model.setWritingStatus(userA);
       expect(model.writers).toHaveLength(1);
 
-      // Refresh before expiry keeps it alive.
-      jest.advanceTimersByTime(1500);
-      model.setWritingStatus(userA, undefined, 2000);
-      jest.advanceTimersByTime(1500);
+      // A single call persists like any other update: no timer drops it.
+      jest.advanceTimersByTime(60_000);
       expect(model.writers).toHaveLength(1);
 
-      // No refresh -> auto-cleared after the timeout (the WS anti-stuck path).
-      jest.advanceTimersByTime(2000);
+      // Only an explicit clear removes it.
+      model.clearWritingStatus(userA);
       expect(model.writers).toHaveLength(0);
     } finally {
       jest.useRealTimers();

--- a/packages/jupyter-chat/src/model.ts
+++ b/packages/jupyter-chat/src/model.ts
@@ -226,18 +226,14 @@ export interface IChatModel extends IDisposable {
   /**
    * Mark a user as currently writing (add or update their writer entry).
    *
+   * The writer stays until explicitly removed via {@link clearWritingStatus}
+   * (or replaced by a new snapshot in {@link updateWriters}); there is no
+   * auto-expiry, so a single call persists like any other update.
+   *
    * @param user - the writing user.
    * @param status - optional writing status (messageID, custom typingIndicator).
-   * @param timeout - optional auto-clear delay in ms. When set, the user is
-   *   automatically cleared after `timeout` unless refreshed by another call.
-   *   Used by transports without their own liveness signal (e.g. WebSocket) to
-   *   avoid a stuck "is typing" if a clear message is never received.
    */
-  setWritingStatus(
-    user: IUser,
-    status?: IChatModel.IWritingStatus,
-    timeout?: number
-  ): void;
+  setWritingStatus(user: IUser, status?: IChatModel.IWritingStatus): void;
 
   /**
    * Remove a user from the writers list.
@@ -247,7 +243,7 @@ export interface IChatModel extends IDisposable {
   /**
    * Broadcast the *current user's* writing status to other clients, or clear it
    * with `null`. Implemented per transport (RTC sets awareness; WebSocket sends
-   * a periodic writing frame). Default implementation is a no-op.
+   * a single writing frame). Default implementation is a no-op.
    */
   broadcastWritingStatus(status: IChatModel.IWritingStatus | null): void;
 
@@ -722,9 +718,7 @@ export abstract class AbstractChatModel implements IChatModel {
    */
   updateWriters(writers: IChatModel.IWriter[]): void {
     // Reconcile the writers map with the provided snapshot (used by
-    // snapshot-style transports such as RTC awareness). Any auto-clear timers
-    // are dropped, since the snapshot is authoritative.
-    this._clearAllWriterTimers();
+    // snapshot-style transports such as RTC awareness).
     const next = new Map<string, IChatModel.IWriter>();
     for (const writer of writers) {
       next.set(writer.user.username, writer);
@@ -738,23 +732,12 @@ export abstract class AbstractChatModel implements IChatModel {
   /**
    * Mark a user as currently writing. See IChatModel.setWritingStatus.
    */
-  setWritingStatus(
-    user: IUser,
-    status?: IChatModel.IWritingStatus,
-    timeout?: number
-  ): void {
+  setWritingStatus(user: IUser, status?: IChatModel.IWritingStatus): void {
     const writer: IChatModel.IWriter = {
       user,
       messageID: status?.messageID,
       typingIndicator: status?.typingIndicator
     };
-    this._clearWriterTimer(user.username);
-    if (timeout !== undefined) {
-      this._writerTimers.set(
-        user.username,
-        window.setTimeout(() => this._removeWriter(user.username), timeout)
-      );
-    }
     const previous = this._writers.get(user.username);
     this._writers.set(user.username, writer);
     if (!previous || !Private.writerEqual(previous, writer)) {
@@ -778,25 +761,9 @@ export abstract class AbstractChatModel implements IChatModel {
   }
 
   private _removeWriter(username: string): void {
-    this._clearWriterTimer(username);
     if (this._writers.delete(username)) {
       this._writersChanged.emit(this.writers);
     }
-  }
-
-  private _clearWriterTimer(username: string): void {
-    const timer = this._writerTimers.get(username);
-    if (timer !== undefined) {
-      window.clearTimeout(timer);
-      this._writerTimers.delete(username);
-    }
-  }
-
-  private _clearAllWriterTimers(): void {
-    for (const timer of this._writerTimers.values()) {
-      window.clearTimeout(timer);
-    }
-    this._writerTimers.clear();
   }
 
   /**
@@ -914,7 +881,6 @@ export abstract class AbstractChatModel implements IChatModel {
   private _documentManager: IDocumentManager | null;
   private _notificationId: string | null = null;
   private _writers = new Map<string, IChatModel.IWriter>();
-  private _writerTimers = new Map<string, number>();
   private _messageEditions = new Map<string, IInputModel>();
   private _messagesUpdated = new Signal<IChatModel, void>(this);
   private _messageChanged = new Signal<IChatModel, IMessage>(this);

--- a/packages/jupyterlab-chat/src/model.ts
+++ b/packages/jupyterlab-chat/src/model.ts
@@ -29,15 +29,6 @@ import { IChatChanges, IYmessage, YChat } from './ychat';
 const WRITING_DELAY = 1000;
 
 /**
- * How long a server-pushed (e.g. AI persona) writing status stays visible
- * without a refresh. The sender is expected to re-broadcast while still
- * writing and to send an explicit stop when done; this is only a safety net so
- * a crashed or forgetful sender cannot leave a "is writing" indicator stuck
- * forever. An explicit stop clears it immediately, regardless of this value.
- */
-const WS_WRITING_TIMEOUT = 3000;
-
-/**
  * Coerce an untrusted value to an `IUser`, or `null` if it is not one.
  * Awareness state is written by arbitrary clients, so the only field we rely on
  * is a string `username`.
@@ -577,7 +568,9 @@ export class LabChatModel
 
   /**
    * Handle a writing status pushed by the server (e.g. an AI agent) over the
-   * WebSocket. The sender controls its own lifecycle via explicit start/stop.
+   * WebSocket. The sender fully controls the lifecycle via explicit start/stop
+   * frames: a `state: true` frame shows the indicator and it stays visible
+   * until a `state: false` frame clears it -- no re-broadcasting is required.
    */
   private _onWsWriting = (
     _: WebSocketHandler,
@@ -587,14 +580,10 @@ export class LabChatModel
       return;
     }
     if (writing.state) {
-      this.setWritingStatus(
-        writing.user,
-        {
-          messageID: writing.messageID,
-          typingIndicator: writing.typingIndicator
-        },
-        WS_WRITING_TIMEOUT
-      );
+      this.setWritingStatus(writing.user, {
+        messageID: writing.messageID,
+        typingIndicator: writing.typingIndicator
+      });
     } else {
       this.clearWritingStatus(writing.user);
     }


### PR DESCRIPTION
## Motivation

A server-pushed writing status (e.g. an AI persona's "is typing" indicator over the RTC-free WebSocket) was only kept alive on the client for 3 seconds. To keep the indicator visible, the sender had to re-broadcast the status on a timer; a single call would silently disappear after 3s. This was a footgun for anyone driving the indicator from the server, and it did not match how every other WebSocket update (messages, users, metadata) behaves — those persist once sent.

## Summary

A writing status now persists until it is explicitly cleared. Calling `broadcast_writing_status(user, status)` sends one frame that shows the indicator and keeps it visible; sending a stop frame (`status=None`) removes it. No re-broadcasting, no background timer.

The lifecycle is now fully explicit start/stop, controlled by the sender.

## Technical details

The auto-expiry lived entirely on the frontend: `_onWsWriting` armed a 3s timeout that dropped the writer unless refreshed. That path and the underlying per-writer timer machinery are removed, and the now-unused `timeout` parameter is dropped from `IChatModel.setWritingStatus` (a small API change).

The server model already sent a single frame like any other update, so it is unchanged. The local user's own typing debounce (RTC awareness) is unrelated and left as-is.

## Testing

Updated the writers unit test to assert a writer persists past the old timeout and is only removed on an explicit clear.