### PR TITLE
Add `WsChatModel.keep_alive()`

### DIFF
--- a/python/jupyterlab-chat/jupyterlab_chat/__init__.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/__init__.py
@@ -66,7 +66,9 @@ def _load_jupyter_server_extension(server_app):
     # under WebSocket it backs the WS handler (owns ``chats_by_id``).
     from .chat_manager import ChatManager
 
-    chat_manager = ChatManager(server_app, rtc_enabled=rtc_info.enabled)
+    chat_manager = ChatManager(
+        server_app, rtc_enabled=rtc_info.enabled, config=server_app.config
+    )
     server_app.web_app.settings["chat_manager"] = chat_manager
 
     # When RTC is off, chat runs over the plain WebSocket handler. When an RTC

--- a/python/jupyterlab-chat/jupyterlab_chat/chat_manager.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/chat_manager.py
@@ -50,20 +50,34 @@ class ChatManager(LoggingConfigurable):
     Responsibilities:
       1. Event bus  -- ``observe_chats`` / emits ``opened|closed|deleted`` via Jupyter Events.
       2. Model access -- ``get`` (sync) / ``create`` (async get-or-create).
-      3. Memory management -- frees a model after ``inactivity_timeout_s`` with no
-         connected clients, or when its backing file is gone.
+      3. Memory management -- frees a WebSocket chat model once it has been
+         ``inactive and empty`` (no connected clients, not kept alive) for longer
+         than ``freeable_chat_grace_period``, or when its backing file is gone.
 
     Every emitted event carries the chat's stable ``chat_id`` (``model.get_id()``).
     """
 
-    inactivity_timeout_s = Float(
-        300.0, config=True, help="Free a chat model after this many seconds with no connected clients."
+    freeable_chat_grace_period = Float(
+        60.0,
+        config=True,
+        help=(
+            "How long (in seconds) a chat may stay inactive and empty -- no "
+            "connected web clients and no open keep_alive() context -- before it "
+            "is marked freeable and reclaimed. Has no effect when RTC is enabled; "
+            "the RTC provider is expected to manage chat memory."
+        ),
     )
-    poll_interval_s = Float(
-        60.0, config=True, help="How often to poll for inactive/deleted chats."
+    freeable_chat_scan_interval = Float(
+        60.0,
+        config=True,
+        help=(
+            "How often (in seconds) the chat manager scans for freeable chats to "
+            "reclaim. Has no effect when RTC is enabled; the RTC provider is "
+            "expected to manage chat memory."
+        ),
     )
 
-    def __init__(self, serverapp: "ServerApp", rtc_enabled: bool = False, start_poller: bool = True, **kwargs):
+    def __init__(self, serverapp: "ServerApp", rtc_enabled: bool = False, start_scanner: bool = True, **kwargs):
         super().__init__(**kwargs)
         self._serverapp = serverapp
         self._settings = serverapp.web_app.settings
@@ -84,9 +98,11 @@ class ChatManager(LoggingConfigurable):
         if rtc_enabled:
             self._wire_rtc_forwarding()
 
-        self._poller = PeriodicCallback(self._poll, self.poll_interval_s * 1000)
-        if start_poller:
-            self._poller.start()
+        self._scanner = PeriodicCallback(
+            self._scan_freeable_chats, self.freeable_chat_scan_interval * 1000
+        )
+        if start_scanner:
+            self._scanner.start()
 
     @property
     def _root_dir(self) -> Path:
@@ -199,7 +215,7 @@ class ChatManager(LoggingConfigurable):
     # ------------------------------------------------------------------
     # Responsibility 3 -- memory management
     # ------------------------------------------------------------------
-    def _poll(self) -> None:
+    def _scan_freeable_chats(self) -> None:
         now = time.time()
         for chat_id in list(self._chats_by_id.keys()):
             model = self._chats_by_id.get(chat_id)
@@ -211,13 +227,13 @@ class ChatManager(LoggingConfigurable):
             if not (self._root_dir / model.get_path()).exists():
                 self._free(chat_id, ChatEventAction.DELETED)
                 continue
-            # Inactivity: only applies to WS models we own the memory for. A
-            # connected client -- or an open ``keep_alive()`` context (e.g. a
-            # persona still writing) -- keeps the chat alive.
+            # A WS model we own the memory for becomes freeable once it has been
+            # inactive and empty (no clients, not kept alive) for longer than the
+            # grace period. While it is still held, reset the grace timer.
             if isinstance(model, WsChatModel):
-                if model.handlers or model.is_kept_alive:
+                if not model.inactive_and_empty:
                     self._last_activity_by_id[chat_id] = now
-                elif now - self._last_activity_by_id.get(chat_id, now) > self.inactivity_timeout_s:
+                elif now - self._last_activity_by_id.get(chat_id, now) > self.freeable_chat_grace_period:
                     self._free(chat_id, ChatEventAction.CLOSED)
 
     def _free(self, chat_id: str, action: ChatEventAction) -> Optional["BaseChatModel"]:
@@ -235,8 +251,8 @@ class ChatManager(LoggingConfigurable):
         return model
 
     def stop(self) -> None:
-        if getattr(self, "_poller", None) is not None:
-            self._poller.stop()
+        if getattr(self, "_scanner", None) is not None:
+            self._scanner.stop()
 
     # ------------------------------------------------------------------
     # WebSocket transport hooks (called by WSChatHandler)
@@ -253,27 +269,17 @@ class ChatManager(LoggingConfigurable):
         self._last_activity_by_id[chat_id] = time.time()
 
     def ws_client_gone(self, chat_id: str) -> None:
-        # The last client for this chat has disconnected. Free the model now
-        # unless a server-side writer (e.g. an AI persona still producing a
-        # reply) is keeping it alive, in which case the poller reclaims it once
-        # the writer stops. Freeing here -- rather than reloading from disk on the
-        # next open -- is what keeps a reopened chat consistent without having to
-        # handle out-of-band file changes.
+        # The last client for this chat has disconnected. Free the model now if
+        # nothing else is holding it (it is now inactive and empty). If a
+        # ``keep_alive()`` context is still open -- e.g. an AI persona finishing a
+        # reply -- leave it: the periodic scan reclaims it once that context exits
+        # and the grace period elapses. Freeing here (rather than reloading from
+        # disk on the next open) keeps a reopened chat consistent without having
+        # to handle out-of-band file changes.
         self._last_activity_by_id[chat_id] = time.time()
-        if not self._has_active_writers(chat_id):
-            self._free(chat_id, ChatEventAction.CLOSED)
-
-    def _has_active_writers(self, chat_id: str) -> bool:
-        """Whether a server-side producer is keeping this chat alive.
-
-        A chat is kept alive while any :meth:`WsChatModel.keep_alive` context is
-        open -- for example an AI persona still producing a reply after every
-        client has disconnected. While kept alive the model is not freed when the
-        last client leaves; the poller reclaims it once no ``keep_alive`` context
-        remains and no clients are connected.
-        """
         model = self._chats_by_id.get(chat_id)
-        return isinstance(model, WsChatModel) and model.is_kept_alive
+        if isinstance(model, WsChatModel) and model.inactive_and_empty:
+            self._free(chat_id, ChatEventAction.CLOSED)
 
     def _get_or_create_ws(self, path: str) -> "WsChatModel":
         # Reuse the live model for this path if one exists (matched by current

--- a/python/jupyterlab-chat/jupyterlab_chat/chat_manager.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/chat_manager.py
@@ -212,9 +212,10 @@ class ChatManager(LoggingConfigurable):
                 self._free(chat_id, ChatEventAction.DELETED)
                 continue
             # Inactivity: only applies to WS models we own the memory for. A
-            # connected client keeps the chat alive.
+            # connected client -- or an open ``keep_alive()`` context (e.g. a
+            # persona still writing) -- keeps the chat alive.
             if isinstance(model, WsChatModel):
-                if model.handlers:
+                if model.handlers or model.is_kept_alive:
                     self._last_activity_by_id[chat_id] = now
                 elif now - self._last_activity_by_id.get(chat_id, now) > self.inactivity_timeout_s:
                     self._free(chat_id, ChatEventAction.CLOSED)
@@ -263,15 +264,16 @@ class ChatManager(LoggingConfigurable):
             self._free(chat_id, ChatEventAction.CLOSED)
 
     def _has_active_writers(self, chat_id: str) -> bool:
-        """Whether a server-side writer is keeping this chat alive.
+        """Whether a server-side producer is keeping this chat alive.
 
-        A "writer" is an AI persona (or other server-side producer) that is still
-        working on a reply and would be orphaned if the model were freed. The
-        server-side writing API is not on this branch yet (see
-        jupyterlab/jupyter-chat#497); until it lands there are no server-side
-        writers, so a chat is freed as soon as its last client disconnects.
+        A chat is kept alive while any :meth:`WsChatModel.keep_alive` context is
+        open -- for example an AI persona still producing a reply after every
+        client has disconnected. While kept alive the model is not freed when the
+        last client leaves; the poller reclaims it once no ``keep_alive`` context
+        remains and no clients are connected.
         """
