### PR TITLE
Update the shared model from WS handler

### DIFF
--- a/packages/jupyterlab-chat/src/model.ts
+++ b/packages/jupyterlab-chat/src/model.ts
@@ -23,7 +23,7 @@ import { Debouncer } from '@lumino/polling';
 import { ISignal, Signal } from '@lumino/signaling';
 
 import { enforceAutosaveEnabled } from './autosave';
-import { IWidgetConfig } from './token';
+import { ILabChatModel, IWidgetConfig } from './token';
 import { WebSocketHandler } from './websocket-handler';
 import { IChatChanges, IYmessage, YChat } from './ychat';
 
@@ -191,7 +191,7 @@ class LabChatUser implements IUser {
  */
 export class LabChatModel
   extends AbstractChatModel
-  implements DocumentRegistry.IModel
+  implements ILabChatModel, DocumentRegistry.IModel
 {
   constructor(options: LabChatModel.IOptions) {
     super(options);
@@ -222,12 +222,9 @@ export class LabChatModel
 
     if (!this.collaborative && options.serverSettings) {
       this._wsHandler = new WebSocketHandler({
-        serverSettings: options.serverSettings
+        serverSettings: options.serverSettings,
+        model: this
       });
-      this._wsHandler.messageReceived.connect(this._onWsMessage, this);
-      this._wsHandler.usersChanged.connect(this._onWsUsersChanged, this);
-      this._wsHandler.metadataChanged.connect(this._onWsMetadata, this);
-      this._wsHandler.writingChanged.connect(this._onWsWriting, this);
     }
   }
 
@@ -469,7 +466,7 @@ export class LabChatModel
       raw_time: this.collaborative ? true : false
     };
 
-    this.sharedModel.addMessage(this._contentToYmessage(content));
+    this.sharedModel.addMessage(this.toYMessage(content));
     return content.id;
   }
 