-        return False
+        model = self._chats_by_id.get(chat_id)
+        return isinstance(model, WsChatModel) and model.is_kept_alive
 
     def _get_or_create_ws(self, path: str) -> "WsChatModel":
         # Reuse the live model for this path if one exists (matched by current

--- a/python/jupyterlab-chat/jupyterlab_chat/tests/test_events.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/tests/test_events.py
@@ -37,7 +37,7 @@ def _make_manager(tmp_path, capture):
     serverapp = cast(
         "ServerApp", SimpleNamespace(web_app=SimpleNamespace(settings=settings))
     )
-    mgr = ChatManager(serverapp, rtc_enabled=False, start_poller=False)
+    mgr = ChatManager(serverapp, rtc_enabled=False, start_scanner=False)
 
     async def listener(logger, schema_id, data):
         capture.append(data)
@@ -112,7 +112,7 @@ def test_inactivity_frees_model(tmp_path):
 
         mgr._last_activity_by_id[model.get_id()] = time.time() - 10_000  # stale
         capture.clear()
-        mgr._poll()
+        mgr._scan_freeable_chats()
         await _drain()
 
         assert mgr.get(model.get_id()) is None  # garbage-collected
@@ -132,7 +132,7 @@ def test_connected_client_keeps_model_alive(tmp_path):
         model.handlers["client-1"] = object()  # simulate a connected client
         mgr._last_activity_by_id[model.get_id()] = time.time() - 10_000
 
-        mgr._poll()
+        mgr._scan_freeable_chats()
         assert mgr.get(model.get_id()) is model  # kept because a client is connected
         mgr.stop()
 
@@ -149,7 +149,7 @@ def test_deletion_frees_model(tmp_path):
 
         chat.unlink()  # deleted via filesystem/ContentsManager
         capture.clear()
-        mgr._poll()
+        mgr._scan_freeable_chats()
         await _drain()
 
         assert mgr.get(model.get_id()) is None
@@ -226,7 +226,7 @@ def test_client_connected_and_disconnected_events(tmp_path):
             "ServerApp",
             SimpleNamespace(web_app=SimpleNamespace(settings=settings)),
         )
-        mgr = ChatManager(serverapp, rtc_enabled=False, start_poller=False)
+        mgr = ChatManager(serverapp, rtc_enabled=False, start_scanner=False)
 
         async def on_event(logger, schema_id, data):
             if data["action"] in ("client_connected", "client_disconnected"):

--- a/python/jupyterlab-chat/jupyterlab_chat/tests/test_ws_keep_alive.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/tests/test_ws_keep_alive.py
@@ -48,8 +48,9 @@ def _make_manager(tmp_path) -> ChatManager:
     serverapp = cast(
         "ServerApp", SimpleNamespace(web_app=SimpleNamespace(settings=settings))
     )
-    # Poller is driven manually via `_poll()` for deterministic timing.
-    return ChatManager(serverapp, rtc_enabled=False, start_poller=False)
+    # The scanner is driven manually via `_scan_freeable_chats()` for
+    # deterministic timing.
+    return ChatManager(serverapp, rtc_enabled=False, start_scanner=False)
 
 
 # ---------------------------------------------------------------------------
@@ -102,14 +103,14 @@ def test_keep_alive_blocks_free_on_last_client_gone(tmp_path):
 
         # Context exited and the last client already left -> the poller reclaims.
         mgr._last_activity_by_id[chat_id] = time.time() - 10_000
-        mgr._poll()
+        mgr._scan_freeable_chats()
         assert mgr.get(chat_id) is None
         mgr.stop()
 
     asyncio.run(run())
 
 
-def test_keep_alive_blocks_inactivity_poll(tmp_path):
+def test_keep_alive_blocks_scan_reclaim(tmp_path):
     async def run():
         mgr = _make_manager(tmp_path)
         (tmp_path / "d.chat").write_text("{}")
@@ -119,11 +120,11 @@ def test_keep_alive_blocks_inactivity_poll(tmp_path):
 
         with model.keep_alive():
             mgr._last_activity_by_id[chat_id] = time.time() - 10_000  # stale
-            mgr._poll()
+            mgr._scan_freeable_chats()
             assert mgr.get(chat_id) is model  # kept alive despite inactivity
 
         mgr._last_activity_by_id[chat_id] = time.time() - 10_000
-        mgr._poll()
+        mgr._scan_freeable_chats()
         assert mgr.get(chat_id) is None
         mgr.stop()
 