@@ -492,7 +489,7 @@ export class LabChatModel
     const index = this.sharedModel.getMessageIndex(id);
     this.sharedModel.updateMessage(
       index,
-      this._contentToYmessage({
+      this.toYMessage({
         ...updatedMessage,
         id,
         edited: updatedMessage.sender.bot ? updatedMessage.edited : true
@@ -598,29 +595,6 @@ export class LabChatModel
       );
     }
   }
-
-  /**
-   * Handle a writing status pushed by the server (e.g. an AI agent) over the
-   * WebSocket. The sender fully controls the lifecycle via explicit start/stop
-   * frames: a `state: true` frame shows the indicator and it stays visible
-   * until a `state: false` frame clears it -- no re-broadcasting is required.
-   */
-  private _onWsWriting = (
-    _: WebSocketHandler,
-    writing: WebSocketHandler.IWriting
-  ): void => {
-    if (writing.user.username === this.user.username) {
-      return;
-    }
-    if (writing.state) {
-      this.setWritingStatus(writing.user, {
-        messageID: writing.messageID,
-        typingIndicator: writing.typingIndicator
-      });
-    } else {
-      this.clearWritingStatus(writing.user);
-    }
-  };
 
   private _enforceAutosaveEnabled = () => {
     enforceAutosaveEnabled(this.sharedModel.awareness);
@@ -829,37 +803,7 @@ export class LabChatModel
     }
   };
 
-  private _onWsUsersChanged = (
-    _: WebSocketHandler,
-    users: Record<string, IUser>
-  ): void => {
-    for (const user of Object.values(users)) {
-      if (!this._sharedModel.getUser(user.username)) {
-        this._sharedModel.setUser(new LabChatUser(user));
-      }
-    }
-  };
-
-  private _onWsMetadata = (
-    _: WebSocketHandler,
-    metadata: Record<string, any>
-  ): void => {
-    for (const [key, value] of Object.entries(metadata)) {
-      this._sharedModel.setMetadata(key, value);
-    }
-  };
-
-  private _onWsMessage = (_: WebSocketHandler, msg: IMessageContent): void => {
-    const ymsg = this._contentToYmessage(msg);
-    const index = this._sharedModel.getMessageIndex(ymsg.id);
-    if (index >= 0) {
-      this._sharedModel.updateMessage(index, ymsg);
-    } else {
-      this._sharedModel.addMessage(ymsg);
-    }
-  };
-
-  private _contentToYmessage(msg: IMessageContent): IYmessage {
+  toYMessage(msg: IMessageContent): IYmessage {
     const sender = msg.sender as IUser;
     if (!this._sharedModel.getUser(sender.username)) {
       this._sharedModel.setUser(new LabChatUser(sender));

--- a/packages/jupyterlab-chat/src/token.ts
+++ b/packages/jupyterlab-chat/src/token.ts
@@ -6,7 +6,9 @@
 import {
   IConfig,
   IActiveCellManager,
+  IChatModel,
   IChatPanel,
+  IMessageContent,
   ISelectionWatcher,
   MultiChatPanel,
   chatIcon
@@ -17,6 +19,7 @@ import { IObservableList } from '@jupyterlab/observables';
 import { Token } from '@lumino/coreutils';
 import { ISignal } from '@lumino/signaling';
 import { ChatWidgetFactory } from './factory';
+import { IYmessage, YChat } from './ychat';
 
 /**
  * The file type for a chat document.
@@ -53,6 +56,15 @@ export type ChatToolbarFactory = (
 export const IChatToolbarFactory = new Token<ChatToolbarFactory>(
   'jupyterlab-chat:IChatToolbarFactory'
 );
+
+/**
+ * The interface for the lab chat model, extending IChatModel with
+ * Yjs-backed shared document access and message conversion.
+ */
+export interface ILabChatModel extends IChatModel {
+  readonly sharedModel: YChat;
+  toYMessage(msg: IMessageContent): IYmessage;
+}
 
 /**
  * The chat configs.

--- a/packages/jupyterlab-chat/src/websocket-handler.ts
+++ b/packages/jupyterlab-chat/src/websocket-handler.ts
@@ -9,6 +9,7 @@ import { ServerConnection } from '@jupyterlab/services';
 import { PromiseDelegate, UUID } from '@lumino/coreutils';
 import { ISignal, Signal } from '@lumino/signaling';
 
+import { ILabChatModel } from './token';
 import {
   CLIENT,
   IClientChatWsMessage,
@@ -24,6 +25,7 @@ const WS_PATH = 'api/chat/ws';
 export namespace WebSocketHandler {
   export interface IOptions {
     serverSettings: ServerConnection.ISettings;
+    model: ILabChatModel;
   }
 
   /**
@@ -62,6 +64,7 @@ export namespace WebSocketHandler {
 export class WebSocketHandler {
   constructor(options: WebSocketHandler.IOptions) {
     this._serverSettings = options.serverSettings;
+    this._model = options.model;
   }
 
   /**
@@ -197,9 +200,17 @@ export class WebSocketHandler {
         this._chatId = data.id;
         this._connectedUser = data.user ?? undefined;
         this._usersMap = data.users ?? {};
+        for (const user of Object.values(this._usersMap)) {
+          if (!this._model.sharedModel.getUser(user.username)) {
+            this._model.sharedModel.setUser(user);
+          }
+        }
+        const messages = (data.messages ?? []).map(msg =>
+          this._applyMessage(msg)
+        );
         this._usersChanged.emit(this._usersMap);
-        for (const msg of data.messages ?? []) {
-          this._messageReceived.emit(this._toMessageContent(msg));
+        for (const content of messages) {
+          this._messageReceived.emit(content);
         }
         this._connected = true;
         this._ready.resolve();
@@ -208,15 +219,25 @@ export class WebSocketHandler {
       case 'users': {
         const incoming = data.users ?? {};
         this._usersMap = { ...this._usersMap, ...incoming };
+        for (const user of Object.values(incoming)) {
+          if (!this._model.sharedModel.getUser(user.username)) {
+            this._model.sharedModel.setUser(user);
+          }
+        }
         this._usersChanged.emit(incoming);
         break;
       }
       case 'metadata': {
-        this._metadataChanged.emit(data.metadata ?? {});
+        const metadata = data.metadata ?? {};
+        for (const [key, value] of Object.entries(metadata)) {
+          this._model.sharedModel.setMetadata(key, value);
+        }
+        this._metadataChanged.emit(metadata);
         break;
       }
       case 'message': {
-        this._messageReceived.emit(this._toMessageContent(data.message));
+        const content = this._applyMessage(data.message);
+        this._messageReceived.emit(content);
         break;
       }
       case 'writing': {
@@ -225,18 +246,29 @@ export class WebSocketHandler {
           name: '',
           display_name: ''
         };
-        this._writingChanged.emit({
+        const writing: WebSocketHandler.IWriting = {
           user,
           state: !!data.state,
           messageID: data.messageID,
           typingIndicator: data.typingIndicator
-        });
+        };
+        if (user.username !== this._model.user?.username) {
+          if (writing.state) {
+            this._model.setWritingStatus(writing.user, {
+              messageID: writing.messageID,
+              typingIndicator: writing.typingIndicator
+            });
+          } else {
+            this._model.clearWritingStatus(writing.user);
+          }
+        }
+        this._writingChanged.emit(writing);
         break;
       }
     }
   }
 
-  private _toMessageContent(msg: IWireMessage): IMessageContent {
+  private _applyMessage(msg: IWireMessage): IMessageContent {
     const username = msg.sender;
     const sender: IUser = this._usersMap[username] ?? {
       username,
@@ -272,6 +304,13 @@ export class WebSocketHandler {
       content.mentions = (msg.mentions as string[]).map(
         u => this._usersMap[u] ?? { username: u, name: u, display_name: u }
       );
+    }
+    const ymsg = this._model.toYMessage(content);
+    const index = this._model.sharedModel.getMessageIndex(ymsg.id);
+    if (index >= 0) {
+      this._model.sharedModel.updateMessage(index, ymsg);
+    } else {
+      this._model.sharedModel.addMessage(ymsg);
     }
     return content;
   }
@@ -332,6 +371,7 @@ export class WebSocketHandler {
 
   private _path = '';
   private _disposed = false;
+  private _model: ILabChatModel;
   private _connected = false;
   private _chatId: string | undefined;
   private _connectedUser: IUser | undefined;

--- a/packages/jupyterlab-chat/src/websocket-handler.ts
+++ b/packages/jupyterlab-chat/src/websocket-handler.ts
@@ -7,7 +7,6 @@ import { IMessageContent, INewMessage, IUser } from '@jupyter/chat';
 import { URLExt } from '@jupyterlab/coreutils';
 import { ServerConnection } from '@jupyterlab/services';
 import { PromiseDelegate, UUID } from '@lumino/coreutils';
-import { ISignal, Signal } from '@lumino/signaling';
 
 import { ILabChatModel } from './token';
 import {
@@ -27,22 +26,6 @@ export namespace WebSocketHandler {
     serverSettings: ServerConnection.ISettings;
     model: ILabChatModel;
   }
-
-  /**
-   * A writing status pushed by the server (e.g. an AI agent). In RTC-free mode
-   * clients never advertise their own typing, so writers only originate
-   * server-side.
-   */
-  export interface IWriting {
-    /** The user the status is about. */
-    user: IUser;
-    /** True if the user is writing, false if they stopped. */
-    state: boolean;
-    /** The message being edited, if any. */
-    messageID?: string;
-    /** Optional custom typing-indicator text. */
-    typingIndicator?: string;
-  }
 }
 
 /**
@@ -51,9 +34,7 @@ export namespace WebSocketHandler {
  * Responsibilities:
  * - Open and maintain the WS connection (reconnect on abnormal close)
  * - Own the WS protocol: parse raw frames, maintain the users map, resolve
- *   sender/mention usernames to IUser objects
- * - Emit clean IMessageContent objects via `messageReceived` for every
- *   message — both historical (on connection) and live
+ *   sender/mention usernames to IUser objects, and update the model directly
  * - Expose a `ready` promise that resolves once the initial connection
  *   message has been processed
  * - Provide typed send methods (sendMessage / updateMessage / deleteMessage)
@@ -65,38 +46,6 @@ export class WebSocketHandler {
   constructor(options: WebSocketHandler.IOptions) {
     this._serverSettings = options.serverSettings;
     this._model = options.model;
-  }
-
-  /**
-   * Emitted for every message received from the server — including the
-   * historical messages delivered on connection — as a resolved IMessageContent.
-   */
-  get messageReceived(): ISignal<this, IMessageContent> {
-    return this._messageReceived;
-  }
-
-  /**
-   * Emitted whenever the set of known users changes — on the initial
-   * connection message and on every subsequent 'users' update.
-   * The payload is the map of new/updated users received from the server.
-   */
-  get usersChanged(): ISignal<this, Record<string, IUser>> {
-    return this._usersChanged;
-  }
-
-  /**
-   * Emitted whenever chat metadata changes -- on every 'metadata' update pushed
-   * by the server. The payload is the map of new/updated metadata entries.
-   */
-  get metadataChanged(): ISignal<this, Record<string, any>> {
-    return this._metadataChanged;
-  }
-
-  /**
-   * Emitted whenever a writing status is pushed by the server (e.g. an AI agent).
-   */
-  get writingChanged(): ISignal<this, WebSocketHandler.IWriting> {
-    return this._writingChanged;
   }
 
   /**
@@ -188,7 +137,6 @@ export class WebSocketHandler {
     this._disposed = true;
     this._socket?.close();
     this._socket = null;
-    Signal.clearData(this);
   }
 
   private _handleMessage(data: IServerChatWsMessage): void {
@@ -205,12 +153,8 @@ export class WebSocketHandler {
             this._model.sharedModel.setUser(user);
           }
         }
-        const messages = (data.messages ?? []).map(msg =>
-          this._applyMessage(msg)
-        );
-        this._usersChanged.emit(this._usersMap);
-        for (const content of messages) {
-          this._messageReceived.emit(content);
+        for (const msg of data.messages ?? []) {
+          this._applyMessage(msg);
         }
         this._connected = true;
         this._ready.resolve();
@@ -224,7 +168,6 @@ export class WebSocketHandler {
             this._model.sharedModel.setUser(user);
           }
         }
-        this._usersChanged.emit(incoming);
         break;
       }
       case 'metadata': {
@@ -232,12 +175,10 @@ export class WebSocketHandler {
         for (const [key, value] of Object.entries(metadata)) {
           this._model.sharedModel.setMetadata(key, value);
         }
-        this._metadataChanged.emit(metadata);
         break;
       }
       case 'message': {
-        const content = this._applyMessage(data.message);
-        this._messageReceived.emit(content);
+        this._applyMessage(data.message);
         break;
       }
       case 'writing': {
@@ -246,29 +187,22 @@ export class WebSocketHandler {
           name: '',
           display_name: ''
         };
-        const writing: WebSocketHandler.IWriting = {
-          user,
-          state: !!data.state,
-          messageID: data.messageID,
-          typingIndicator: data.typingIndicator
-        };
         if (user.username !== this._model.user?.username) {
-          if (writing.state) {
-            this._model.setWritingStatus(writing.user, {
-              messageID: writing.messageID,
-              typingIndicator: writing.typingIndicator
+          if (data.state) {
+            this._model.setWritingStatus(user, {
+              messageID: data.messageID,
+              typingIndicator: data.typingIndicator
             });
           } else {
-            this._model.clearWritingStatus(writing.user);
+            this._model.clearWritingStatus(user);
           }
         }
-        this._writingChanged.emit(writing);
         break;
       }
     }
   }
 
-  private _applyMessage(msg: IWireMessage): IMessageContent {
+  private _applyMessage(msg: IWireMessage): void {
     const username = msg.sender;
     const sender: IUser = this._usersMap[username] ?? {
       username,
@@ -312,7 +246,6 @@ export class WebSocketHandler {
     } else {
       this._model.sharedModel.addMessage(ymsg);
     }
-    return content;
   }
 
   private _send(data: IClientChatWsMessage): void {
@@ -379,8 +312,4 @@ export class WebSocketHandler {
   private _serverSettings: ServerConnection.ISettings;
   private _usersMap: Record<string, IUser> = {};
   private _ready = new PromiseDelegate<void>();
-  private _messageReceived = new Signal<this, IMessageContent>(this);
-  private _usersChanged = new Signal<this, Record<string, IUser>>(this);
-  private _metadataChanged = new Signal<this, Record<string, any>>(this);
-  private _writingChanged = new Signal<this, WebSocketHandler.IWriting>(this);
 }


### PR DESCRIPTION
This PR moves the logic of updating the shared model to the WS handler on message.

Before, the WS handler triggered a signal on change (new message, new user, ...), and the `LabChatModel` listened to this change to update its shared model. This workflow introduces several signals to listen from `LabChatModel`, and several associated methods, used only if the websocket handler is used.

With these changes, the websocket handler knows about the shared model of the model, and update the changes directly instead of triggering a signal.

A new `ILabChatModel` interface is introduced, to provide the minimal requirements required by the websocket handler to update the model (`sharedModel` and `toYMessage` complementing the `IChatModel` interface).
 