--- a/python/jupyterlab-chat/jupyterlab_chat/tests/test_ws_keep_alive.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/tests/test_ws_keep_alive.py
@@ -1,0 +1,187 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+"""Tests for ``WsChatModel.keep_alive`` and ChatManager memory reclamation.
+
+``keep_alive()`` lets a server-side producer (e.g. an AI persona) pin a chat in
+memory while it finishes work, so the model is not freed the moment the last
+client disconnects. These cover the model-level context manager, the
+``ChatManager`` honoring it, and -- via ``weakref`` -- that a *freed* model is
+actually released from memory. The last point matters because ``WsChatModel``
+registers a ContentsManager event listener whose bound-method callback would
+otherwise keep the instance alive; ``dispose()`` must remove it.
+"""
+import asyncio
+import gc
+import time
+import weakref
+from pathlib import Path
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, cast
+
+import jupyter_server
+import pytest
+from jupyter_events import EventLogger
+
+from jupyterlab_chat.chat_manager import ChatManager
+from jupyterlab_chat.websocket_model import WsChatModel
+
+if TYPE_CHECKING:
+    from jupyter_server.serverapp import ServerApp
+
+
+def _event_logger() -> EventLogger:
+    """An EventLogger with the ContentsManager schema registered, matching a real
+    server (so a WsChatModel can register/remove its contents listener)."""
+    logger = EventLogger()
+    logger.register_event_schema(
+        Path(jupyter_server.__file__).parent
+        / "event_schemas"
+        / "contents_service"
+        / "v1.yaml"
+    )
+    return logger
+
+
+def _make_manager(tmp_path) -> ChatManager:
+    logger = _event_logger()
+    settings = {"event_logger": logger, "server_root_dir": str(tmp_path)}
+    serverapp = cast(
+        "ServerApp", SimpleNamespace(web_app=SimpleNamespace(settings=settings))
+    )
+    # Poller is driven manually via `_poll()` for deterministic timing.
+    return ChatManager(serverapp, rtc_enabled=False, start_poller=False)
+
+
+# ---------------------------------------------------------------------------
+# Model-level context manager
+# ---------------------------------------------------------------------------
+
+
+def test_keep_alive_toggles_is_kept_alive(tmp_path):
+    model = WsChatModel(path="a.chat", root_dir=tmp_path)
+    assert model.is_kept_alive is False
+    with model.keep_alive():
+        assert model.is_kept_alive is True
+    assert model.is_kept_alive is False
+
+
+def test_keep_alive_is_reentrant(tmp_path):
+    model = WsChatModel(path="a.chat", root_dir=tmp_path)
+    with model.keep_alive():
+        with model.keep_alive():
+            assert model.is_kept_alive is True
+        # Still alive: the outer context is still open.
+        assert model.is_kept_alive is True
+    assert model.is_kept_alive is False
+
+
+def test_keep_alive_releases_on_exception(tmp_path):
+    model = WsChatModel(path="a.chat", root_dir=tmp_path)
+    with pytest.raises(RuntimeError):
+        with model.keep_alive():
+            raise RuntimeError("boom")
+    assert model.is_kept_alive is False
+
+
+# ---------------------------------------------------------------------------
+# ChatManager honors keep_alive
+# ---------------------------------------------------------------------------
+
+
+def test_keep_alive_blocks_free_on_last_client_gone(tmp_path):
+    async def run():
+        mgr = _make_manager(tmp_path)
+        (tmp_path / "c.chat").write_text("{}")
+        model = mgr.ws_open("c.chat")
+        chat_id = model.get_id()
+
+        with model.keep_alive():
+            # Last client disconnects while a keep_alive context is open.
+            mgr.ws_client_gone(chat_id)
+            assert mgr.get(chat_id) is model  # pinned, not freed
+
+        # Context exited and the last client already left -> the poller reclaims.
+        mgr._last_activity_by_id[chat_id] = time.time() - 10_000
+        mgr._poll()
+        assert mgr.get(chat_id) is None
+        mgr.stop()
+
+    asyncio.run(run())
+
+
+def test_keep_alive_blocks_inactivity_poll(tmp_path):
+    async def run():
+        mgr = _make_manager(tmp_path)
+        (tmp_path / "d.chat").write_text("{}")
+        model = mgr.ws_open("d.chat")
+        chat_id = model.get_id()
+        assert not model.handlers
+
+        with model.keep_alive():
+            mgr._last_activity_by_id[chat_id] = time.time() - 10_000  # stale
+            mgr._poll()
+            assert mgr.get(chat_id) is model  # kept alive despite inactivity
+
+        mgr._last_activity_by_id[chat_id] = time.time() - 10_000
+        mgr._poll()
+        assert mgr.get(chat_id) is None
+        mgr.stop()
+
+    asyncio.run(run())
+
+
+# ---------------------------------------------------------------------------
+# weakref: a freed model is released from memory; a kept-alive one is retained
+# ---------------------------------------------------------------------------
+
+
+def test_freed_model_is_garbage_collected(tmp_path):
+    """Stopping a chat (last client gone, no keep_alive) must drop every
+    reference so the model is collectable -- in particular ``dispose()`` removes
+    the ContentsManager listener, whose bound-method callback would otherwise
+    keep the model alive."""
+
+    async def run():
+        mgr = _make_manager(tmp_path)
+        (tmp_path / "e.chat").write_text("{}")
+        model = mgr.ws_open("e.chat")
+        chat_id = model.get_id()
+        ref = weakref.ref(model)
+        assert ref() is not None
+
+        # Stop the chat: last client gone with no keep_alive context -> freed.
+        mgr.ws_client_gone(chat_id)
+        assert mgr.get(chat_id) is None
+
+        # Drop our own strong reference; nothing else should retain the model.
+        del model
+        await asyncio.sleep(0)
+        gc.collect()
+        assert ref() is None
+        mgr.stop()
+
+    asyncio.run(run())
+
+
+def test_kept_alive_model_is_retained_in_memory(tmp_path):
+    """The mirror of the above: while a keep_alive context is open, the model
+    stays reachable (the manager keeps it) even after the last client leaves."""
+
+    async def run():
+        mgr = _make_manager(tmp_path)
+        (tmp_path / "f.chat").write_text("{}")
+        model = mgr.ws_open("f.chat")
+        chat_id = model.get_id()
+        ref = weakref.ref(model)
+
+        with model.keep_alive():
+            mgr.ws_client_gone(chat_id)
+            del model
+            await asyncio.sleep(0)
+            gc.collect()
+            # Retained by the manager because a keep_alive context is open.
+            assert ref() is not None
+            assert mgr.get(chat_id) is ref()
+        mgr.stop()
+
+    asyncio.run(run())

--- a/python/jupyterlab-chat/jupyterlab_chat/websocket_handler.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/websocket_handler.py
@@ -261,7 +261,9 @@ class WSChatHandler(JupyterHandler, websocket.WebSocketHandler):
                 model.get_path(), client_id, model.get_id()
             )
             if not model.handlers:
-                # Don't free immediately: the manager reclaims the model after a
-                # grace period of inactivity unless a client reconnects.
+                # Last client gone: let the manager decide. It frees the chat now
+                # if nothing else is holding it, or keeps it for an open
+                # keep_alive() context (reclaimed by the periodic scan once that
+                # context exits and the grace period elapses).
                 self._chat_manager.ws_client_gone(model.get_id())
         self.log.info("WS chat client %s disconnected", client_id)

--- a/python/jupyterlab-chat/jupyterlab_chat/websocket_model.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/websocket_model.py
@@ -167,8 +167,9 @@ class WsChatModel(BaseChatModel):
                 chat.add_message(NewMessage(body="done", sender=persona_id))
 
         Reentrant: nested or concurrent contexts each hold the chat alive until
-        the last one exits. Once no contexts remain the model is reclaimed
-        normally -- on the next inactivity poll if the last client already left.
+        the last one exits. Once no contexts remain the chat becomes
+        ``inactive and empty`` again and is reclaimed by the chat manager's
+        periodic scan (see ``ChatManager.freeable_chat_grace_period``).
 
         Exclusive to the WebSocket backend. Under real-time collaboration a
         chat's memory is managed by jupyter-collaboration at a higher layer, so
@@ -184,6 +185,19 @@ class WsChatModel(BaseChatModel):
     def is_kept_alive(self) -> bool:
         """Whether at least one :meth:`keep_alive` context is currently open."""
         return self._keep_alive_depth > 0
+
+    @property
+    def inactive_and_empty(self) -> bool:
+        """Whether nothing is currently holding this chat in memory: no connected
+        web clients and no open :meth:`keep_alive` context.
+
+        This is the first state in the WebSocket memory lifecycle
+        (``inactive and empty`` -> ``freeable`` -> ``freed``): the
+        :class:`~jupyterlab_chat.chat_manager.ChatManager` starts a grace timer
+        once a chat is inactive and empty and frees it once it has stayed that
+        way past ``freeable_chat_grace_period``.
+        """
+        return not self.handlers and not self.is_kept_alive
 
     def resolve_message(self, message: dict) -> dict:
         """Return a copy of a message with attachment IDs replaced by full objects."""

--- a/python/jupyterlab-chat/jupyterlab_chat/websocket_model.py
+++ b/python/jupyterlab-chat/jupyterlab_chat/websocket_model.py
@@ -6,9 +6,10 @@ import logging
 import os
 import time
 import uuid
+from contextlib import contextmanager
 from dataclasses import asdict
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, Iterator, List, Optional, Union
 
 from jupyter_events import EventLogger
 from jupyter_server.services.contents.manager import ContentsManager
@@ -60,6 +61,11 @@ class WsChatModel(BaseChatModel):
         self.path = path
         self.root_dir = root_dir
         self.handlers: Dict[str, websocket.WebSocketHandler] = {}
+        # Number of open ``keep_alive()`` contexts. While > 0 the ChatManager
+        # will not free this model even with no connected clients (see
+        # ``keep_alive`` / ``is_kept_alive``). An int -- not a bool -- so nested
+        # or concurrent contexts each hold the model alive until the last exits.
+        self._keep_alive_depth = 0
         self._messages: list[dict] = []
         self._indexes_by_id: dict[str, int] = {}
         self._users: Dict[str, dict] = {}
@@ -140,6 +146,44 @@ class WsChatModel(BaseChatModel):
                 )
             )
         )
+
+    # ------------------------------------------------------------------
+    # Memory management (WebSocket-only)
+    # ------------------------------------------------------------------
+
+    @contextmanager
+    def keep_alive(self) -> Iterator[None]:
+        """Keep this chat model alive for the duration of the ``with`` block.
+
+        While at least one ``keep_alive()`` context is open, the
+        :class:`~jupyterlab_chat.chat_manager.ChatManager` will not free this
+        model even if every client disconnects -- neither when the last client
+        leaves nor on the inactivity poll. Use it to guard a server-side
+        operation that must outlive the connected clients, e.g. an AI persona
+        still producing a reply after the user closed the tab::
+
+            with chat.keep_alive():
+                await do_some_long_work()
+                chat.add_message(NewMessage(body="done", sender=persona_id))
+
+        Reentrant: nested or concurrent contexts each hold the chat alive until
+        the last one exits. Once no contexts remain the model is reclaimed
+        normally -- on the next inactivity poll if the last client already left.
+
+        Exclusive to the WebSocket backend. Under real-time collaboration a
+        chat's memory is managed by jupyter-collaboration at a higher layer, so
+        keeping it alive here is neither needed nor wired in.
+        """
+        self._keep_alive_depth += 1
+        try:
+            yield
+        finally:
+            self._keep_alive_depth -= 1
+
+    @property
+    def is_kept_alive(self) -> bool:
+        """Whether at least one :meth:`keep_alive` context is currently open."""
+        return self._keep_alive_depth > 0
 
     def resolve_message(self, message: dict) -> dict:
         """Return a copy of a message with attachment IDs replaced by full objects."""

--- a/ui-tests/chat_test_extension.py
+++ b/ui-tests/chat_test_extension.py
@@ -3,17 +3,24 @@
 
 """Test-only server extension for the UI tests.
 
-Exposes ``POST /chat-test/add-user`` so an E2E test can add a user to a *live*
-chat the way an AI persona does -- ``chat.set_user()`` on the server, after web
-clients have already connected -- and then assert the clients' user list updates.
+Exposes three endpoints used by the E2E suite:
 
-It is transport-agnostic: it resolves the live model from the ``ChatManager`` by
-path, which is a ``WsChatModel`` under the RTC-free WebSocket transport and a
-``YChat`` under real-time collaboration. In both cases ``set_user`` propagates to
-connected clients (a WS broadcast, or a shared-document write).
+* ``POST /chat-test/add-user`` -- add a user to a *live* chat the way an AI
+  persona does (``chat.set_user()`` on the server, after clients connected), so
+  a test can assert the clients' user list updates. Transport-agnostic.
+* ``GET /chat-test/chat-alive?path=<path>`` -- report whether a chat model is
+  still held in memory by the ``ChatManager`` (read-only liveness probe).
+* ``POST /chat-test/keep-alive`` ``{path, seconds}`` -- pin a chat with
+  ``WsChatModel.keep_alive()`` for ``seconds`` then send a message, simulating a
+  server-side producer that must outlive the connected clients.
+
+``add-user`` resolves the live model from the ``ChatManager`` by path, which is a
+``WsChatModel`` under the RTC-free WebSocket transport and a ``YChat`` under
+real-time collaboration. The liveness/keep-alive endpoints are specific to the
+WebSocket memory model and are only exercised by ``@websocket``-tagged tests.
 
 !! Never enable this in production: it lets any authenticated caller inject
-arbitrary users into a chat.
+arbitrary users into a chat and hold chats in memory.
 """
 from __future__ import annotations
 
@@ -24,7 +31,7 @@ import tornado
 from jupyter_server.base.handlers import JupyterHandler
 from jupyter_server.utils import url_path_join
 
-from jupyterlab_chat.models import User
+from jupyterlab_chat.models import NewMessage, User
 
 
 class AddUserHandler(JupyterHandler):
@@ -50,6 +57,54 @@ class AddUserHandler(JupyterHandler):
         self.finish(json.dumps({"ok": True}))
 
 
+class ChatAliveHandler(JupyterHandler):
+    """``GET /chat-test/chat-alive?path=<path>`` -> ``{"alive": bool}``.
+
+    Read-only liveness probe: reports whether a chat model for ``path`` is
+    currently held in memory by the ``ChatManager``. It must NOT create the model
+    (that would resurrect a freed chat), so it scans the live registry by path
+    instead of calling ``ChatManager.create``.
+    """
+
+    @tornado.web.authenticated
+    async def get(self) -> None:
+        path = self.get_query_argument("path")
+        chats_by_id = self.settings.get("chats_by_id", {})
+        alive = any(model.get_path() == path for model in chats_by_id.values())
+        self.finish(json.dumps({"alive": alive}))
+
+
+class KeepAliveHandler(JupyterHandler):
+    """``POST /chat-test/keep-alive`` ``{path, seconds}`` -> ``{"ok": true}``.
+
+    Simulates a server-side producer (e.g. an AI persona) that must outlive the
+    connected clients: it opens a ``WsChatModel.keep_alive()`` context, waits
+    ``seconds`` (during which the client may disconnect), then sends a message
+    and exits the context. It runs in the background so the request returns
+    immediately; the caller then closes the client tab and observes the chat
+    staying alive until the context resolves.
+    """
+
+    @tornado.web.authenticated
+    async def post(self) -> None:
+        body = json.loads(self.request.body or b"{}")
+        path = body["path"]
+        seconds = float(body.get("seconds", 5))
+
+        manager = self.settings["chat_manager"]
+        model = await manager.create(path)
+        if model is None:
+            raise tornado.web.HTTPError(404, f"chat not live: {path}")
+
+        async def _run() -> None:
+            with model.keep_alive():
+                await asyncio.sleep(seconds)
+                model.add_message(NewMessage(body="Hi", sender="server-bot"))
+
+        asyncio.ensure_future(_run())
+        self.finish(json.dumps({"ok": True}))
+
+
 def _jupyter_server_extension_points():
     return [{"module": "chat_test_extension"}]
 
@@ -57,6 +112,14 @@ def _jupyter_server_extension_points():
 def _load_jupyter_server_extension(server_app) -> None:
     web_app = server_app.web_app
     base_url = web_app.settings["base_url"]
-    route = url_path_join(base_url, "chat-test", "add-user")
-    web_app.add_handlers(".*$", [(route, AddUserHandler)])
-    server_app.log.info("Registered chat_test_extension (test-only add-user endpoint)")
+    web_app.add_handlers(
+        ".*$",
+        [
+            (url_path_join(base_url, "chat-test", "add-user"), AddUserHandler),
+            (url_path_join(base_url, "chat-test", "chat-alive"), ChatAliveHandler),
+            (url_path_join(base_url, "chat-test", "keep-alive"), KeepAliveHandler),
+        ],
+    )
+    server_app.log.info(
+        "Registered chat_test_extension (test-only add-user/chat-alive/keep-alive endpoints)"
+    )

--- a/ui-tests/jupyter_server_test_config.py
+++ b/ui-tests/jupyter_server_test_config.py
@@ -56,11 +56,11 @@ c.ServerApp.jpserver_extensions = {"chat_test_extension": True}
 
 # Reclaim RTC-free chat models quickly in tests so ws-chats-freed.spec.ts can
 # observe a chat being freed shortly after its last client disconnects (the
-# production default is 5 minutes). This only affects the WebSocket WsChatModel
+# production defaults are 60s each). This only affects the WebSocket WsChatModel
 # path; YChat memory is managed by jupyter-collaboration, so the collaborative
 # CI legs are unaffected.
-c.ChatManager.inactivity_timeout_s = 2.0
-c.ChatManager.poll_interval_s = 1.0
+c.ChatManager.freeable_chat_grace_period = 2.0
+c.ChatManager.freeable_chat_scan_interval = 1.0
 
 # Each UI test runs in its own temporary directory, but all documents handled by
 # the server otherwise share the same SQLite YStore. Use one temporary file per

--- a/ui-tests/jupyter_server_test_config.py
+++ b/ui-tests/jupyter_server_test_config.py
@@ -54,6 +54,14 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 c.ServerApp.jpserver_extensions = {"chat_test_extension": True}
 
+# Reclaim RTC-free chat models quickly in tests so ws-chats-freed.spec.ts can
+# observe a chat being freed shortly after its last client disconnects (the
+# production default is 5 minutes). This only affects the WebSocket WsChatModel
+# path; YChat memory is managed by jupyter-collaboration, so the collaborative
+# CI legs are unaffected.
+c.ChatManager.inactivity_timeout_s = 2.0
+c.ChatManager.poll_interval_s = 1.0
+
 # Each UI test runs in its own temporary directory, but all documents handled by
 # the server otherwise share the same SQLite YStore. Use one temporary file per
 # document so parallel tests do not contend for a database lock.

--- a/ui-tests/tests/ws-chats-freed.spec.ts
+++ b/ui-tests/tests/ws-chats-freed.spec.ts
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+import { expect, IJupyterLabPageFixture, test } from '@jupyterlab/galata';
+
+import { openChat, USER } from './test-utils';
+import { webSocketOnly } from './tags';
+
+/**
+ * Whether the server still holds a chat model for `path` in memory. Queries the
+ * read-only test endpoint, which reports the `ChatManager` registry without
+ * resurrecting a freed chat.
+ */
+async function isChatAlive(
+  page: IJupyterLabPageFixture,
+  path: string
+): Promise<boolean> {
+  return page.evaluate(async (path: string) => {
+    const settings = (window.jupyterapp as any).serviceManager.serverSettings;
+    const url =
+      settings.baseUrl +
+      'chat-test/chat-alive?path=' +
+      encodeURIComponent(path);
+    const headers: Record<string, string> = {};
+    if (settings.token) {
+      headers['Authorization'] = 'token ' + settings.token;
+    }
+    const response = await fetch(url, { headers });
+    const body = await response.json();
+    return body.alive as boolean;
+  }, path);
+}
+
+/**
+ * Ask the server to hold the chat alive with `WsChatModel.keep_alive()` for
+ * `seconds`, then send a "Hi" message. Returns as soon as the background task is
+ * scheduled (server-side), before it completes.
+ */
+async function keepAlive(
+  page: IJupyterLabPageFixture,
+  path: string,
+  seconds: number
+): Promise<void> {
+  const status = await page.evaluate(
+    async ({ path, seconds }) => {
+      const settings = (window.jupyterapp as any).serviceManager.serverSettings;
+      const url = settings.baseUrl + 'chat-test/keep-alive';
+      const headers: Record<string, string> = {
+        'Content-Type': 'application/json'
+      };
+      if (settings.token) {
+        headers['Authorization'] = 'token ' + settings.token;
+      }
+      const response = await fetch(url, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ path, seconds })
+      });
+      return response.status;
+    },
+    { path, seconds }
+  );
+  expect(status).toBe(200);
+}
+
+/**
+ * Read and parse a .chat file from disk via the ContentsManager.
+ */
+async function readChat(
+  page: IJupyterLabPageFixture,
+  path: string
+): Promise<any> {
+  return page.evaluate(async (p: string) => {
+    const model = await window.jupyterapp.serviceManager.contents.get(p, {
+      content: true,
+      type: 'file',
+      format: 'text'
+    });
+    return JSON.parse(model.content);
+  }, path);
+}
+
+// WebSocket-only: this exercises WsChatModel memory management. Under real-time
+// collaboration the chat model lifecycle is owned by jupyter-collaboration at a
+// higher layer, so these guarantees do not apply and the suite is skipped on the
+// collaborative CI legs (via `--grep-invert @websocket`).
+test.describe('#ws-chats-freed', webSocketOnly, () => {
+  test.use({ mockUser: USER });
+
+  test('the chat model is freed after the client closes the tab', async ({
+    page
+  }) => {
+    const filename = 'ws-chats-freed-plain.chat';
+    await page.filebrowser.contents.uploadContent('{}', 'text', filename);
+
+    await openChat(page, filename);
+    // The model is live while a client is connected.
+    expect(await isChatAlive(page, filename)).toBe(true);
+
+    // Closing the tab disconnects the only client. With no keep_alive context
+    // the manager frees the model.
+    await page.activity.closePanel(filename);
+    await expect(async () => {
+      expect(await isChatAlive(page, filename)).toBe(false);
+    }).toPass({ timeout: 15000 });
+
+    await page.filebrowser.contents.deleteFile(filename);
+  });
+
+  test('keep_alive() keeps the chat alive until the context resolves', async ({
+    page
+  }) => {
+    const filename = 'ws-chats-freed-keepalive.chat';
+    await page.filebrowser.contents.uploadContent('{}', 'text', filename);
+
+    await openChat(page, filename);
+    expect(await isChatAlive(page, filename)).toBe(true);
+
+    // The server opens a keep_alive() context for a few seconds, then sends
+    // "Hi" and exits it. This runs in the background on the server.
+    await keepAlive(page, filename, 6);
+
+    // The client leaves immediately. Without keep_alive the model would be freed
+    // on this disconnect; the open context must keep it alive instead.
+    await page.activity.closePanel(filename);
+    expect(await isChatAlive(page, filename)).toBe(true);
+
+    // The context body runs to completion while the chat is still alive: its
+    // "Hi" message is persisted even though no client is connected.
+    await expect(async () => {
+      const content = await readChat(page, filename);
+      const bodies = (content.messages ?? []).map((m: any) => m.body);
+      expect(bodies).toContain('Hi');
+    }).toPass({ timeout: 20000 });
+
+    // Once the context resolves and the (already-gone) client is not replaced,
+    // the manager reclaims the model.
+    await expect(async () => {
+      expect(await isChatAlive(page, filename)).toBe(false);
+    }).toPass({ timeout: 20000 });
+
+    await page.filebrowser.contents.deleteFile(filename);
+  });
+});


### PR DESCRIPTION
## Motivation

Under the RTC-free WebSocket transport, the `ChatManager` frees a chat model as soon as its last client disconnects (or after an inactivity timeout). That is the right default, but it orphans a server-side producer that is still working: if an AI persona is mid-reply when the user closes the tab, the model backing its `add_message`/`update_message` calls can be freed out from under it.

The manager already anticipated this with a `_has_active_writers()` hook (referencing #497), but there was no public way for a producer to actually mark itself active.

## Summary

Adds `WsChatModel.keep_alive()`, a reentrant context manager that pins the chat in memory for the duration of a `with` block. While any context is open the chat is not freed even if every client disconnects; once the last context exits it is reclaimed normally.

```python
with chat.keep_alive():
    await do_some_long_work()
    chat.add_message(NewMessage(body="done", sender=persona_id))
```

This is exclusive to the WebSocket backend -- under RTC a chat's memory is managed by jupyter-collaboration at a higher layer, so it is neither needed nor wired in there.

## Technical details

- `_has_active_writers()` now reports `model.is_kept_alive`, and the inactivity poll treats a kept-alive model like one with a connected client.
- `ChatManager` is now constructed with `config=server_app.config` so its `inactivity_timeout_s` / `poll_interval_s` traits (already declared `config=True`) actually take effect. The UI-test server uses this to reclaim WS models quickly.

## Testing

- Backend unit tests for the context-manager semantics and the manager honoring it, plus a `weakref` test proving a freed model is garbage-collected (i.e. `dispose()` really removes its ContentsManager listener).
- New `ui-tests/tests/ws-chats-freed.spec.ts` (tagged `@websocket`, RTC-free legs only): a chat is freed after the client closes the tab, and with `keep_alive()` it stays alive until the server-side context resolves.